### PR TITLE
Docs: use podcli.com install URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,13 @@ managed directory. You don't need Go, Node, Python, or FFmpeg installed.
 **macOS / Linux**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nmbrthirteen/podcli/main/install.sh | sh
+curl -fsSL https://podcli.com/install.sh | sh
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-irm https://raw.githubusercontent.com/nmbrthirteen/podcli/main/install.ps1 | iex
+irm https://podcli.com/install.ps1 | iex
 ```
 
 Then just run it — the first launch sets itself up:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,8 +6,8 @@ and Remotion, generates `checksums.txt`, and publishes a GitHub release. End use
 install with no prerequisites:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nmbrthirteen/podcli/main/install.sh | sh
-# Windows: irm https://raw.githubusercontent.com/nmbrthirteen/podcli/main/install.ps1 | iex
+curl -fsSL https://podcli.com/install.sh | sh
+# Windows: irm https://podcli.com/install.ps1 | iex
 ```
 
 Platforms: macOS arm64, Linux x64/arm64, Windows x64. (npm isn't used — the


### PR DESCRIPTION
Switch the README + RELEASE install commands from the raw.githubusercontent URL to the branded https://podcli.com/install.sh (and install.ps1), now hosted on the landing.