### PR TITLE
Release v2.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcli",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "AI-powered podcast clip generator for TikTok/YouTube Shorts. Transcribe, find viral moments, export vertical clips with burned captions.",
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Version bump to 2.3.4 to release the accumulated main work (thumbnail poster, suggestion dedup, preset persistence, AI-CLI error surfacing, hermetic python deps, studio demo mode + docs drift CI). Tag v2.3.4 after merge to publish.