### PR TITLE
Fix CLI-backed Studio actions in bundled runtime (honor PODCLI_BACKEND)

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -28,6 +28,12 @@ function resolveHome(): string {
 
 const home = resolveHome();
 
+// Hermetic installs run from a bundled runtime where the backend lives outside
+// projectRoot; the launcher points PODCLI_BACKEND at it.
+const backendDir = process.env.PODCLI_BACKEND
+  ? resolve(process.env.PODCLI_BACKEND)
+  : join(projectRoot, "backend");
+
 function detectPython(): string {
   if (process.env.PYTHON_PATH) return process.env.PYTHON_PATH;
   const isWindows = process.platform === "win32";
@@ -44,6 +50,7 @@ function detectPython(): string {
 export const paths = {
   home,
   projectRoot,
+  backendDir,
   homeMarker,
   dataDir,
   cache: join(dataDir, "cache"),
@@ -61,9 +68,7 @@ export const paths = {
   corrections: join(home, "corrections.json"),
   thumbnailConfig: join(home, "thumbnail-config.json"),
   integrations: join(home, "integrations.json"),
-  pythonBackend: process.env.PODCLI_BACKEND
-    ? join(resolve(process.env.PODCLI_BACKEND), "main.py")
-    : join(projectRoot, "backend", "main.py"),
+  pythonBackend: join(backendDir, "main.py"),
   pythonPath: detectPython(),
   ffmpegPath: process.env.FFMPEG_PATH || "ffmpeg",
   ffprobePath: process.env.FFPROBE_PATH || "ffprobe",

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -1327,7 +1327,7 @@ function runPy(scriptAndArgs: string[]): Promise<{ code: number; stdout: string;
 }
 
 const runCli = (args: string[]) =>
-  runPy([join(paths.projectRoot, "backend", "cli.py"), "--no-banner", ...args]);
+  runPy([join(paths.backendDir, "cli.py"), "--no-banner", ...args]);
 
 // Composite a thumbnail PNG onto the start of a clip. stripStart > 0 removes a
 // prior card first (avoids stacking on re-bake). Returns the bake's success.
@@ -1720,7 +1720,7 @@ app.post("/api/clips/:id/davinci", async (req, res) => {
     res.status(400).json({ error: "rendered file missing" });
     return;
   }
-  const cli = join(paths.projectRoot, "backend", "services", "integrations", "davinci_resolve", "cli.py");
+  const cli = join(paths.backendDir, "services", "integrations", "davinci_resolve", "cli.py");
   const r = await runPy([cli, "--source", clip.output_path, "--title", clip.title]);
   if (r.code !== 0) {
     res.status(400).json({ error: stripAnsi(r.stderr || r.stdout) || "export failed" });


### PR DESCRIPTION
## Bug
In the bundled runtime, thumbnail-config import/export/reset failed:

```
Import failed: .../runtime/python/bin/python3: can't open file
'.../podcli/backend/cli.py': [Errno 2] No such file or directory
```

`runCli` (and the DaVinci export) resolved the Python backend at `projectRoot/backend`. In a hermetic install the bundle ships the backend under `runtime/backend` and the launcher points `PODCLI_BACKEND` at it, so the hardcoded path missed it. This broke **every CLI-backed Studio action** in the bundle (clips edit, bake-thumbnail, and the new thumbnail-config commands). Executor-based features were unaffected because `pythonBackend` already honored `PODCLI_BACKEND`.

## Fix
Resolve the backend dir once in `paths.ts` — `PODCLI_BACKEND` when set, else `projectRoot/backend` — and use it for `runCli`, `pythonBackend`, and the DaVinci CLI path. Works identically in dev and in the bundled runtime, on every platform.

## Verification
- Ran the **built** `dist/studio/web-server.mjs` with `PODCLI_BACKEND` set (as the launcher does): `GET`, `PUT import`, and `reset` all succeed; no "No such file" errors.
- `npx vitest run` — 47 pass (incl. `paths.test.ts`); root + client `tsc` clean; studio bundle builds.