### PR TITLE
Fix clip suggestion: dedup vs history, real error surfacing, and title wrap

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -503,6 +503,7 @@ def handle_suggest_clips(task_id: str, params: dict):
 
     segments = params.get("segments", [])
     top_n = params.get("top_n", 5)
+    existing_clips = params.get("existing_clips", [])
 
     if not segments:
         emit_result(task_id, "error", error="segments is required")
@@ -522,6 +523,7 @@ def handle_suggest_clips(task_id: str, params: dict):
     clips = suggest_with_claude(
         segments=segments,
         top_n=top_n,
+        exclude_clips=existing_clips,
         progress_callback=lambda pct, msg: emit_progress(task_id, "suggesting", pct, msg),
     )
 

--- a/backend/services/claude_suggest.py
+++ b/backend/services/claude_suggest.py
@@ -684,6 +684,30 @@ def _dedupe_clips_by_range(clips: list[dict]) -> list[dict]:
     return sorted(kept, key=lambda c: c.get("start_second", 0))
 
 
+def _drop_clips_overlapping(clips: list[dict], exclude_clips: list[dict]) -> list[dict]:
+    """Drop clips that overlap an excluded range by >50% of the shorter clip.
+    The prompt already asks the AI to skip these; this enforces it if it doesn't."""
+    if not exclude_clips:
+        return clips
+    kept = []
+    for clip in clips:
+        start = float(clip.get("start_second", 0))
+        end = float(clip.get("end_second", 0))
+        dur = max(0.0, end - start)
+        overlaps = False
+        for ex in exclude_clips:
+            ex_start = float(ex.get("start_second", 0))
+            ex_end = float(ex.get("end_second", 0))
+            overlap = max(0.0, min(end, ex_end) - max(start, ex_start))
+            shorter = min(dur, max(0.0, ex_end - ex_start)) or 1.0
+            if overlap / shorter > 0.5:
+                overlaps = True
+                break
+        if not overlaps:
+            kept.append(clip)
+    return kept
+
+
 def _select_top_by_score(clips: list[dict], top_n: int) -> list[dict]:
     """Keep the highest-scored `top_n` clips, then order them by start time.
     Ranking by score must come before truncation — otherwise the earliest clips
@@ -1014,7 +1038,9 @@ def suggest_with_claude(
                     "_ai_engine": engine,
                 })
 
-            selected = _select_top_by_score(normalized, top_n)
+            selected = _select_top_by_score(
+                _drop_clips_overlapping(normalized, exclude_clips or []), top_n
+            )
 
             if selected:
                 if progress_callback:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcli",
-  "version": "2.2.1",
+  "version": "2.3.1",
   "description": "AI-powered podcast clip generator for TikTok/YouTube Shorts. Transcribe, find viral moments, export vertical clips with burned captions.",
   "type": "module",
   "license": "AGPL-3.0-only",

--- a/src/ui/client/ClipDetail.tsx
+++ b/src/ui/client/ClipDetail.tsx
@@ -247,7 +247,7 @@ export default function ClipDetail() {
 
           <div className="section">
             <label style={labelStyle}>Title & captions</label>
-            <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} style={{ width: "100%" }} />
+            <textarea value={title} onChange={(e) => setTitle(e.target.value)} rows={2} style={{ width: "100%", resize: "vertical", lineHeight: 1.5 }} />
             <div style={{ display: "flex", gap: 10, marginTop: 10, alignItems: "center" }}>
               <select value={captionStyle} onChange={(e) => setCaptionStyle(e.target.value)} style={{ flex: 1 }}>
                 {CAPTION_STYLES.map((s) => <option key={s} value={s}>{s}</option>)}

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -2635,7 +2635,17 @@ app.post("/api/claude-suggest", async (req, res) => {
   }
 
   try {
-    const params: Record<string, unknown> = { segments: segs, top_n };
+    // Feed already-known moments to the AI so it doesn't re-suggest the same
+    // ranges: clips already rendered for this video plus current suggestions.
+    const rendered = uiState.videoPath
+      ? await clipsHistory.getBySource(uiState.videoPath).catch(() => [])
+      : [];
+    const existing_clips = [
+      ...rendered.map((c) => ({ start_second: c.start_second, end_second: c.end_second, title: c.title })),
+      ...uiState.suggestions.map((s) => ({ start_second: s.start_second, end_second: s.end_second, title: s.title })),
+    ];
+
+    const params: Record<string, unknown> = { segments: segs, top_n, existing_clips };
     if (min_duration) params.min_duration = min_duration;
     if (max_duration) params.max_duration = max_duration;
     const result = await executor.execute<{ clips?: SuggestedClip[] }>(


### PR DESCRIPTION
Three fixes to the clip suggestion / clip detail flow:

**1. Suggestions no longer repeat moments.** Suggestion now knows about clips already rendered for the current video plus the moments already on screen, and skips those ranges (with a >50%-overlap safety filter dropping any repeat the AI returns anyway).

**2. Real failure reason instead of a generic login hint.** Suggestion already captured the actual failure (Claude/Codex stderr, a timeout, or unparseable output) but only sent it to transient progress and returned `None`, so the user always saw "AI CLI found but suggestion failed - check claude/codex login" no matter the real cause. It now surfaces the actual detail and classifies it (auth vs usage/rate limit vs crash), e.g. "not logged in. Run \`claude\` once in a terminal to authenticate" or "usage or rate limit reached." Directly addresses the blocker in the studio.

**3. Long clip titles are fully visible.** The clip title editor wraps instead of scrolling a single-line box.

Typecheck, build, and the 48-test suite pass.