### PR TITLE
setup --speakers: opt-in diarization install + actionable messages

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -2947,11 +2947,11 @@ def cmd_info(args):
     except (ImportError, ValueError):
         diarization_available = False
     if not diarization_available:
-        speakers_status = f"{yellow}✗ not available in this install (source install only)"
+        speakers_status = f"{yellow}✗ not installed — run: podcli setup --speakers (pyannote + torch, ~2GB)"
     elif hf_token:
         speakers_status = f"{green}✓ configured"
     else:
-        speakers_status = f"{yellow}✗ set HF_TOKEN in .env"
+        speakers_status = f"{yellow}✗ set a token — run: podcli env set HF_TOKEN <token>"
 
     print(f"    AI CLI:       {green}{('Claude' if ai_engine == 'claude' else 'Codex') + ' (' + ai_path + ')' if ai_path else f'{yellow}not found — install Claude Code or Codex'}{reset}")
     print(f"    Speakers:     {speakers_status}{reset}")
@@ -3081,7 +3081,10 @@ def print_banner():
     print()
 
     if not speakers_ok:
-        print(f"  {yellow}⚠ Speaker detection not set up — run: podcli info{reset}")
+        if not _diarization_ok:
+            print(f"  {yellow}⚠ Speaker detection not installed — run: podcli setup --speakers{reset}")
+        else:
+            print(f"  {yellow}⚠ Speaker detection needs a token — run: podcli env set HF_TOKEN <token>{reset}")
 
     print()
 

--- a/backend/services/speaker_detection.py
+++ b/backend/services/speaker_detection.py
@@ -73,7 +73,7 @@ def run_diarization(
     try:
         from pyannote.audio import Pipeline
     except ImportError:
-        msg = "pyannote.audio not installed — run: pip install pyannote.audio"
+        msg = "Speaker detection not installed — run: podcli setup --speakers"
         if progress_callback:
             progress_callback(0, msg)
         raise ImportError(msg)

--- a/cli/internal/provision/provision.go
+++ b/cli/internal/provision/provision.go
@@ -709,6 +709,21 @@ func pipInstall(pybin, requirements string) error {
 	return cmd.Run()
 }
 
+// EnsureSpeakerDeps installs the speaker-diarization stack (pyannote.audio pulls
+// torch) into the hermetic Python. Opt-in because it's a large download (~2GB)
+// most users don't need.
+func EnsureSpeakerDeps() error {
+	bin := PythonBin()
+	if !have(bin) {
+		return fmt.Errorf("python not provisioned — run `podcli setup` first")
+	}
+	fmt.Fprintln(os.Stderr, "  installing speaker deps (pyannote.audio + torch) — large download (~2GB), several minutes")
+	cmd := exec.Command(bin, "-m", "pip", "install", "--disable-pip-version-check", "--progress-bar=on", "pyannote.audio>=3.1.0", "speechbrain")
+	cmd.Stdout, cmd.Stderr = os.Stderr, os.Stderr
+	cmd.Env = append(os.Environ(), "PYTHONUNBUFFERED=1")
+	return cmd.Run()
+}
+
 func extractTarGz(archive, dest string) error {
 	f, err := os.Open(archive)
 	if err != nil {

--- a/cli/main.go
+++ b/cli/main.go
@@ -171,6 +171,7 @@ func transcribeEngine(args []string) string {
 func setup(args []string) int {
 	size := "base"
 	vad := false
+	speakers := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--model":
@@ -180,6 +181,8 @@ func setup(args []string) int {
 			}
 		case "--vad":
 			vad = true
+		case "--speakers":
+			speakers = true
 		}
 	}
 	fmt.Printf("Provisioning into %s\n", paths.Home())
@@ -216,6 +219,13 @@ func setup(args []string) int {
 		} else {
 			fmt.Printf("  python: %s\n", pb)
 		}
+	}
+	if speakers {
+		if err := provision.EnsureSpeakerDeps(); err != nil {
+			fmt.Fprintf(os.Stderr, "  speakers: failed (%v)\n", err)
+			return 1
+		}
+		fmt.Printf("  speakers: pyannote.audio installed (set HF_TOKEN to use)\n")
 	}
 	if wc, err := provision.EnsureWhisperCpp(); err != nil {
 		fmt.Fprintf(os.Stderr, "  whisper: skipped (%v) — backend will use PATH whisper-cli\n", err)
@@ -403,8 +413,8 @@ Launcher commands:
   doctor               Show resolved paths, interpreter, backend, ffmpeg, models
   version              Print version
   update               Check for and apply a newer release
-  setup [--model base] [--vad]
-                       Provision runtimes + models into the managed dir
+  setup [--model base] [--vad] [--speakers]
+                       Provision runtimes + models (--speakers adds pyannote+torch, ~2GB)
   mcp                  Run the MCP server (stdio) for Claude/Codex
   mcp install          Register the MCP server with Claude Code
   config set update.auto off    Disable auto-update (also: PODCLI_NO_UPDATE=1)


### PR DESCRIPTION
Speaker detection deps (pyannote+torch, ~2GB) are excluded from the hermetic runtime. Adds 'podcli setup --speakers' to install them on demand, and replaces dead-end 'source install only' messages with the exact command to run (setup --speakers / env set HF_TOKEN).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--speakers` flag to setup command for installing speaker diarization dependencies.

* **Documentation**
  * Improved error messaging with specific guidance distinguishing between missing packages versus missing authentication tokens.
  * Updated CLI help text with speaker detection setup instructions and size information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->