### PR TITLE
fix: make Windows setup failures visible + double-click installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,17 @@ chmod +x setup.sh podcli
 ./setup.sh
 ```
 
-**Windows (PowerShell)**
+**Windows**
 
 ```powershell
 git clone https://github.com/nmbrthirteen/podcli.git
 cd podcli
-# If scripts are blocked: Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-.\setup.ps1
+```
+
+Then double-click **`install.cmd`** (or run it in a terminal). It installs everything and keeps the window open so you can see the result. To launch the studio afterwards:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File setup.ps1 -Ui
 ```
 
 This will:

--- a/install.cmd
+++ b/install.cmd
@@ -1,0 +1,19 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+
+echo Installing podcli - this can take a few minutes (downloads Whisper, Python and Node packages)...
+echo.
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0setup.ps1" -Install
+set "RC=%ERRORLEVEL%"
+
+echo.
+if not "%RC%"=="0" (
+    echo Install failed with code %RC%. Review the messages above.
+) else (
+    echo Install complete. To open the studio, run:  powershell -ExecutionPolicy Bypass -File setup.ps1 -Ui
+)
+echo.
+pause
+exit /b %RC%

--- a/setup.ps1
+++ b/setup.ps1
@@ -202,17 +202,28 @@ function Show-Mcp {
     Write-Host ""
 }
 
-Write-Banner
+try {
+    Write-Banner
 
-if ($Mcp) {
-    Show-Mcp
-} elseif ($Ui) {
-    Invoke-LaunchUi
-} elseif ($Install) {
-    Invoke-Install
-} else {
-    Invoke-Install
-    Write-Host "----------------------------------------"
+    if ($Mcp) {
+        Show-Mcp
+    } elseif ($Ui) {
+        Invoke-LaunchUi
+    } elseif ($Install) {
+        Invoke-Install
+    } else {
+        Invoke-Install
+        Write-Host "----------------------------------------"
+        Write-Host ""
+        Invoke-LaunchUi
+    }
+} catch {
     Write-Host ""
-    Invoke-LaunchUi
+    Write-Host "  Setup failed: $($_.Exception.Message)"
+    Write-Host "  Fix the issue above and re-run .\setup.ps1"
+    Write-Host ""
+    if ($Host.Name -eq "ConsoleHost") {
+        Read-Host "  Press Enter to close"
+    }
+    exit 1
 }

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,17 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    echo ""
+    echo "  This is the macOS/Linux installer. On Windows, use:"
+    echo "    install.cmd            (double-click, or run in a terminal)"
+    echo "    or: powershell -ExecutionPolicy Bypass -File setup.ps1"
+    echo ""
+    exit 1
+    ;;
+esac
+
 # ============================================================
 # podcli — Install & Launch
 # Usage:


### PR DESCRIPTION
## Problem

A Windows user ran `setup.ps1` via *Run with PowerShell*; it failed and the window **closed before the error was readable** ("terminal too fast to close down"). They assumed they could just `pip install` Whisper manually — but the installer also wires up FFmpeg/OpenCV/Pillow, the venv, Node packages, the TS build, and `.env`, so manual pip isn't equivalent.

## Fixes

- **`setup.ps1`** — wrap the run in try/catch; on failure print a clear message and `Read-Host` pause so the window stays open and the error is visible. (Whisper was already installed automatically via `backend/requirements.txt`.)
- **`install.cmd`** — double-clickable installer (the natural Windows entry point — double-clicking a `.ps1` only opens an editor). Bootstraps PowerShell with `-ExecutionPolicy Bypass`, runs `setup.ps1 -Install`, and `pause`s so output never vanishes.
- **`setup.sh`** — detect Git Bash/MSYS/Cygwin and redirect to the Windows installer instead of half-running (the `source venv/bin/activate` line is broken on Windows venvs, which use `Scripts\`).
- **README** — Windows Quick Start now points at `install.cmd`.

## Verify

- `bash -n setup.sh`: OK
- `setup.ps1` try/catch balanced; ASCII-only output (no cmd codepage mojibake)