### PR TITLE
Highlights: auto mode, max-quality render, reusable logo

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -388,6 +388,7 @@ def handle_manage_reel(task_id: str, params: dict):
             "source": session.source,
             "sources": sources,
             "format": session.format,
+            "logo": session.logo,
             "out_dir": session.out_dir,
             "reel_path": reel_file if os.path.exists(reel_file) else None,
             "moments": moments,
@@ -397,12 +398,16 @@ def handle_manage_reel(task_id: str, params: dict):
         if action == "new":
             from services.transcript_packer import compute_cache_hash, load_cached_transcript_for_video
             video_paths = params.get("video_paths") or []
+            # Auto lets the saliency threshold decide how many moments clear the bar,
+            # capped for sanity, with a wide length range so windows aren't constrained.
+            auto = bool(params.get("auto"))
             common = dict(
                 profile=params.get("profile", "auto"),
                 format=params.get("format", "horizontal"),
-                top_n=int(params.get("top_n", 10)),
-                min_dur=float(params.get("min_dur", 15.0)),
-                max_dur=float(params.get("max_dur", 60.0)),
+                top_n=50 if auto else int(params.get("top_n", 10)),
+                min_dur=5.0 if auto else float(params.get("min_dur", 15.0)),
+                max_dur=120.0 if auto else float(params.get("max_dur", 60.0)),
+                logo=params.get("logo") or "",
                 progress_callback=lambda p, m: emit_progress(task_id, "detecting", p, m),
             )
             if video_paths:
@@ -435,6 +440,10 @@ def handle_manage_reel(task_id: str, params: dict):
             emit_result(task_id, "success", data=payload(session, reel))
         elif action == "build":
             session = ReelSession.load(params["session_id"])
+            if "logo" in params:
+                session.logo = params.get("logo") or ""
+                for mm in session.moments:
+                    mm.dirty = True
             reel = build_reel(session, progress_callback=lambda p, m: emit_progress(task_id, "building", p, m))
             emit_result(task_id, "success", data=payload(session, reel))
         else:

--- a/backend/services/reel.py
+++ b/backend/services/reel.py
@@ -51,6 +51,7 @@ class ReelSession:
     profile: str
     out_dir: str
     format: str = "horizontal"
+    logo: str = ""
     moments: list[Moment] = field(default_factory=list)
 
     def save(self) -> str:
@@ -86,6 +87,7 @@ def seed_session(
     min_dur: float = 15.0,
     max_dur: float = 60.0,
     words: Optional[list[dict]] = None,
+    logo: str = "",
     progress_callback: Optional[Callable] = None,
 ) -> ReelSession:
     """Run detection once and persist the moments as an editable session."""
@@ -105,7 +107,7 @@ def seed_session(
         for c in clips
     ]
     session = ReelSession(
-        session_id, source, profile, out_dir, format=get_format(format).name, moments=moments
+        session_id, source, profile, out_dir, format=get_format(format).name, logo=logo, moments=moments
     )
     session.save()
     return session
@@ -120,6 +122,7 @@ def seed_session_pooled(
     top_n: int = 10,
     min_dur: float = 15.0,
     max_dur: float = 60.0,
+    logo: str = "",
     progress_callback: Optional[Callable] = None,
 ) -> ReelSession:
     """Detect across many videos, rank globally, and persist one editable session."""
@@ -139,7 +142,7 @@ def seed_session_pooled(
         for c in clips
     ]
     session = ReelSession(
-        session_id, sources[0], profile, out_dir, format=get_format(format).name, moments=moments
+        session_id, sources[0], profile, out_dir, format=get_format(format).name, logo=logo, moments=moments
     )
     session.save()
     return session
@@ -202,16 +205,30 @@ def _scale_filter(format: str) -> str:
             f"pad={w}:{h}:(ow-iw)/2:(oh-ih)/2")
 
 
