### PR TITLE
Global command palette (⌘K)

### DIFF
--- a/src/ui/client/CommandPalette.tsx
+++ b/src/ui/client/CommandPalette.tsx
@@ -65,12 +65,17 @@ export default function CommandPalette() {
     if (!open) return;
     inputRef.current?.focus();
     if (loaded.current) return;
-    loaded.current = true;
-    api<{ id: string; title: string }[]>("/history?limit=100").then((h) => setClips(h || [])).catch(() => {});
-    api<{ name: string; type: string }[]>("/assets").then((a) => setAssets(a || [])).catch(() => {});
+    Promise.allSettled([
+      api<{ id: string; title: string }[]>("/history?limit=100").then((h) => setClips(h || [])),
+      api<{ name: string; type: string }[]>("/assets").then((a) => setAssets(a || [])),
+    ]).then((r) => {
+      // Only cache success, so a failed fetch retries on the next open.
+      if (r.every((x) => x.status === "fulfilled")) loaded.current = true;
+    });
   }, [open]);
 
-  useEffect(() => setActive(0), [query]);
+  // Keep the active row valid when the query or the loaded data changes.
+  useEffect(() => setActive(0), [query, clips, assets]);
 
   const go = useCallback((run: () => void) => { close(); run(); }, [close]);
 

