### PR TITLE
Say what podcli actually does, and report the real clips path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,40 @@ podcli                       # interactive menu, opens the web studio
 podcli process episode.mp4   # transcribe, pick moments, render clips
 ```
 
-Clips land in `podcli-clips/` in the directory you ran it from.
+Clips land in `podcli-clips/` in the directory you ran it from, so each show keeps its own renders. Everything else (knowledge, presets, assets, clip history, cache) lives in one managed folder that follows you between directories. Set `PODCLI_OUTPUT` to render somewhere fixed instead.
 
 ## What you get
 
-- Clips in 9:16, 16:9, or 1:1, with captions sized for each canvas
-- Face tracking that follows the speaker, including split-screen layouts
+**Clips**
+
+- 9:16, 16:9, or 1:1, with captions sized for each canvas
+- Face tracking that follows the speaker, split-screen layouts included
+- Multi-segment cuts that drop filler, long pauses, and tangents
 - Four caption styles: branded, hormozi, karaoke, subtle
-- Hardware encoding on VideoToolbox, NVENC, and VAAPI, with a CPU fallback
-- A web studio at `localhost:3847` for review, thumbnails, and content
-- A knowledge base that teaches the AI your show's voice and title rules
+- Logos, intros, outros, and background music from a reusable asset library
+- Loudness-normalized audio and hardware encoding on VideoToolbox, NVENC, and VAAPI, with a CPU fallback
+
+**Finding the moments**
+
+- Whisper transcription with speaker diarization, or bring your own transcript as `.txt`, `.srt`, or `.vtt`
+- AssemblyAI as an alternative engine, and yt-dlp to pull an episode straight from a URL
+- AI scoring against your knowledge base, checked against your episode database so it stops resuggesting moments you already published
+- Audio energy and laughter detection to build highlight reels
+
+**The studio at `localhost:3847`**
+
+- Library, episode workspace, per-clip detail, highlights, thumbnails, content, analytics, assets, knowledge, config, integrations, and MCP setup
+- `⌘K` command palette across pages, clips, and assets
+- Titles, descriptions, tags, and hashtags, with any section regenerated on your own guidance
+- Thumbnail studio for 16:9 and 9:16, with frame and text options
+- Transcript corrections that carry through to every render
+
+**Shipping it**
+
+- 26 MCP tools, so an agent can transcribe, score, render, and publish through conversation
+- YouTube publishing plus performance analytics to see which clips landed
+- DaVinci Resolve export as FCPXML when you want to finish by hand
+- Presets, clip history with duplicate detection, and a transcript cache
 
 ## Use it from your agent
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -623,7 +623,9 @@ func doctor() {
 	fmt.Printf("  runtime:  %s\n", paths.RuntimeDir())
 	fmt.Printf("  models:   %s\n", paths.ModelsDir())
 	fmt.Printf("  presets/knowledge/assets/history/cache: %s  (global - follow you everywhere)\n", paths.Home())
-	if cwd, err := os.Getwd(); err == nil {
+	if out := os.Getenv("PODCLI_OUTPUT"); out != "" {
+		fmt.Printf("  clips:    %s  (PODCLI_OUTPUT)\n", out)
+	} else if cwd, err := os.Getwd(); err == nil {
 		fmt.Printf("  clips:    %s  (rendered into your working directory)\n", filepath.Join(cwd, "podcli-clips"))
 	}
 	fmt.Println("\nEngine resolution")


### PR DESCRIPTION
Follow-up to #69, which squash-merged before this commit landed on it.

## The feature list undersold the project

"What you get" named six things. The repo ships considerably more, none of it mentioned: an asset library with intros, outros, and background music; AssemblyAI as an alternative engine; yt-dlp URL import; laughter detection for highlight reels; transcript corrections; the ⌘K command palette; the thumbnail and content studios; YouTube analytics; DaVinci FCPXML export; multi-segment cuts; audio normalization; presets; duplicate detection.

Everything is enumerated from source (26 `server.tool` registrations, 12 studio routes) and grouped into clips, finding the moments, the studio, and shipping. The tool count is stated as 26, which `check-docs-drift.mjs` verifies against the call sites, so it cannot rot silently the way "22 tools" did.

## `doctor` reported the wrong clips path

It printed `cwd/podcli-clips` unconditionally, even with `PODCLI_OUTPUT` set, so anyone using the override was told the wrong directory. The backend has always honored the variable (`backend/config/paths.py:47`); only the report was wrong.

```
PODCLI_OUTPUT=/tmp/fixed-clips  ->  clips: /tmp/fixed-clips  (PODCLI_OUTPUT)
unset                           ->  clips: /tmp/podcli-clips (working directory)
```

This touches `cli/`, so it reaches users on the next tag.

## Clips are per-directory on purpose

Verified against the released 2.4.2 binary from two working directories: renders go to `./podcli-clips` each time, while the managed home stays constant. Knowledge, presets, assets, history, and cache are unified and follow you between directories; only renders are per-show. `engine.go:197` states the intent. The README now says it outright, since the split reads like an oversight otherwise.

## Verification

`check-docs-drift.mjs` clean, `go build` / `vet` / `test` clean, both `doctor` branches exercised, zero em or en dashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the quick start and overview to clarify where clips are saved and how persistent app state is managed.
  * Reworked the feature overview into clearer sections with more detailed descriptions of clipping, moment-finding, studio tools, and publishing workflows.

* **Bug Fixes**
  * Updated the diagnostic output to correctly show the configured clip destination when a custom output path is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->