-def _cut(source: str, out_dir: str, idx: int, m: Moment, format: str) -> str:
+def _encode_flags() -> list[str]:
+    from services.encoder import get_video_encode_flags
+    return [*get_video_encode_flags(), "-c:a", "aac", "-b:a", "256k", "-movflags", "+faststart"]
+
+
+def _cut(source: str, out_dir: str, idx: int, m: Moment, format: str, logo: str = "") -> str:
     clips_dir = os.path.join(out_dir, "clips")
     os.makedirs(clips_dir, exist_ok=True)
     out = os.path.join(clips_dir, f"clip_{idx:02d}.mp4")
-    proc_run([
-        "ffmpeg", "-y", "-ss", str(m.start), "-i", source, "-t", str(m.duration),
-        "-vf", _scale_filter(format),
-        "-c:v", "libx264", "-preset", "veryfast", "-crf", "20",
-        "-c:a", "aac", "-b:a", "192k", out, "-loglevel", "error",
-    ], timeout=120, check=True)
+    cmd = ["ffmpeg", "-y", "-ss", str(m.start), "-i", source, "-t", str(m.duration)]
+    if logo and os.path.exists(logo):
+        spec = get_format(format)
+        logo_h = max(1, round(spec.height * 0.08))
+        margin = max(1, round(spec.height * 0.04))
+        cmd += [
+            "-i", logo, "-filter_complex",
+            f"[0:v]{_scale_filter(format)}[base];[1:v]scale=-1:{logo_h}[lg];"
+            f"[base][lg]overlay=W-w-{margin}:{margin}[v]",
+            "-map", "[v]", "-map", "0:a?",
+        ]
+    else:
+        cmd += ["-vf", _scale_filter(format)]
+    cmd += [*_encode_flags(), out, "-loglevel", "error"]
+    proc_run(cmd, timeout=300, check=True)
     return out
 
 
@@ -225,7 +242,7 @@ def build_reel(session: ReelSession, progress_callback: Optional[Callable] = Non
         if m.dirty or not os.path.exists(clip):
             if progress_callback:
                 progress_callback(int(n / len(active) * 90), f"cutting moment {i}")
-            clip = _cut(m.source or session.source, session.out_dir, i, m, session.format)
+            clip = _cut(m.source or session.source, session.out_dir, i, m, session.format, session.logo)
             m.dirty = False
         files.append(clip)
     session.save()
@@ -238,8 +255,8 @@ def build_reel(session: ReelSession, progress_callback: Optional[Callable] = Non
                   "-c", "copy", reel, "-loglevel", "error"], timeout=300, check=False)
     if r.returncode != 0:
         proc_run(["ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", lst,
-                  "-c:v", "libx264", "-c:a", "aac", reel, "-loglevel", "error"],
-                 timeout=600, check=True)
+                  *_encode_flags(), reel, "-loglevel", "error"],
+                 timeout=900, check=True)
     if progress_callback:
         progress_callback(100, f"built reel with {len(files)} moments")
     return reel

