### PR TITLE
Fix remotion bundle extraction (./ root entry rejected)

### DIFF
--- a/cli/internal/provision/extract_test.go
+++ b/cli/internal/provision/extract_test.go
@@ -1,0 +1,63 @@
+package provision
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeTarGz builds a .tar.gz from (name, content) entries; empty content means a dir.
+func writeTarGz(t *testing.T, path string, entries [][2]string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		name, body := e[0], e[1]
+		if body == "" {
+			tw.WriteHeader(&tar.Header{Name: name, Typeflag: tar.TypeDir, Mode: 0o755})
+			continue
+		}
+		tw.WriteHeader(&tar.Header{Name: name, Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(body))})
+		tw.Write([]byte(body))
+	}
+	tw.Close()
+	gz.Close()
+}
+
+// `tar -C dir .` emits a "./" root entry; extractTarGz must accept it, not reject
+// it as an escaping path (the bug that broke Remotion bundle extraction).
+func TestExtractTarGzAcceptsRootEntry(t *testing.T) {
+	tmp := t.TempDir()
+	archive := filepath.Join(tmp, "bundle.tar.gz")
+	writeTarGz(t, archive, [][2]string{
+		{"./", ""},
+		{"./render.mjs", "export default 1\n"},
+		{"./node_modules/x/index.js", "x\n"},
+	})
+	dest := filepath.Join(tmp, "out")
+	if err := extractTarGz(archive, dest); err != nil {
+		t.Fatalf("extractTarGz rejected a ./-rooted archive: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "render.mjs")); err != nil {
+		t.Errorf("render.mjs not extracted: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "node_modules", "x", "index.js")); err != nil {
+		t.Errorf("nested file not extracted: %v", err)
+	}
+}
+
+func TestExtractTarGzRejectsEscapingPath(t *testing.T) {
+	tmp := t.TempDir()
+	archive := filepath.Join(tmp, "evil.tar.gz")
+	writeTarGz(t, archive, [][2]string{{"../escape.txt", "bad\n"}})
+	if err := extractTarGz(archive, filepath.Join(tmp, "out")); err == nil {
+		t.Fatal("expected extractTarGz to reject a ../ escaping entry")
+	}
+}

--- a/cli/internal/provision/provision.go
+++ b/cli/internal/provision/provision.go
@@ -731,7 +731,9 @@ func extractTarGz(archive, dest string) error {
 			return err
 		}
 		target := filepath.Join(dest, h.Name)
-		if !strings.HasPrefix(target, root) {
+		// Allow the archive's own root entry ("./" from `tar -C dir .`), which
+		// resolves to dest itself; reject only paths that escape dest.
+		if target != filepath.Clean(dest) && !strings.HasPrefix(target, root) {
 			return fmt.Errorf("unsafe path in archive: %s", h.Name)
 		}
 		switch h.Typeflag {


### PR DESCRIPTION
extractTarGz rejected the './' root entry that 'tar -C dir .' produces, so the Remotion bundle never extracted and captions silently fell back to ASS. Accept the entry resolving to dest; still reject ../ escapes. Regression tests added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tarball extraction to correctly handle root directory entries while rejecting malformed paths that attempt to escape the destination directory.

* **Tests**
  * Added test coverage for tarball extraction behavior with root entries and path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->