### PR TITLE
fix: transcription crash when there are no speaker labels

### DIFF
--- a/backend/services/face_analysis.py
+++ b/backend/services/face_analysis.py
@@ -305,7 +305,7 @@ def analyze_faces(
                 speaker_mappings[top_2[1]] = 1 - speaker_mappings[top_2[0]]
 
         # Extra speakers → dominant speaker's cluster
-        dominant_idx = speaker_mappings.get(speakers_by_talk[0], 0)
+        dominant_idx = speaker_mappings.get(speakers_by_talk[0], 0) if speakers_by_talk else 0
         for sp in speakers_by_talk[2:]:
             speaker_mappings[sp] = dominant_idx
     elif len(clusters_list) >= 2 and len(speakers) >= 2:

--- a/backend/services/transcription.py
+++ b/backend/services/transcription.py
@@ -9,6 +9,7 @@ Produces word-level timestamps with speaker labels by:
 
 import os
 import subprocess
+import sys
 import tempfile
 from typing import Optional, Callable
 


### PR DESCRIPTION
## Symptom

```
Transcription failed: NameError: name 'sys' is not defined
  ...
  face_analysis.py line 308, in analyze_faces
    dominant_idx = speaker_mappings.get(speakers_by_talk[0], 0)
  IndexError: list index out of range
  ...
  transcription.py line 208 ... print(..., file=sys.stderr)
  NameError: name 'sys' is not defined
```

## Two stacked bugs

1. **`face_analysis.py:308`** — the split-screen mapping branch is gated on `is_split_screen and len(clusters_list) >= 2` (`face_analysis.py:200`), which does **not** require any speakers. With no diarization the transcript has no speaker labels, so `speakers` is empty, `speakers_by_talk = []`, and `speakers_by_talk[0]` raises `IndexError`. Guarded with `... if speakers_by_talk else 0` (the `[2:]` slice was already empty-safe). The 1-speaker path is unchanged.

2. **`transcription.py:208`** — face analysis is best-effort, wrapped in try/except, but the handler used `sys.stderr` without `import sys` → `NameError` turned a recoverable warning into a fatal crash. Added `import sys`.

Not Windows-specific — it triggers whenever a video looks split-screen but the transcript carries no speaker labels (e.g. no `HF_TOKEN`/pyannote, which is optional). With both fixes, face analysis is skipped with a warning and transcription completes.

## Verify

- `py_compile` both files: OK
- Repro pattern (empty `speakers_by_talk`) no longer raises.