### PR TITLE
Release v2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "podcli",
-  "version": "2.3.7",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "podcli",
-      "version": "2.3.7",
+      "version": "2.4.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fontsource/dm-sans": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcli",
-  "version": "2.3.7",
+  "version": "2.4.0",
   "description": "AI-powered podcast clip generator for TikTok/YouTube Shorts. Transcribe, find viral moments, export vertical clips with burned captions.",
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Version bump for the asset library release (#62). Tag `v2.4.0` after merge to trigger the build + publish pipeline.