### PR TITLE
docs: cache GitHub stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <p align="center">
   <a href="https://github.com/nmbrthirteen/podcli/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="license: AGPL-3.0" /></a>
-  <a href="https://github.com/nmbrthirteen/podcli/stargazers"><img src="https://img.shields.io/github/stars/nmbrthirteen/podcli?style=social" alt="stars" /></a>
+  <a href="https://github.com/nmbrthirteen/podcli/stargazers"><img src="https://img.shields.io/github/stars/nmbrthirteen/podcli?style=social&cacheSeconds=86400" alt="stars" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
The dynamic GitHub stars badge (`img.shields.io/github/stars/...`) intermittently renders **"Unable to select next GitHub token from pool"** instead of a count. That's a shields.io server-side issue: its shared GitHub-API token pool gets rate-limited, so it can't fetch the live star count.

Adding `&cacheSeconds=86400` makes shields serve a cached value for a day and hit the GitHub API far less often, which avoids the error in the common case. (The static license badge was never affected since it makes no API call.)