### PR TITLE
Fix Apple Silicon SIGKILL on the darwin binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,17 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # darwin builds on macOS so the arm64 binary is signed in a way Apple
+    # Silicon's kernel accepts; cross-compiling it on Linux yields a binary the
+    # kernel SIGKILLs at exec.
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:
-          - { goos: darwin, goarch: arm64 }
-          - { goos: linux, goarch: amd64 }
-          - { goos: linux, goarch: arm64 }
-          - { goos: windows, goarch: amd64 }
+          - { runner: macos-14, goos: darwin, goarch: arm64 }
+          - { runner: ubuntu-latest, goos: linux, goarch: amd64 }
+          - { runner: ubuntu-latest, goos: linux, goarch: arm64 }
+          - { runner: ubuntu-latest, goos: windows, goarch: amd64 }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,13 @@ fi
 
 cp "$tmp/$asset" "$bin_dir/podcli"
 chmod 0755 "$bin_dir/podcli"
+
+# Apple Silicon's kernel kills cross-compiled (Linux-built) arm64 binaries whose
+# signature it won't accept, even with a valid-on-disk ad-hoc signature. Re-sign
+# ad-hoc on the Mac so the binary runs.
+if [ "$goos" = "darwin" ] && command -v codesign >/dev/null 2>&1; then
+  codesign --force --sign - "$bin_dir/podcli" >/dev/null 2>&1 || true
+fi
 echo "  installed: $bin_dir/podcli"
 
 linked=""


### PR DESCRIPTION
Cross-compiled darwin/arm64 binaries get SIGKILLed at exec on Apple Silicon (AMFI rejects the Linux-built signature). Build darwin on a macOS runner so it's signed acceptably; install.sh also ad-hoc re-signs on macOS, which fixes the already-published v2.0.0 (install.sh is fetched live).