### PR TITLE
Add yt-dlp web UI import

### DIFF
--- a/backend/requirements-runtime.txt
+++ b/backend/requirements-runtime.txt
@@ -7,5 +7,6 @@ numpy>=1.24.0
 Pillow>=10.0.0
 questionary>=2.0.0
 python-dotenv>=1.2.2
+yt-dlp>=2025.6.30
 google-api-python-client>=2.0.1
 google-auth-oauthlib>=1.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,6 +20,7 @@ questionary>=2.0.0
 
 # Utilities
 python-dotenv>=1.2.2
+yt-dlp>=2025.6.30
 
 # YouTube analytics (optional — only needed for live OAuth sync; CSV import works without these)
 google-api-python-client>=2.0.1

--- a/src/ui/client/EpisodeWorkspace.jsx
+++ b/src/ui/client/EpisodeWorkspace.jsx
@@ -11,10 +11,12 @@ import {
   Home as HomeGlyph,
   Users as UsersGlyph,
   Inbox,
+  Download as DownloadGlyph,
 } from 'lucide-react';
 import CopyButton from './CopyButton';
 
 const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
+const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
     const api = async (path, opts = {}) => {
       const res = await fetch(`/api${path}`, { headers: { 'Content-Type': 'application/json', ...opts.headers }, ...opts });
       let body = null;
@@ -528,6 +530,9 @@ const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(
 
       const [logoUploading, setLogoUploading] = useState(false);
       const [browsing, setBrowsing] = useState(false);
+      const [downloadingVideo, setDownloadingVideo] = useState(false);
+      const [downloadJobId, setDownloadJobId] = useState(null);
+      const downloadStream = useJob(downloadJobId);
       const [clipHistory, setClipHistory] = useState([]);
       const [historyOpen, setHistoryOpen] = useState(false);
 
@@ -737,7 +742,7 @@ const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(
       const autoTranscribeRef = useRef('');
       useEffect(() => {
         const vp = videoPath.trim();
-        if (transcriptMode === 'whisper' && vp && !transcript && !transcribing && vp !== autoTranscribeRef.current) {
+        if (transcriptMode === 'whisper' && vp && !isHttpUrl(vp) && !transcript && !transcribing && vp !== autoTranscribeRef.current) {
           autoTranscribeRef.current = vp;
           autoTranscribe(vp);
         }
@@ -846,7 +851,7 @@ const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(
       // Video source URL
       const videoUrl = previewSrc
         ? `/api/preview/${previewSrc}`
-        : videoPath
+        : videoPath && !isHttpUrl(videoPath)
           ? `/api/stream-source?path=${encodeURIComponent(videoPath)}`
           : null;
 
@@ -893,6 +898,49 @@ const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(
         } catch (e) { setError('Browse failed: ' + e.message); }
         finally { setBrowsing(false); }
       }, []);
+
+      const downloadVideo = async () => {
+        const url = videoPath.trim();
+        if (!url || downloadingVideo) return;
+        setDownloadingVideo(true); setError(null);
+        try {
+          const d = await api('/download-video', { method: 'POST', body: JSON.stringify({ url }) });
+          if (d.error) { setError(d.error); setDownloadingVideo(false); return; }
+          if (d.job_id) { setDownloadJobId(d.job_id); return; }
+          setError('Download failed: missing job id');
+          setDownloadingVideo(false);
+        } catch (e) { setError('Download failed: ' + e.message); setDownloadingVideo(false); }
+      };
+
+      useEffect(() => {
+        if (!downloadStream) return;
+        if (downloadStream.status === 'done') {
+          const d = downloadStream.result;
+          if (!d?.file_path) {
+            setError('Download finished without a video file.');
+            setDownloadingVideo(false);
+            setDownloadJobId(null);
+            return;
+          }
+          setFile(d);
+          setVideoPath(d.file_path);
+          setTranscript(null);
+          setCachedTranscript(false);
+          setTranscriptText('');
+          setTranscriptFileName('');
+          setSuggestions([]);
+          setDeselected(new Set());
+          setResults([]);
+          setEnergyData({});
+          autoTranscribeRef.current = '';
+          setDownloadingVideo(false);
+          setDownloadJobId(null);
+        } else if (downloadStream.status === 'error') {
+          setError('Download failed: ' + (downloadStream.error || 'Unknown error'));
+          setDownloadingVideo(false);
+          setDownloadJobId(null);
+        }
+      }, [downloadStream?.status]);
 
       const findMoment = async () => {
         const text = momentText.trim();
@@ -981,7 +1029,7 @@ const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(
           parts.push('Then call suggest_clips with your suggestions.');
         }
         const settings = [];
-        if (videoPath) settings.push(`Video: ${videoPath.split('/').pop()}`);
+        if (videoPath) settings.push(`Video: ${videoPath.split(/[\\/]/).pop()}`);
         settings.push(`Style: ${captionStyle}`);
         settings.push(`Crop: ${cropStrategy}`);
         if (logoPath) settings.push(`Logo: set`);
@@ -991,6 +1039,11 @@ const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(
       };
 
       const copyGeneratePrompt = async () => {
+        if (isProcessing) return;
+        if (sourceIsUrl) {
+          setError('Download the video first, then find best moments.');
+          return;
+        }
         // If user has pasted a transcript but it hasn't been parsed yet, parse it first
         if (transcriptMode === 'import' && transcriptText.trim() && !transcript) {
           setError(null);
@@ -1090,7 +1143,8 @@ const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(
         }
       };
 
-      const isProcessing = phase === 'parsing' || phase === 'suggesting' || phase === 'exporting' || transcribing;
+      const isProcessing = phase === 'parsing' || phase === 'suggesting' || phase === 'exporting' || transcribing || downloadingVideo;
+      const sourceIsUrl = isHttpUrl(videoPath);
       const selectedClips = suggestions.filter((_, i) => !deselected.has(i));
 
       const getExportStatus = (resultIdx) => {
@@ -1184,17 +1238,28 @@ const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(
                     )}
                   </div>
                 )}
-                {videoPath && (
+                {videoPath && !sourceIsUrl && (
                   <div className="file-badge fade-in">
                     <div className="dot" />
-                    <div className="name">{videoPath.split('/').pop()}</div>
+                    <div className="name">{videoPath.split(/[\\/]/).pop()}</div>
                     <button className="btn btn-ghost btn-sm" onClick={() => setVideoPath('')} style={{ padding: '4px 10px', fontSize: 11 }}>Clear</button>
                   </div>
                 )}
-                <input type="text" placeholder="Or paste a local path: /Users/you/episode.mp4"
-                  value={videoPath} onChange={e => setVideoPath(e.target.value)}
-                  disabled={isProcessing || browsing}
-                  style={{ marginTop: 8, fontSize: 12, padding: '9px 13px', background: 'var(--bg)', borderColor: videoPath ? 'var(--green-border)' : 'var(--border)' }} />
+                <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                  <input type="text" placeholder="Paste a local path or YouTube/video URL"
+                    value={videoPath} onChange={e => setVideoPath(e.target.value)}
+                    disabled={isProcessing || browsing}
+                    onKeyDown={e => { if (e.key === 'Enter' && sourceIsUrl) downloadVideo(); }}
+                    style={{ flex: 1, fontSize: 12, padding: '9px 13px', background: 'var(--bg)', borderColor: videoPath ? 'var(--green-border)' : 'var(--border)' }} />
+                  <button className="btn btn-ghost btn-sm" onClick={downloadVideo} disabled={!sourceIsUrl || isProcessing || browsing}>
+                    {downloadingVideo ? <div className="spinner sm" /> : <><DownloadGlyph size={14} /> Download</>}
+                  </button>
+                </div>
+                {downloadingVideo && (
+                  <div className="progress-track" style={{ marginTop: 6 }}>
+                    <div className="progress-fill" style={{ width: `${downloadStream?.progress || 5}%` }} />
+                  </div>
+                )}
               </div>
 
               {/* Transcript */}
@@ -1483,8 +1548,13 @@ const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(
               {/* Generate */}
               {phase === 'idle' && (
                 <div>
+                  {sourceIsUrl && (
+                    <div style={{ fontSize: 12, color: 'var(--text2)', marginBottom: 8 }}>
+                      Download the video first, then find best moments.
+                    </div>
+                  )}
                   <button className="btn btn-go"
-                    disabled={!videoPath.trim() || (transcriptMode === 'import' && !transcriptText.trim()) || (transcriptMode === 'whisper' && !transcript) || browsing || transcribing}
+                    disabled={isProcessing || sourceIsUrl || !videoPath.trim() || (transcriptMode === 'import' && !transcriptText.trim()) || (transcriptMode === 'whisper' && !transcript) || browsing || transcribing}
                     onClick={copyGeneratePrompt}
                     style={generateCopied ? { background: 'var(--green)', transition: 'background 0.2s' } : {}}>
                     {phase === 'suggesting' ? 'Claude is analyzing...' : generateCopied ? 'Copied. Paste in Claude' : 'Find best moments'}

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -24,6 +24,8 @@ import { mkdir, readdir, unlink } from "fs/promises";
 import path from "path";
 import { join, dirname, basename, extname, resolve } from "path";
 import { execSync, spawn } from "child_process";
+import { lookup } from "dns/promises";
+import { isIP } from "net";
 import { tmpdir } from "os";
 import { fileURLToPath } from "url";
 import { v4 as uuidv4 } from "uuid";
@@ -81,7 +83,7 @@ function safePath(base: string, filename: string): string | null {
 // Track active jobs so the UI can poll progress
 interface JobState {
   id: string;
-  type: "transcribe" | "create_clip" | "batch_clips";
+  type: "transcribe" | "create_clip" | "batch_clips" | "download_video";
   status: "pending" | "running" | "done" | "error";
   progress: number;
   message: string;
@@ -360,6 +362,70 @@ const upload = multer({
   },
 });
 
+function isPublicIp(address: string): boolean {
+  const family = isIP(address);
+  const mapped = address.toLowerCase().startsWith("::ffff:") ? address.slice(7) : "";
+  if (mapped) {
+    if (isIP(mapped) === 4) return isPublicIp(mapped);
+    const parts = mapped.split(":").map((part) => Number.parseInt(part, 16));
+    if (parts.length === 2 && parts.every((part) => Number.isFinite(part))) {
+      return isPublicIp([
+        parts[0] >> 8,
+        parts[0] & 255,
+        parts[1] >> 8,
+        parts[1] & 255,
+      ].join("."));
+    }
+  }
+  if (family === 4) {
+    const parts = address.split(".").map((part) => Number(part));
+    const [a, b] = parts;
+    return !(
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 198 && (b === 18 || b === 19)) ||
+      a >= 224
+    );
+  }
+  if (family === 6) {
+    const normalized = address.toLowerCase();
+    return !(
+      normalized === "::1" ||
+      normalized === "::" ||
+      normalized.startsWith("fc") ||
+      normalized.startsWith("fd") ||
+      normalized.startsWith("fe80:")
+    );
+  }
+  return false;
+}
+
+async function validateDownloadUrl(rawUrl: unknown): Promise<string> {
+  if (typeof rawUrl !== "string" || !rawUrl.trim()) {
+    throw new Error("url is required");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl.trim());
+  } catch {
+    throw new Error(`Invalid URL: ${rawUrl}`);
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error(`Unsupported URL protocol: ${parsed.protocol}. Use http or https.`);
+  }
+  // Best-effort SSRF preflight: yt-dlp still resolves redirects itself at download time.
+  const addresses = await lookup(parsed.hostname, { all: true, verbatim: false });
+  if (addresses.length === 0 || addresses.some((entry) => !isPublicIp(entry.address))) {
+    throw new Error(`Download URL host is not allowed: ${parsed.hostname}. Use a public video URL.`);
+  }
+  return parsed.toString();
+}
+
 // --- API Routes ---
 
 /**
@@ -376,6 +442,157 @@ app.post("/api/upload", upload.single("file"), (req, res) => {
     filename: req.file.originalname,
     size_mb: Math.round((req.file.size / (1024 * 1024)) * 100) / 100,
   });
+});
+
+/**
+ * POST /api/download-video — Download a video URL with yt-dlp into uploads.
+ */
+app.post("/api/download-video", async (req, res) => {
+  let url: string;
+  try {
+    url = await validateDownloadUrl(req.body?.url);
+  } catch (err) {
+    res.status(400).json({ error: errMsg(err) });
+    return;
+  }
+
+  try {
+    await mkdir(uploadDir, { recursive: true });
+  } catch (err) {
+    res.status(500).json({ error: `Failed to create upload directory: ${errMsg(err)}` });
+    return;
+  }
+
+  const jobId = uuidv4();
+  const job: JobState = {
+    id: jobId,
+    type: "download_video",
+    status: "running",
+    progress: 0,
+    message: "Downloading video",
+    createdAt: Date.now(),
+  };
+  jobs.set(jobId, job);
+
+  const args = [
+    "-m",
+    "yt_dlp",
+    // Node is enabled only as a local JS runtime; remote EJS components stay disabled.
+    "--js-runtimes",
+    `node:${process.execPath}`,
+    "--no-playlist",
+    "--format",
+    "b[ext=mp4]/b",
+    "--restrict-filenames",
+    "--windows-filenames",
+    "--paths",
+    uploadDir,
+    "--output",
+    "%(title).200B [%(id)s].%(ext)s",
+    "--newline",
+    "--progress",
+    "--progress-template",
+    "download:podcli-progress:%(progress._percent_str)s",
+    "--print",
+    "after_move:podcli-filepath:%(filepath)s",
+    url,
+  ];
+  const proc = spawn(paths.pythonPath, args, {
+    env: { ...process.env, PYTHONUNBUFFERED: "1" },
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let outputFilePath = "";
+  let settled = false;
+  let responded = false;
+  const timer = setTimeout(() => proc.kill("SIGTERM"), 3600_000);
+  const finish = (action: () => void): void => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    action();
+  };
+
+  const readYtDlpOutput = (raw: string): void => {
+    for (const line of raw.split(/\r?\n/)) {
+      const progress = line.match(/podcli-progress:\s*(\d+(?:\.\d+)?)%/);
+      if (progress) {
+        job.progress = Number(progress[1]);
+        job.message = "Downloading video";
+        broadcastSSE("job-update", { jobId, progress: job.progress, message: job.message });
+        continue;
+      }
+      const trimmed = line.trim();
+      if (trimmed.startsWith("podcli-filepath:")) {
+        outputFilePath = trimmed.slice("podcli-filepath:".length);
+      }
+    }
+  };
+
+  proc.stdout.on("data", (chunk: Buffer) => {
+    const raw = chunk.toString();
+    stdout += raw;
+    readYtDlpOutput(raw);
+  });
+  proc.stderr.on("data", (chunk: Buffer) => {
+    const raw = chunk.toString();
+    stderr += raw;
+    readYtDlpOutput(raw);
+    if (stderr && job.progress === 0) {
+      job.message = "Downloading video";
+    }
+  });
+  proc.on("error", (err) => {
+    finish(() => {
+      job.status = "error";
+      job.error = `Failed to start yt-dlp with ${paths.pythonPath}: ${err.message}`;
+      job.message = job.error;
+      broadcastSSE("job-error", { jobId, error: job.error });
+    });
+  });
+  proc.on("close", (code) => {
+    finish(() => {
+      if (code !== 0) {
+        job.status = "error";
+        job.error = `yt-dlp failed for ${url} with exit code ${code}. stderr: ${stderr.slice(-1200)}`;
+        job.message = job.error;
+        broadcastSSE("job-error", { jobId, error: job.error });
+        return;
+      }
+
+      const filePath = outputFilePath;
+      if (!filePath || !existsSync(filePath)) {
+        job.status = "error";
+        job.error = `yt-dlp finished but did not report an output file. stdout: ${stdout.slice(-1200)} stderr: ${stderr.slice(-1200)}`;
+        job.message = job.error;
+        broadcastSSE("job-error", { jobId, error: job.error });
+        return;
+      }
+
+      const stat = statSync(filePath);
+      registerSourcePath(filePath);
+      uiState.videoPath = filePath;
+      uiState.filePath = filePath;
+      uiState.lastUpdated = Date.now();
+      persistState();
+      broadcastSSE("state-sync", uiState);
+      job.status = "done";
+      job.progress = 100;
+      job.message = "Download complete";
+      job.result = {
+        file_path: filePath,
+        filename: basename(filePath),
+        size_mb: Math.round((stat.size / (1024 * 1024)) * 100) / 100,
+      };
+      broadcastSSE("job-complete", { jobId, result: job.result });
+    });
+  });
+  req.on("close", () => {
+    if (!responded && !settled) proc.kill("SIGTERM");
+  });
+  responded = true;
+  res.json({ job_id: jobId, status: "running" });
 });
 
 /**


### PR DESCRIPTION
## Summary

Adds yt-dlp support to the web UI so users can paste a YouTube or direct video URL into the existing video source field, download it locally, and continue through the current preview/transcription workflow.

## Changes

- Add `yt-dlp` to backend runtime requirements.
- Add `POST /api/download-video` for server-side URL validation and downloads.
- Use Node as yt-dlp’s JavaScript runtime and enable the EJS remote component required for current YouTube extraction.
- Combine local path and URL entry into one source field.
- Disable the Download button for local paths and enable it only for HTTP(S) URLs.

## Validation

- `npm.cmd run build`
- `npm.cmd test`
- Manually verified the reported YouTube URL downloads successfully through `/api/download-video`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for downloading videos from HTTP/HTTPS links directly in the app, including progress feedback and automatic switching to the downloaded local file.
* **Bug Fixes**
  * Improved handling of local file paths vs. web URLs so previews and transcription behave correctly.
  * Reset transcription, clip-selection, and related results state after a download completes so the workflow restarts cleanly.
  * Blocked generation (“Find best moments” and prompt generation) while the source is still a URL to prevent invalid workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->