### PR TITLE
Release v2.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "podcli",
-  "version": "2.3.3",
+  "version": "2.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "podcli",
-      "version": "2.3.3",
+      "version": "2.3.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fontsource/dm-sans": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcli",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "AI-powered podcast clip generator for TikTok/YouTube Shorts. Transcribe, find viral moments, export vertical clips with burned captions.",
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Bumps version to 2.3.5.

Includes #55: studio and remotion bundles now refresh when the launcher version moves ahead, so `podcli update` followed by a UI launch picks up the new Web UI automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to 2.3.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->