### PR TITLE
Release v2.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "podcli",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "podcli",
-      "version": "2.3.6",
+      "version": "2.3.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fontsource/dm-sans": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcli",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "AI-powered podcast clip generator for TikTok/YouTube Shorts. Transcribe, find viral moments, export vertical clips with burned captions.",
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Bumps version to 2.3.7.

Includes #59: Find Highlights accepts YouTube/video URLs (yt-dlp download).