### PR TITLE
Refresh studio and remotion bundles on launcher update

### DIFF
--- a/cli/internal/provision/stamp_test.go
+++ b/cli/internal/provision/stamp_test.go
@@ -1,0 +1,31 @@
+package provision
+
+import (
+	"os"
+	"testing"
+)
+
+func TestBundleStampGatesRefetch(t *testing.T) {
+	dir := t.TempDir()
+
+	if bundleAt(dir, "2.3.5") {
+		t.Fatal("unstamped bundle must not be reported as current")
+	}
+
+	writeBundleStamp(dir, "2.3.5")
+	if !bundleAt(dir, "2.3.5") {
+		t.Fatal("bundle stamped at the running version must be current")
+	}
+	if bundleAt(dir, "2.3.6") {
+		t.Fatal("bundle stamped at an older version must be refetched")
+	}
+
+	writeBundleStamp(dir, "2.3.6")
+	if !bundleAt(dir, "2.3.6") {
+		t.Fatal("re-stamp must move the bundle to the new version")
+	}
+
+	if _, err := os.Stat(bundleStamp(dir)); err != nil {
+		t.Fatalf("stamp file should exist: %v", err)
+	}
+}

--- a/cli/internal/provision/studio.go
+++ b/cli/internal/provision/studio.go
@@ -40,6 +40,17 @@ func NodeBin() string {
 func StudioDir() string    { return filepath.Join(paths.RuntimeDir(), "studio") }
 func StudioServer() string { return filepath.Join(StudioDir(), "web-server.mjs") }
 
+func bundleStamp(dir string) string { return filepath.Join(dir, ".podcli-version") }
+
+func bundleAt(dir, version string) bool {
+	b, err := os.ReadFile(bundleStamp(dir))
+	return err == nil && strings.TrimSpace(string(b)) == version
+}
+
+func writeBundleStamp(dir, version string) {
+	os.WriteFile(bundleStamp(dir), []byte(version), 0o644)
+}
+
 func EnsureNode() (string, error) {
 	bin := NodeBin()
 	if have(bin) {
@@ -91,8 +102,8 @@ func RemotionScript() string { return filepath.Join(RemotionDir(), "render.mjs")
 // a production node_modules with native bindings) and extracts it into the
 // runtime dir so remotion/ and node_modules/ sit beside backend/. Per-platform
 // because @rspack and the Remotion compositor ship native binaries.
-func EnsureRemotion() (string, error) {
-	if have(RemotionScript()) {
+func EnsureRemotion(version string) (string, error) {
+	if have(RemotionScript()) && bundleAt(RemotionDir(), version) {
 		return RemotionDir(), nil
 	}
 	name := fmt.Sprintf("remotion-bundle-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
@@ -124,6 +135,7 @@ func EnsureRemotion() (string, error) {
 	if !have(RemotionScript()) {
 		return "", fmt.Errorf("remotion render.mjs missing after extraction")
 	}
+	writeBundleStamp(RemotionDir(), version)
 	return RemotionDir(), nil
 }
 
@@ -158,9 +170,9 @@ func EnsureRemotionBrowser() error {
 
 // EnsureStudio fetches the prebuilt, platform-independent studio bundle (server +
 // SPA) from the latest release into StudioDir.
-func EnsureStudio() (string, error) {
+func EnsureStudio(version string) (string, error) {
 	server := StudioServer()
-	if have(server) {
+	if have(server) && bundleAt(StudioDir(), version) {
 		return StudioDir(), nil
 	}
 	assets, err := latestReleaseAssets()
@@ -191,6 +203,7 @@ func EnsureStudio() (string, error) {
 	if !have(server) {
 		return "", fmt.Errorf("studio server missing after extraction in %s", StudioDir())
 	}
+	writeBundleStamp(StudioDir(), version)
 	return StudioDir(), nil
 }
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -78,6 +78,26 @@ func wantsRuntime(args []string) bool {
 	return false
 }
 
+func wantsStudio(args []string) bool {
+	if len(args) == 0 {
+		return true
+	}
+	switch args[0] {
+	case "studio", "ui", "webui":
+		return true
+	}
+	return false
+}
+
+func refreshStudioBundles() {
+	if _, err := provision.EnsureStudio(Version); err != nil {
+		fmt.Fprintf(os.Stderr, "  studio: not refreshed (%v)\n", err)
+	}
+	if _, err := provision.EnsureRemotion(Version); err != nil {
+		fmt.Fprintf(os.Stderr, "  remotion: not refreshed (%v)\n", err)
+	}
+}
+
 // ensureRuntime self-provisions on first run so `podcli` works without a separate
 // `podcli setup`. Not called on the mcp path, whose stdout is the JSON-RPC channel.
 func ensureRuntime() error {
@@ -113,6 +133,9 @@ func runEngine(args []string) int {
 			fmt.Fprintln(os.Stderr, "podcli:", err)
 			return 1
 		}
+	}
+	if wantsStudio(args) {
+		refreshStudioBundles()
 	}
 	if transcribeEngine(args) == "whispercpp" {
 		model, err := provision.EnsureModel(transcribeModel(args))
@@ -263,12 +286,12 @@ func setup(args []string) int {
 	} else {
 		fmt.Printf("  node:    %s\n", nb)
 	}
-	if sd, err := provision.EnsureStudio(); err != nil {
+	if sd, err := provision.EnsureStudio(Version); err != nil {
 		fmt.Fprintf(os.Stderr, "  studio:  skipped (%v) - Web UI needs a published release\n", err)
 	} else {
 		fmt.Printf("  studio:  %s\n", sd)
 	}
-	if rd, err := provision.EnsureRemotion(); err != nil {
+	if rd, err := provision.EnsureRemotion(Version); err != nil {
 		fmt.Fprintf(os.Stderr, "  remotion: skipped (%v) - captions/thumbnails need a published release\n", err)
 	} else {
 		fmt.Printf("  remotion: %s\n", rd)


### PR DESCRIPTION
## Problem

`podcli update` swaps only the launcher binary. The studio UI (`web-server.mjs`, `mcp-server.mjs`) and remotion bundle are fetched from GitHub release assets and were guarded purely on file existence (`if have(server) return`), so once on disk they were never refreshed. Result: the launcher reports the new version while the Web UI stays on whatever build first provisioned it.

## Fix

- Stamp each fetched bundle with the launcher version that provisioned it (`.podcli-version`).
- `EnsureStudio` / `EnsureRemotion` re-fetch when the on-disk stamp is behind the running launcher.
- On UI launches (`podcli`, `studio`, `ui`, `webui`), `refreshStudioBundles` reconciles the stamp. It is a local file read (no network) when already current.

After an update, the next UI launch runs the new launcher's code, detects the stale stamp, and pulls the matching bundle automatically. No manual `podcli setup`. This also self-heals installs that are already stale.

Node stays unstamped by design: it is pinned to `nodeVersion` and carries no product features, so re-fetching it on every release would be a wasted download.

## Tests

- `stamp_test.go` covers the stamp gating logic.
- Full `go test ./...` passes.