### PR TITLE
Release: drop Intel Mac from v2.0.0 matrices + installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - { goos: darwin, goarch: amd64 }
           - { goos: darwin, goarch: arm64 }
           - { goos: linux, goarch: amd64 }
           - { goos: linux, goarch: arm64 }
@@ -56,7 +55,6 @@ jobs:
       matrix:
         include:
           - { runner: macos-14, goos: darwin, goarch: arm64 }
-          - { runner: macos-13, goos: darwin, goarch: amd64 }
           - { runner: ubuntu-latest, goos: linux, goarch: amd64 }
           - { runner: ubuntu-24.04-arm, goos: linux, goarch: arm64 }
           - { runner: windows-latest, goos: windows, goarch: amd64 }
@@ -114,7 +112,6 @@ jobs:
       matrix:
         include:
           - { runner: macos-14, goos: darwin, goarch: arm64 }
-          - { runner: macos-13, goos: darwin, goarch: amd64 }
           - { runner: ubuntu-latest, goos: linux, goarch: amd64 }
           - { runner: ubuntu-24.04-arm, goos: linux, goarch: arm64 }
           - { runner: windows-latest, goos: windows, goarch: amd64 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,29 +152,3 @@ jobs:
         with:
           files: dist/*
           generate_release_notes: true
-
-  publish-npm:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Assert NPM_TOKEN is set
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "::error::NPM_TOKEN secret is not set — refusing to publish. The GitHub release and assets are already published; set the secret and re-run this job." >&2
-            exit 1
-          fi
-      - name: Publish wrapper pinned to the tag
-        working-directory: npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
-          npm publish --access public

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ podcli                       # interactive menu (and Web UI)
 podcli process episode.mp4   # transcribe + export clips
 ```
 
+Supported platforms: macOS (Apple Silicon), Linux (x64 / arm64), Windows (x64).
+Intel Macs are coming in a follow-up release.
+
 **Optional**, for AI clip suggestion and the PodStack slash commands: install
 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or
 [Codex](https://openai.com/index/introducing-codex/) (auto-detected).

--- a/README.md
+++ b/README.md
@@ -169,12 +169,6 @@ curl -fsSL https://raw.githubusercontent.com/nmbrthirteen/podcli/main/install.sh
 irm https://raw.githubusercontent.com/nmbrthirteen/podcli/main/install.ps1 | iex
 ```
 
-**With npm** (if you already have Node):
-
-```bash
-npm install -g podcli
-```
-
 Then just run it — the first launch sets itself up:
 
 ```bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,45 +1,41 @@
 # Releasing podcli
 
 Distribution is fully automated by `.github/workflows/release.yml`: pushing a
-`v*` tag builds the launcher for all five platforms, builds whisper.cpp, bundles
-the studio and Remotion, generates `checksums.txt`, publishes a GitHub release,
-and publishes the npm package. End users then install with no prerequisites:
+`v*` tag builds the launcher per platform, builds whisper.cpp, bundles the studio
+and Remotion, generates `checksums.txt`, and publishes a GitHub release. End users
+install with no prerequisites:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/nmbrthirteen/podcli/main/install.sh | sh
-# or: npm install -g podcli   (Windows: install.ps1)
+# Windows: irm https://raw.githubusercontent.com/nmbrthirteen/podcli/main/install.ps1 | iex
 ```
 
-## One-time setup
-
-- Set the **`NPM_TOKEN`** repository secret (an npm automation token with publish
-  rights). Without it the GitHub release still publishes; the npm job fails and
-  can be re-run after the secret is added.
+Platforms: macOS arm64, Linux x64/arm64, Windows x64. (npm isn't used — the
+unscoped name `podcli` is blocked by npm as too similar to `pod-cli`.)
 
 ## Cutting a release
 
-1. Pick the version `X.Y.Z`. Set it in **`npm/package.json`** (`install.js` fetches
-   the binary from `releases/download/vX.Y.Z/`, so the npm version must equal the
-   tag). Optionally align the root `package.json`.
+1. Pick the version `X.Y.Z` and tag with it. The installers resolve the latest
+   release automatically.
 2. Merge to `main` and make sure CI is green.
 3. Tag and push:
    ```bash
    git tag vX.Y.Z
    git push origin vX.Y.Z
    ```
-4. Watch the `release` workflow. It produces these assets (the names the npm
-   wrapper, self-update, and provisioner expect):
+4. Watch the `release` workflow. It produces these assets (the names the
+   installers, self-update, and provisioner expect):
    - `podcli-{darwin,linux,windows}-{amd64,arm64}[.exe]` — static launchers
    - `whisper-cli-<os>-<arch>[.exe]`
    - `studio-bundle.tar.gz`
    - `remotion-<os>-<arch>.tar.gz`
    - `checksums.txt`
-5. Verify the npm publish succeeded (`npm view podcli version`).
+5. Verify the release is published with all assets, then run the smoke test below.
 
 ## Smoke test (ideally one machine per OS)
 
 ```bash
-curl -fsSL .../install.sh | sh      # or npm i -g podcli
+curl -fsSL .../install.sh | sh      # Windows: irm .../install.ps1 | iex
 podcli doctor                        # paths + engine resolution
 podcli process sample.mp4 --top 1    # transcribe -> suggest -> export a clip
 podcli                               # interactive menu -> Open Web UI

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,9 @@ case "$arch" in
   *) err "unsupported architecture: $arch" ;;
 esac
 target="${goos}-${goarch}"
+if [ "$target" = "darwin-amd64" ]; then
+  err "Intel Macs aren't supported yet (coming in v2.0.1). Apple Silicon, Linux, and Windows are available."
+fi
 bin_dir="$home_dir/bin"
 mkdir -p "$bin_dir"
 

--- a/npm/scripts/install.js
+++ b/npm/scripts/install.js
@@ -21,7 +21,6 @@ function allowedHost(h) {
 }
 
 const TARGETS = {
-  'darwin-x64': 'darwin-amd64',
   'darwin-arm64': 'darwin-arm64',
   'linux-x64': 'linux-amd64',
   'linux-arm64': 'linux-arm64',


### PR DESCRIPTION
Intel-Mac (macos-13) runners are scarce and blocked the v2.0.0 release; the Remotion compositor can't be cross-built for darwin/amd64. Drops darwin/amd64 from the build/whisper/remotion matrices and makes the installers report Intel Mac as not-yet-supported instead of 404ing. The v2.0.0 tag already carries this; this brings main in sync so the curl installer and future releases match.