### PR TITLE
fix: UTF-8 stdout/stderr + AI CLI capture on Windows

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -18,6 +18,14 @@ import sys
 import textwrap
 import time
 
+# Windows stdout/stderr default to cp1252, which can't encode chars like '→'; output is UTF-8.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            pass
+
 _env_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".env")
 try:
     from dotenv import load_dotenv

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,14 @@ import json
 import os
 import sys
 
+# Windows stdout/stderr default to cp1252, which can't encode chars like '→'; IPC is UTF-8.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError):
+            pass
+
 # Load .env file (for HF_TOKEN, etc.)
 try:
     from dotenv import load_dotenv

--- a/backend/services/claude_suggest.py
+++ b/backend/services/claude_suggest.py
@@ -104,6 +104,8 @@ def _run_ai_command(
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             cwd=project_dir,
             timeout=timeout,
         )
@@ -125,6 +127,8 @@ def _run_ai_command(
         f'cat "{prompt_file}" | "{cli_path}" --print -p -',
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         cwd=project_dir,
         timeout=timeout,
         shell=True,


### PR DESCRIPTION
## Symptom (Windows)

```
Suggestion failed: UnicodeEncodeError: 'charmap' codec can't encode character
'→' in position 3671: character maps to <undefined>
  ... backend/main.py ...
```

## Cause

On Windows, Python defaults stdout/stderr (and `subprocess` `text=True` capture) to the legacy ANSI codepage (cp1252 / 'charmap'), which can't represent characters like `→`, `✓`, or emoji. The suggestion flow captures the AI CLI's output and prints it over the stdout JSON channel, so a single `→` aborted the whole task. (The earlier Windows PR fixed `open()` calls — this is the *stream* side, which it didn't cover.)

## Fix

- **`backend/main.py`, `backend/cli.py`** — reconfigure `stdout`/`stderr` to UTF-8 (`errors='replace'`) at startup. All IPC with the TS executor is already UTF-8; this aligns the Python side. No-op on macOS/Linux (already UTF-8).
- **`backend/services/claude_suggest.py`** — capture the Claude/Codex CLI output with `encoding='utf-8', errors='replace'` on both the `codex exec` and `cat | cli` paths, so reading the model's output doesn't choke on cp1252 either.

## Verify

- `py_compile` all three: OK
- Reconfigure + `→ ✓ 🎬` print: OK

## Known follow-up (separate)

The claude fallback path uses `cat "..." | cli` via `shell=True`, and `cat` isn't a Windows shell builtin — so that specific fallback still needs a Windows-native equivalent. Out of scope for this encoding fix.