### PR TITLE
fix: detect Python correctly on Windows

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -29,9 +29,15 @@ const home = resolveHome();
 
 function detectPython(): string {
   if (process.env.PYTHON_PATH) return process.env.PYTHON_PATH;
-  const venvPython = join(projectRoot, "venv", "bin", "python3");
+  const isWindows = process.platform === "win32";
+  const venvPython = join(
+    projectRoot,
+    "venv",
+    isWindows ? "Scripts" : "bin",
+    isWindows ? "python.exe" : "python3"
+  );
   if (existsSync(venvPython)) return venvPython;
-  return "python3";
+  return isWindows ? "python" : "python3";
 }
 
 export const paths = {


### PR DESCRIPTION
## What changed

detectPython() in src/config/paths.ts hardcoded Unix-style paths (env/bin/python3, fallback python3) which do not exist on Windows.

## Why

On Windows, the venv Python binary lives at env\Scripts\python.exe and the system fallback is python (not python3). This caused the MCP server to fail with spawn python3 ENOENT on every transcription attempt, making the tool completely non-functional on Windows.

## Fix

The function now checks process.platform === 'win32' and resolves the correct path for each platform:

- **Windows:** env\Scripts\python.exe → fallback python
- **Unix/macOS:** env/bin/python3 → fallback python3

Note: PYTHON_PATH env var (already documented in the README and set in claude_desktop_config.json) still takes priority and overrides this detection.