### PR TITLE
Trust Hugging Face CDN redirect hosts in model downloader

### DIFF
--- a/cli/internal/provision/provision.go
+++ b/cli/internal/provision/provision.go
@@ -369,6 +369,7 @@ func allowedDownloadHost(h string) bool {
 		"github.com",            // release assets
 		"githubusercontent.com", // objects.* / release-assets.* CDN
 		"huggingface.co",        // whisper.cpp models + cdn-lfs*.huggingface.co
+		"hf.co",                 // HF CDN redirects: us.aws.cdn.hf.co, cas-bridge.xethub.hf.co
 		"nodejs.org",            // hermetic Node
 		"evermeet.cx",           // macOS ffmpeg
 		"johnvansickle.com",     // linux ffmpeg

--- a/cli/internal/provision/redirect_test.go
+++ b/cli/internal/provision/redirect_test.go
@@ -10,6 +10,7 @@ func TestAllowedDownloadHost(t *testing.T) {
 	allow := []string{
 		"github.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com",
 		"huggingface.co", "cdn-lfs.huggingface.co", "cdn-lfs-us-1.huggingface.co",
+		"hf.co", "us.aws.cdn.hf.co", "cas-bridge.xethub.hf.co",
 		"nodejs.org", "evermeet.cx", "johnvansickle.com", "www.johnvansickle.com",
 	}
 	for _, h := range allow {
@@ -20,7 +21,7 @@ func TestAllowedDownloadHost(t *testing.T) {
 	// Suffix spoofing must not pass: a trusted name as a left-label is not enough.
 	deny := []string{
 		"evil.com", "github.com.evil.com", "huggingface.co.attacker.net",
-		"githubusercontent.com.evil.com", "127.0.0.1", "",
+		"githubusercontent.com.evil.com", "hf.co.attacker.net", "127.0.0.1", "",
 	}
 	for _, h := range deny {
 		if allowedDownloadHost(h) {


### PR DESCRIPTION
## Problem

Fresh installs can't complete first-time setup: the model downloader requests `huggingface.co` but Hugging Face serves the bytes via a redirect to its CDN — `us.aws.cdn.hf.co` (and, for the Xet backend, `cas-bridge.xethub.hf.co`). Those hosts live under `hf.co`, not `huggingface.co`, so `allowedDownloadHost()` refused the redirect:

```
ggml-base interrupted (attempt 1/6):
Get "https://us.aws.cdn.hf.co/...":
refusing redirect to untrusted host "us.aws.cdn.hf.co" — resuming
```

`ggml-base.bin` never downloads and setup loops forever.

## Fix

Add `hf.co` to the trusted download-host allowlist in `cli/internal/provision/provision.go`. The existing suffix match (`h == base || strings.HasSuffix(h, "."+base)`) covers all `*.hf.co` CDN edges while still rejecting spoofs like `hf.co.attacker.net`.

Updated `redirect_test.go` to cover the CDN hosts (allow) and the spoof (deny).

## Scope check

Other download paths were reviewed and are unaffected — `update.go` (self-update) and `npm/scripts/install.js` only pull the podcli binary from GitHub; the Python backend downloads models via `huggingface_hub`/pyannote, which handle CDN redirects themselves.

Fixes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded trusted download hosts to include `hf.co` for model fetch and download flows.
  * Strengthened redirect checks so lookalike or suffix-matching domains like `hf.co.attacker.net` are still blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->