### PR TITLE
Fix OSError [Errno 22] when running `process` without a TTY

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -187,6 +187,10 @@ def _has_successful_results(results: list) -> bool:
 
 def _should_enter_post_render_loop(config: dict, interrupted: bool, results: list) -> bool:
     """Open the post-render rerender flow on explicit config or partial interrupt recovery."""
+    # The post-render loop is interactive (prompt_toolkit); never enter it
+    # without a real terminal or it crashes with OSError [Errno 22].
+    if not sys.stdin.isatty():
+        return False
     return bool(config.get("post_render_review", False) or (interrupted and _has_successful_results(results)))
 
 
@@ -579,7 +583,7 @@ def cmd_process(args):
     print(f"\n  [4/4] Exporting {len(clips)} clips{_ai_label} to {output_dir}/")
     results = []
     t0 = time.time()
-    _skip_review = not config.get("review_each_clip", False)
+    _skip_review = not config.get("review_each_clip", False) or not sys.stdin.isatty()
     interrupted = False
 
     try:
@@ -1077,6 +1081,13 @@ Transcript:
 
 def _review_clips(clips: list, segments: list, energy_scores: list | None, config: dict) -> list:
     """Interactive clip review — user can select/deselect, ask for more, or find specific moments."""
+    # Non-interactive (piped/scripted/no TTY): skip the picker and render all
+    # suggested clips. The picker uses prompt_toolkit, which raises
+    # OSError [Errno 22] when stdin isn't a real terminal.
+    if not sys.stdin.isatty():
+        print(f"\n         Non-interactive run — rendering all {len(clips)} suggested clips.")
+        return clips
+
     import questionary
     from questionary import Style
 

--- a/tests/test_cli_output_dir.py
+++ b/tests/test_cli_output_dir.py
@@ -75,13 +75,24 @@ class CliOutputDirTests(unittest.TestCase):
         )
 
     def test_should_enter_post_render_loop_when_interrupted_with_completed_results(self):
-        should_enter = cli_mod._should_enter_post_render_loop(
-            config={"post_render_review": False},
-            interrupted=True,
-            results=[{"output_path": "/tmp/clip.mp4"}],
-        )
+        with mock.patch("sys.stdin.isatty", return_value=True):
+            should_enter = cli_mod._should_enter_post_render_loop(
+                config={"post_render_review": False},
+                interrupted=True,
+                results=[{"output_path": "/tmp/clip.mp4"}],
+            )
 
         self.assertTrue(should_enter)
+
+    def test_should_not_enter_post_render_loop_without_tty(self):
+        with mock.patch("sys.stdin.isatty", return_value=False):
+            should_enter = cli_mod._should_enter_post_render_loop(
+                config={"post_render_review": True},
+                interrupted=True,
+                results=[{"output_path": "/tmp/clip.mp4"}],
+            )
+
+        self.assertFalse(should_enter)
 
     def test_should_not_enter_post_render_loop_when_interrupted_without_completed_results(self):
         should_enter = cli_mod._should_enter_post_render_loop(
@@ -93,11 +104,12 @@ class CliOutputDirTests(unittest.TestCase):
         self.assertFalse(should_enter)
 
     def test_should_enter_post_render_loop_when_config_enabled(self):
-        should_enter = cli_mod._should_enter_post_render_loop(
-            config={"post_render_review": True},
-            interrupted=False,
-            results=[],
-        )
+        with mock.patch("sys.stdin.isatty", return_value=True):
+            should_enter = cli_mod._should_enter_post_render_loop(
+                config={"post_render_review": True},
+                interrupted=False,
+                results=[],
+            )
 
         self.assertTrue(should_enter)
 


### PR DESCRIPTION
## Problem

Running `podcli process <video>` in a non-interactive context (piped stdin, CI, a wrapper script, or another process driving the CLI) crashes with:

```
OSError: [Errno 22] Invalid argument
  ...
  File ".../prompt_toolkit/input/vt100.py", line 165, in _attached_input
    loop.add_reader(fd, callback_wrapper)
```

The clip-review step uses questionary/prompt_toolkit, which calls `loop.add_reader()` on stdin. That fails when stdin isn't a real terminal, so the whole render aborts even though transcription and clip detection already succeeded.

## Fix

Guard the three interactive entry points with `sys.stdin.isatty()`:

- **`_review_clips()`** — renders all suggested clips (the same as the default "Render N selected clips" action) instead of launching the picker.
- **`_should_enter_post_render_loop()`** — returns `False` so the post-render menu never opens.
- **per-clip `_skip_review`** — forced `True`.

Interactive behavior in a real terminal is completely unchanged; this only affects the no-TTY path, which previously could only crash.

## Testing

`./podcli process clip.mp4 --top 1 --crop face --caption-style hormozi --quality max --no-speakers < /dev/null`

- **Before:** `OSError: [Errno 22]` during clip review.
- **After:** exit 0 — transcribes, selects, and renders the clip headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes when running the CLI with piped input or in non-interactive mode. The tool now correctly detects non-TTY environments and disables interactive prompts, instead rendering all output directly. This enables reliable use in automated workflows, scripts, CI/CD pipelines, and other non-interactive contexts where input cannot be interactively provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->