--- a/src/server.ts
+++ b/src/server.ts
@@ -2102,6 +2102,14 @@ export function createServer(): McpServer {
         .enum(["vertical", "horizontal", "square"])
         .optional()
         .describe("For 'new': reel aspect ratio (default horizontal)"),
+      auto: z
+        .boolean()
+        .optional()
+        .describe("For 'new': let detection pick the best moments and how many, ignoring top_n/min_dur/max_dur"),
+      logo: z
+        .string()
+        .optional()
+        .describe("For 'new'/'build': path to a logo image overlaid top-right on the reel; empty string removes it"),
       top_n: z.number().optional().describe("For 'new': number of moments"),
       min_dur: z.number().optional().describe("For 'new': shortest moment in seconds (default 15)"),
       max_dur: z.number().optional().describe("For 'new': longest moment in seconds (default 60)"),

--- a/src/ui/client/HighlightsPage.tsx
+++ b/src/ui/client/HighlightsPage.tsx
@@ -19,6 +19,7 @@ interface HighlightsResp {
   source: string;
   sources?: string[];
   format: string;
+  logo?: string;
   out_dir: string;
   reel_path: string | null;
   moments: Moment[];
@@ -260,9 +261,14 @@ export default function HighlightsPage() {
   const [browsing, setBrowsing] = useState(false);
   const [dragOver, setDragOver] = useState(false);
   const [format, setFormat] = useState<Format>("horizontal");
+  const [auto, setAuto] = useState(true);
   const [topN, setTopN] = useState(10);
   const [minDur, setMinDur] = useState(15);
   const [maxDur, setMaxDur] = useState(60);
+  const [logoPath, setLogoPath] = useState("");
+  const [logoUploading, setLogoUploading] = useState(false);
+  const createLogoRef = useRef<HTMLInputElement>(null);
+  const sessionLogoRef = useRef<HTMLInputElement>(null);
   const [session, setSession] = useState<HighlightsResp | null>(null);
   const [selected, setSelected] = useState(0);
   const [busy, setBusy] = useState(false);
@@ -283,6 +289,9 @@ export default function HighlightsPage() {
 
   useEffect(() => {
     refreshList();
+    api<{ settings?: { logoPath?: string } }>("/ui-state")
+      .then((s) => { if (s.settings?.logoPath) setLogoPath(s.settings.logoPath); })
+      .catch(() => {});
   }, []);
 
   async function call(body: Record<string, unknown>, label: string) {
@@ -377,11 +386,46 @@ export default function HighlightsPage() {
     setPathDraft("");
   }
 
+  async function uploadImage(f: File): Promise<string | null> {
+    setLogoUploading(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", f);
+      const res = await fetch("/api/upload", { method: "POST", body: fd });
+      const d = (await res.json()) as { file_path?: string; error?: string };
+      if (d.file_path) {
+        api("/ui-state", {
+          method: "POST",
+          body: JSON.stringify({ _source: "ui", settings: { logoPath: d.file_path } }),
+        }).catch(() => {});
+        return d.file_path;
+      }
+      setMsg(d.error || "Logo upload failed");
+      return null;
+    } catch {
+      setMsg("Logo upload failed");
+      return null;
+    } finally {
+      setLogoUploading(false);
+    }
+  }
+
+  async function applySessionLogo(f: File | null) {
+    if (!session) return;
+    const logo = f ? await uploadImage(f) : "";
+    if (f && !logo) return;
+    call(
+      { action: "build", session_id: session.session_id, logo },
+      f ? "Adding logo and rebuilding…" : "Removing logo…",
+    );
+  }
+
   const detect = () => {
     const seed =
       videoPaths.length === 1 ? { video_path: videoPaths[0] } : { video_paths: videoPaths };
+    const tuning = auto ? { auto: true } : { top_n: topN, min_dur: minDur, max_dur: maxDur };
     call(
-      { action: "new", ...seed, profile: "auto", format, top_n: topN, min_dur: minDur, max_dur: maxDur },
+      { action: "new", ...seed, profile: "auto", format, ...tuning, ...(logoPath ? { logo: logoPath } : {}) },
       videoPaths.length > 1
         ? `Finding the best moments across ${videoPaths.length} videos (one-time)…`
         : "Finding the best moments (one-time, ~2 min)…",
@@ -479,6 +523,15 @@ export default function HighlightsPage() {
           style={{ width: "100%", marginTop: 8, fontFamily: "var(--font-mono)", fontSize: 12 }}
         />
 
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 16 }}>
+          <span className="field-label" style={{ margin: 0 }}>Moments</span>
+          <div style={{ display: "inline-flex", gap: 4 }}>
+            <button className={`btn btn-sm ${auto ? "btn-primary" : "btn-ghost"}`} onClick={() => setAuto(true)}>Auto</button>
+            <button className={`btn btn-sm ${!auto ? "btn-primary" : "btn-ghost"}`} onClick={() => setAuto(false)}>Custom</button>
+          </div>
+          {auto && <span className="hint">Best moments and how many, picked for you</span>}
+        </div>
+
         <div className="row" style={{ marginTop: 14 }}>
           <Field label="Format">
             <select value={format} onChange={(e) => setFormat(e.target.value as Format)}>
@@ -487,15 +540,37 @@ export default function HighlightsPage() {
               <option value="square">Square 1:1</option>
             </select>
           </Field>
-          <Field label="Moments">
-            <input type="number" min={1} max={50} value={topN} onChange={(e) => setTopN(Number(e.target.value))} style={{ width: "100%" }} />
-          </Field>
-          <Field label="Min length (s)">
-            <input type="number" min={1} value={minDur} onChange={(e) => setMinDur(Number(e.target.value))} style={{ width: "100%" }} />
-          </Field>
-          <Field label="Max length (s)">
-            <input type="number" min={1} value={maxDur} onChange={(e) => setMaxDur(Number(e.target.value))} style={{ width: "100%" }} />
-          </Field>
+          {!auto && (
+            <>
+              <Field label="Moments">
+                <input type="number" min={1} max={50} value={topN} onChange={(e) => setTopN(Number(e.target.value))} style={{ width: "100%" }} />
+              </Field>
+              <Field label="Min length (s)">
+                <input type="number" min={1} value={minDur} onChange={(e) => setMinDur(Number(e.target.value))} style={{ width: "100%" }} />
+              </Field>
+              <Field label="Max length (s)">
+                <input type="number" min={1} value={maxDur} onChange={(e) => setMaxDur(Number(e.target.value))} style={{ width: "100%" }} />
+              </Field>
+            </>
+          )}
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 14 }}>
+          <span className="field-label" style={{ margin: 0 }}>Logo</span>
+          {logoPath ? (
+            <div className="file-badge">
+              <div className="dot" />
+              <div className="name">{basename(logoPath)}</div>
+              <button className="btn btn-ghost btn-sm" onClick={() => setLogoPath("")} style={{ padding: "4px 10px", fontSize: 11 }}>Remove</button>
+            </div>
+          ) : (
+            <button className="btn btn-ghost btn-sm" disabled={logoUploading} onClick={() => createLogoRef.current?.click()}>
+              {logoUploading ? "Uploading…" : "Add logo"}
+            </button>
+          )}
+          <span className="hint">Overlaid top-right on every clip</span>
+          <input ref={createLogoRef} type="file" accept=".png,.jpg,.jpeg,.svg,.webp" style={{ display: "none" }}
+            onChange={(e) => { const f = e.target.files?.[0]; e.target.value = ""; if (f) uploadImage(f).then((p) => p && setLogoPath(p)); }} />
         </div>
 
         <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 16 }}>
@@ -523,11 +598,19 @@ export default function HighlightsPage() {
             </button>
             <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
               <span className="hint">{enabled}/{session.moments.length} in the cut</span>
+              <button className="btn btn-ghost btn-sm" disabled={busy || logoUploading} onClick={() => sessionLogoRef.current?.click()}>
+                {logoUploading ? "Uploading…" : session.logo ? "Change logo" : "Add logo"}
+              </button>
+              {session.logo && (
+                <button className="btn btn-ghost btn-sm" disabled={busy} onClick={() => applySessionLogo(null)}>Remove logo</button>
+              )}
               {session.reel_path && (
                 <a className="btn btn-primary btn-sm" href={download(session.reel_path)} style={{ textDecoration: "none", display: "inline-flex", alignItems: "center", gap: 6 }}>
                   <DownloadIcon /> Download reel
                 </a>
               )}
+              <input ref={sessionLogoRef} type="file" accept=".png,.jpg,.jpeg,.svg,.webp" style={{ display: "none" }}
+                onChange={(e) => { const f = e.target.files?.[0]; e.target.value = ""; if (f) applySessionLogo(f); }} />
             </div>
           </div>
 

--- a/src/ui/public/css/styles.css
+++ b/src/ui/public/css/styles.css
@@ -1341,7 +1341,7 @@ p, li, figcaption, blockquote, .subtitle, .file-preview, .card-desc, .int-row .d
 
 /* ── Reframe timeline polish (grabbable handles) ── */
 .rf-track { height: 44px; }
-.rf-handle { width: 10px; border-radius: 4px; top: -3px; bottom: -3px; transform: translateX(-5px); cursor: ew-resize; box-shadow: 0 0 0 1px rgba(0,0,0,0.45); z-index: 2; }
+.rf-handle { width: 10px; border-radius: 4px; top: -3px; bottom: -3px; transform: translateX(-5px); cursor: ew-resize; box-shadow: 0 0 0 1px rgba(0,0,0,0.45); z-index: 2; pointer-events: auto; }
 .rf-handle::after { content: ""; position: absolute; top: 50%; left: 50%; width: 2px; height: 16px; background: rgba(0,0,0,0.4); transform: translate(-50%,-50%); border-radius: 1px; }
 .rf-track:hover .rf-handle { box-shadow: 0 0 0 1px var(--accent-glow); }
 .rf-playhead { z-index: 3; }

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -544,8 +544,14 @@ app.post("/api/download-video", async (req, res) => {
     "--js-runtimes",
     `node:${process.execPath}`,
     "--no-playlist",
+    // Best video+audio up to 1080p merged to mp4. A bare muxed stream (b[ext=mp4])
+    // is 360p on YouTube, which then upscales into a terrible-looking reel.
     "--format",
-    "b[ext=mp4]/b",
+    "bv*[height<=1080]+ba/b[height<=1080]/bv*+ba/b",
+    "--merge-output-format",
+    "mp4",
+    "--ffmpeg-location",
+    paths.ffmpegPath,
     "--restrict-filenames",
     "--windows-filenames",
     "--paths",


### PR DESCRIPTION
Bundles the Find Highlights improvements. No release; ready for review.

## Auto moments
An **Auto / Custom** toggle (default Auto). Auto lets the saliency threshold decide the best moments and how many (capped at 50) with a wide length range, so you don't dial in a count. Custom keeps the manual top_n / min / max fields.

## Max-quality render
- Clips and the concat re-encode now **reuse the shared `get_video_encode_flags()`** (hardware-accelerated, crf-18 / cq-18), the same encoder the caption/clip pipeline uses, instead of the old `veryfast/crf20`.
- **YouTube downloads**: the format was `b[ext=mp4]`, which is YouTube's 360p muxed stream, then upscaled into a terrible-looking reel. Now `bv*[height<=1080]+ba` merged to mp4 via the managed ffmpeg. This was the real cause of the "terrible quality" report.

## Reusable logo
Optional logo overlaid top-right on every clip. Stored on the reel session and re-applied on re-cut. It **reuses the shared brand logo** (`settings.logoPath`): Highlights pre-fills from it, and an uploaded logo is saved back, so it persists across reels and matches the episode/captions flow. Add or remove a logo on an existing reel from the session header (rebuilds).

## Fix: trim handles
The moment trim handles were unclickable, `.rf-handle` kept `pointer-events: none` from an earlier rule while the later "grabbable" rule never re-enabled it. One-line CSS fix.

## Reuse notes
- Encoder: `services/encoder.get_video_encode_flags()`
- Overlay: mirrors `captions_burn` (scale to 8% height, overlay at margin)
- Logo upload/persist: `/api/upload` + `/api/ui-state` settings
- URL download + job SSE: unchanged, from the episode page

## Verification
`tsc --noEmit` + `vite build` pass; backend compiles; ReelSession `logo` round-trips with backward-compatible load of old sessions.