### PR TITLE
chore: add CODEOWNERS to route PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# podcli code owners
+# Lines added here are auto-requested for review on PRs touching matching paths.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Every PR is reviewed by @nmbrthirteen until additional maintainers are promoted.
+# Promote a trusted contributor by adding them here (and granting Write access in
+# Settings → Collaborators); from then on either reviewer can approve.
+
+*    @nmbrthirteen


### PR DESCRIPTION
## Summary

Adds \`.github/CODEOWNERS\` with @nmbrthirteen as the default owner for every path.

GitHub will now auto-request review from listed code owners whenever a PR touches matching files.

## Why

Sets up the open-source contribution model:
- Anyone can fork + open PRs (default GitHub behavior)
- Only repo collaborators can click Merge
- Code owners are auto-requested for review

When a trusted contributor is promoted later, adding them to this file (and granting Write access in repository settings) makes them an additional valid reviewer — no other plumbing needed.

## Follow-up (not in this PR)

When a second maintainer joins, bump branch protection:

\`\`\`bash
gh api repos/nmbrthirteen/podcli/branches/main/protection/required_pull_request_reviews \\
  -X PATCH -f required_approving_review_count=1 -F require_code_owner_reviews=true
\`\`\`

That makes code-owner approval mandatory for every merge.

## Test plan

- [x] File renders correctly on GitHub's CODEOWNERS preview
- [ ] After merge, open a test PR and confirm @nmbrthirteen is auto-requested as reviewer