### PR TITLE
fix: serve built SPA from dist when web-server runs from source

### DIFF
--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -50,6 +50,11 @@ import type {
 const log = childLogger("web-server");
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const publicDir = existsSync(join(__dirname, "public", "index.html"))
+  ? join(__dirname, "public")
+  : resolve(__dirname, "..", "..", "dist", "ui", "public");
+
 const app = express();
 const PORT = parseInt(process.env.PORT || "3847");
 
@@ -299,7 +304,7 @@ function createBatchHistoryRecorder({
 app.use(express.json({ limit: "50mb" }));
 
 // Serve static frontend
-app.use(express.static(join(__dirname, "public")));
+app.use(express.static(publicDir));
 
 // File upload config
 const uploadDir = join(paths.working, "uploads");
@@ -2366,7 +2371,7 @@ async function main() {
   // SPA fallback: client-side routes (/, /episode, /clip/:id) resolve to the
   // built index.html. Registered last so it never shadows /api or static assets.
   app.get(/^(?!\/api\/).*/, (_req, res) => {
-    res.sendFile(join(__dirname, "public", "index.html"));
+    res.sendFile(join(publicDir, "index.html"));
   });
 
   app.listen(PORT, () => {


### PR DESCRIPTION
## Problem

`npm run ui` (`tsx src/ui/web-server.ts`) booted fine but 500'd on first page load:

```
Error: ENOENT: no such file or directory, stat '...\src\ui\public\index.html'
```

The server resolves its static dir relative to its own file (`__dirname/public`). Running from source that's `src/ui/public`, which only holds static assets — the SPA `index.html` is emitted by `vite build` into `dist/ui/public`. So the dev server had no `index.html` to serve. (Prod, `node dist/ui/web-server.js`, was always fine.)

## Fix

Resolve `publicDir` once: use `__dirname/public` when it contains `index.html`, otherwise fall back to the built `dist/ui/public`. Both `express.static` and the SPA fallback route now use it. Prod behavior is unchanged; `npm run ui` now works after a build.

## Verify

- `tsc --noEmit`: clean
- vitest: 47/47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced server configuration for improved asset resolution and deployment flexibility. The application now intelligently locates and serves frontend resources from multiple sources with better fallback mechanisms. Single-page application routing has been improved to work reliably across different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->