### PR TITLE
Send the release tag with the landing dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,4 +172,4 @@ jobs:
             -H "Authorization: Bearer $LANDING_DISPATCH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/nmbrthirteen/podcli-landing/dispatches \
-            -d '{"event_type":"release"}'
+            -d "{\"event_type\":\"release\",\"client_payload\":{\"tag\":\"${GITHUB_REF_NAME}\"}}"


### PR DESCRIPTION
The `release` dispatch to podcli-landing carried no `client_payload`, so the receiving workflow could not name the release it was rebuilding for. Now it sends the tag, and the landing log line reads `Vercel responded 201 for podcli v2.4.3`.

Pairs with nmbrthirteen/podcli-landing#7, which is where the actual rebuild happens. Worth knowing why that PR exists: this dispatch has fired since v2.4.1 and never caused a rebuild, because the receiving job only commits when the docs submodule moves, and a podcli release never moves it. The step name here promised something the other repo never delivered.