### PR TITLE
Fix blank clip detail page (undefined var) + type-check the SPA in build

### DIFF
--- a/scripts/build-studio.sh
+++ b/scripts/build-studio.sh
@@ -9,6 +9,9 @@ here="$(cd "$(dirname "$0")/.." && pwd)"
 out="${1:-$here/dist/studio}"
 cd "$here"
 
+# Type-check the SPA — vite/esbuild don't, so undefined-var bugs in the client
+# would otherwise ship silently (blank pages at runtime).
+npx tsc --noEmit -p src/ui/client/tsconfig.json
 npm run build   # tsc + vite -> dist/ui/web-server.js + dist/ui/public
 
 rm -rf "$out"

--- a/src/ui/client/ClipDetail.tsx
+++ b/src/ui/client/ClipDetail.tsx
@@ -176,7 +176,7 @@ export default function ClipDetail() {
 
       <div className="clip-detail">
         <div className="clip-detail-player">
-          {file ? <ClipPlayer key={previewUrl} src={previewUrl} onTime={(t) => (playerTime.current = t)} /> : <div className="phone-empty">No rendered output</div>}
+          {clip.output_path ? <ClipPlayer key={previewUrl} src={previewUrl} onTime={(t) => (playerTime.current = t)} /> : <div className="phone-empty">No rendered output</div>}
           <button className="btn btn-ghost btn-sm" style={{ width: "100%", marginTop: 10 }} onClick={() => setReframing(true)}>Reframe (fix camera)</button>
           <div className="clip-meta">
             <span>{fmt(clip.start_second)}–{fmt(clip.end_second)} · {clip.duration}s</span>


### PR DESCRIPTION
ClipDetail referenced a removed `file` variable in the player conditional → ReferenceError → blank /clip/:id. Use clip.output_path. The client SPA isn't type-checked by the build (vite/esbuild skip types), so it shipped silently; build-studio.sh now runs the client tsc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed clip detail display to correctly show rendered output when available.

* **Chores**
  * Added TypeScript type-checking to the build process for improved code quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->