--- a/src/ui/client/CommandPalette.tsx
+++ b/src/ui/client/CommandPalette.tsx
@@ -1,0 +1,159 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
+import { Search, FileText, Film, Package, CornerDownLeft } from "lucide-react";
+import { api } from "./lib";
+
+interface Cmd {
+  id: string;
+  label: string;
+  sub?: string;
+  group: "Pages" | "Clips" | "Assets";
+  keywords?: string;
+  run: () => void;
+}
+
+const PAGES: { label: string; path: string; kw: string }[] = [
+  { label: "Library", path: "/", kw: "clips home dashboard" },
+  { label: "New episode", path: "/episode", kw: "upload transcribe process video" },
+  { label: "Content", path: "/content", kw: "titles descriptions hashtags" },
+  { label: "Highlights", path: "/highlights", kw: "reel moments" },
+  { label: "Thumbnails", path: "/thumbnails", kw: "cover image" },
+  { label: "Assets", path: "/assets", kw: "logo outro intro music brand kit" },
+  { label: "Knowledge", path: "/knowledge", kw: "brand voice banned words" },
+  { label: "Config", path: "/config", kw: "settings api keys tokens" },
+  { label: "Integrations", path: "/integrations", kw: "youtube davinci" },
+  { label: "MCP setup", path: "/mcp", kw: "claude codex cursor" },
+  { label: "Analytics", path: "/analytics", kw: "performance views retention ctr" },
+];
+
+const GROUP_ICON = {
+  Pages: <FileText size={15} />,
+  Clips: <Film size={15} />,
+  Assets: <Package size={15} />,
+};
+
+export default function CommandPalette() {
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const [clips, setClips] = useState<{ id: string; title: string }[]>([]);
+  const [assets, setAssets] = useState<{ name: string; type: string }[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const loaded = useRef(false);
+
+  const close = useCallback(() => { setOpen(false); setQuery(""); setActive(0); }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    };
+    const onTrigger = () => setOpen(true);
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("open-command-palette", onTrigger);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("open-command-palette", onTrigger);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    inputRef.current?.focus();
+    if (loaded.current) return;
+    loaded.current = true;
+    api<{ id: string; title: string }[]>("/history?limit=100").then((h) => setClips(h || [])).catch(() => {});
+    api<{ name: string; type: string }[]>("/assets").then((a) => setAssets(a || [])).catch(() => {});
+  }, [open]);
+
+  useEffect(() => setActive(0), [query]);
+
+  const go = useCallback((run: () => void) => { close(); run(); }, [close]);
+
+  const results = useMemo<Cmd[]>(() => {
+    const q = query.trim().toLowerCase();
+    const pageCmds: Cmd[] = PAGES.map((p) => ({
+      id: `p:${p.path}`, label: p.label, group: "Pages", keywords: p.kw,
+      run: () => navigate(p.path),
+    }));
+    const clipCmds: Cmd[] = clips.map((c) => ({
+      id: `c:${c.id}`, label: c.title || "Untitled clip", sub: "Clip", group: "Clips",
+      run: () => navigate(`/clip/${c.id}`),
+    }));
+    const assetCmds: Cmd[] = assets.map((a) => ({
+      id: `a:${a.name}`, label: a.name, sub: a.type, group: "Assets",
+      run: () => navigate("/assets"),
+    }));
+    const all = [...pageCmds, ...clipCmds, ...assetCmds];
+    if (!q) return pageCmds;
+    const match = (c: Cmd) =>
+      c.label.toLowerCase().includes(q) ||
+      (c.sub?.toLowerCase().includes(q) ?? false) ||
+      (c.keywords?.includes(q) ?? false);
+    return all.filter(match).slice(0, 24);
+  }, [query, clips, assets, navigate]);
+
+  const groups = useMemo(() => {
+    const order: Cmd["group"][] = ["Pages", "Clips", "Assets"];
+    return order
+      .map((g) => ({ group: g, items: results.filter((r) => r.group === g) }))
+      .filter((g) => g.items.length > 0);
+  }, [results]);
+
+  const flat = results;
+
+  if (!open || typeof document === "undefined") return null;
+
+  return createPortal(
+    <div className="cmdk-overlay" onClick={close}>
+      <div className="cmdk" onClick={(e) => e.stopPropagation()}>
+        <div className="cmdk-head">
+          <Search size={17} className="cmdk-search-icon" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") close();
+              else if (e.key === "ArrowDown") { e.preventDefault(); setActive((i) => Math.min(i + 1, flat.length - 1)); }
+              else if (e.key === "ArrowUp") { e.preventDefault(); setActive((i) => Math.max(i - 1, 0)); }
+              else if (e.key === "Enter" && flat[active]) { e.preventDefault(); go(flat[active].run); }
+            }}
+            placeholder="Search pages, clips, and assets"
+          />
+          <kbd className="cmdk-kbd">esc</kbd>
+        </div>
+
+        <div className="cmdk-list">
+          {flat.length === 0 && <div className="cmdk-empty">No matches for “{query}”.</div>}
+          {groups.map((g) => (
+            <div key={g.group} className="cmdk-group">
+              <div className="cmdk-group-label">{g.group}</div>
+              {g.items.map((c) => {
+                const idx = flat.indexOf(c);
+                return (
+                  <button
+                    key={c.id}
+                    className={`cmdk-item${idx === active ? " active" : ""}`}
+                    onMouseEnter={() => setActive(idx)}
+                    onClick={() => go(c.run)}
+                  >
+                    <span className="cmdk-item-icon">{GROUP_ICON[c.group]}</span>
+                    <span className="cmdk-item-label">{c.label}</span>
+                    {c.sub && <span className="cmdk-item-sub">{c.sub}</span>}
+                    {idx === active && <CornerDownLeft size={13} className="cmdk-item-enter" />}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/ui/client/CommandPalette.tsx
+++ b/src/ui/client/CommandPalette.tsx
@@ -74,9 +74,6 @@ export default function CommandPalette() {
     });
   }, [open]);
 
-  // Keep the active row valid when the query or the loaded data changes.
-  useEffect(() => setActive(0), [query, clips, assets]);
-
   const go = useCallback((run: () => void) => { close(); run(); }, [close]);
 
   const results = useMemo<Cmd[]>(() => {
@@ -110,6 +107,7 @@ export default function CommandPalette() {
   }, [results]);
 
   const flat = results;
+  const activeIdx = Math.min(active, Math.max(0, flat.length - 1));
 
   if (!open || typeof document === "undefined") return null;
 
@@ -121,12 +119,12 @@ export default function CommandPalette() {
           <input
             ref={inputRef}
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => { setQuery(e.target.value); setActive(0); }}
             onKeyDown={(e) => {
               if (e.key === "Escape") close();
               else if (e.key === "ArrowDown") { e.preventDefault(); setActive((i) => Math.min(i + 1, flat.length - 1)); }
               else if (e.key === "ArrowUp") { e.preventDefault(); setActive((i) => Math.max(i - 1, 0)); }
-              else if (e.key === "Enter" && flat[active]) { e.preventDefault(); go(flat[active].run); }
+              else if (e.key === "Enter" && flat[activeIdx]) { e.preventDefault(); go(flat[activeIdx].run); }
             }}
             placeholder="Search pages, clips, and assets"
           />
@@ -143,14 +141,14 @@ export default function CommandPalette() {
                 return (
                   <button
                     key={c.id}
-                    className={`cmdk-item${idx === active ? " active" : ""}`}
+                    className={`cmdk-item${idx === activeIdx ? " active" : ""}`}
                     onMouseEnter={() => setActive(idx)}
                     onClick={() => go(c.run)}
                   >
                     <span className="cmdk-item-icon">{GROUP_ICON[c.group]}</span>
                     <span className="cmdk-item-label">{c.label}</span>
                     {c.sub && <span className="cmdk-item-sub">{c.sub}</span>}
-                    {idx === active && <CornerDownLeft size={13} className="cmdk-item-enter" />}
+                    {idx === activeIdx && <CornerDownLeft size={13} className="cmdk-item-enter" />}
                   </button>
                 );
               })}

--- a/src/ui/client/Layout.tsx
+++ b/src/ui/client/Layout.tsx
@@ -12,7 +12,9 @@ import {
   BarChart3,
   Scissors,
   Package,
+  Search,
 } from "lucide-react";
+import CommandPalette from "./CommandPalette";
 
 const icons: Record<string, typeof LayoutGrid> = {
   library: LayoutGrid,
@@ -49,6 +51,12 @@ export default function Layout() {
           <img src="/podcli-logo-transparent.png" alt="podcli" />
         </Link>
 
+        <button className="sidebar-search" onClick={() => window.dispatchEvent(new Event("open-command-palette"))}>
+          <Search className="ico" strokeWidth={1.8} size={15} />
+          <span>Search</span>
+          <kbd>⌘K</kbd>
+        </button>
+
         <div className="sidebar-section">Studio</div>
         <NavLink to="/" end className="sidebar-link"><Icon name="library" /> Library</NavLink>
         <NavLink to="/episode" className="sidebar-link"><Icon name="episode" /> New episode</NavLink>
@@ -70,6 +78,7 @@ export default function Layout() {
       <main className="shell-main">
         <Outlet />
       </main>
+      <CommandPalette />
     </div>
   );
 }

--- a/src/ui/public/css/styles.css
+++ b/src/ui/public/css/styles.css
@@ -1363,6 +1363,49 @@ p, li, figcaption, blockquote, .subtitle, .file-preview, .card-desc, .int-row .d
   .stream-in { animation: none; }
 }
 
+/* ── Command palette (global search) ── */
+.sidebar-search {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  margin: 6px 0 14px; padding: 8px 10px; cursor: pointer;
+  background: var(--surface2); border: 1px solid var(--border);
+  border-radius: var(--radius-sm); color: var(--text3); font-family: inherit; font-size: 13px;
+  transition: border-color 0.15s var(--ease), color 0.15s var(--ease);
+}
+.sidebar-search:hover { border-color: var(--border-hover); color: var(--text2); }
+.sidebar-search span { flex: 1; text-align: left; }
+.sidebar-search kbd { font-size: 10px; border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px; color: var(--text3); }
+
+.cmdk-overlay {
+  position: fixed; inset: 0; z-index: 1000; display: flex; align-items: flex-start; justify-content: center;
+  padding: 12vh 16px 16px; background: rgba(0,0,0,0.6); backdrop-filter: blur(6px);
+  animation: fadeIn 0.12s var(--ease);
+}
+.cmdk {
+  width: 100%; max-width: 580px; overflow: hidden;
+  background: var(--surface); border: 1px solid var(--border-hover);
+  border-radius: var(--radius-lg); box-shadow: 0 24px 64px rgba(0,0,0,0.55);
+  animation: scaleIn 0.16s var(--ease-out);
+}
+.cmdk-head { display: flex; align-items: center; gap: 12px; padding: 0 16px; border-bottom: 1px solid var(--border); }
+.cmdk-search-icon { color: var(--text3); flex-shrink: 0; }
+.cmdk-head input { flex: 1; border: none !important; background: transparent !important; box-shadow: none !important; padding: 15px 0 !important; font-size: 15px; color: var(--text); }
+.cmdk-kbd { font-size: 10px; color: var(--text3); border: 1px solid var(--border); border-radius: 4px; padding: 2px 6px; flex-shrink: 0; }
+.cmdk-list { max-height: 54vh; overflow-y: auto; padding: 8px; }
+.cmdk-empty { padding: 28px; text-align: center; color: var(--text3); font-size: 13px; }
+.cmdk-group + .cmdk-group { margin-top: 6px; }
+.cmdk-group-label { font-size: 10px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase; color: var(--text3); padding: 6px 10px 4px; }
+.cmdk-item {
+  display: flex; align-items: center; gap: 10px; width: 100%; text-align: left;
+  padding: 9px 10px; background: none; border: none; border-radius: var(--radius-sm);
+  color: var(--text2); font-family: inherit; font-size: 13.5px; cursor: pointer;
+}
+.cmdk-item.active { background: var(--surface2); color: var(--text); }
+.cmdk-item-icon { display: inline-flex; color: var(--text3); flex-shrink: 0; }
+.cmdk-item.active .cmdk-item-icon { color: var(--accent); }
+.cmdk-item-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cmdk-item-sub { font-size: 11px; color: var(--text3); text-transform: capitalize; flex-shrink: 0; }
+.cmdk-item-enter { color: var(--text3); flex-shrink: 0; }
+
 /* ── Assets page ── */
 .asset-section-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
 .asset-count { color: var(--text3); font-weight: 500; margin-left: 4px; }


### PR DESCRIPTION
A spotlight-style global search across the studio, replacing the page-scoped Assets search. Press ⌘K (or the sidebar Search button) on any page to search **Pages**, **Clips**, and **Assets**, with arrow-key navigation and Enter to jump. Built with the existing design tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global command palette for quick keyboard-driven navigation.
  * Open it with **Ctrl/⌘+K** or via the new **Search** button in the sidebar.
  * Search across pages, recent clips, and assets with grouped results and fast selection.
  * Supports keyboard navigation, click-to-open actions, and closing on Escape or outside click.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->