### PR TITLE
Render clips past the length target instead of failing them

### DIFF
--- a/backend/services/claude_suggest.py
+++ b/backend/services/claude_suggest.py
@@ -541,7 +541,7 @@ All timestamps you return MUST be in SECONDS as numbers (e.g., 123.4), NOT minut
 
 DURATION RULES (CRITICAL):
 - Target: {TARGET_CLIP_DURATION_MIN}-{TARGET_CLIP_DURATION_MAX} seconds (this is the viral sweet spot)
-- Maximum: {MAX_CLIP_DURATION} seconds (absolute hard limit — anything longer WILL FAIL rendering)
+- Maximum: {MAX_CLIP_DURATION} seconds (anything longer still renders, but gets flagged as over target)
 - Minimum: {MIN_CLIP_DURATION} seconds (too short = no payoff)
 - SHORTER IS BETTER. A punchy 25s clip outperforms a 40s clip every time.
 - If a thought takes longer than {TARGET_CLIP_DURATION_MAX}s, use segments to cut the filler in the middle

--- a/backend/services/clip_generator.py
+++ b/backend/services/clip_generator.py
@@ -715,8 +715,10 @@ def generate_clip(
         keep_segments = None
         duration = end_second - start_second
 
+    length_warning = None
     if duration > spec.dur_max:
-        raise ValueError(f"Clip too long ({duration:.0f}s). Max {spec.dur_max} seconds for {spec.name}.")
+        length_warning = f"{duration:.0f}s, over the {spec.dur_max}s {spec.name} target"
+        print(f"  {length_warning}", file=sys.stderr, flush=True)
 
     # Load style config for branded-specific settings
     style_config = get_style(caption_style)
@@ -940,6 +942,8 @@ def generate_clip(
             "crop_strategy": crop_strategy,
             "format": spec.name,
         }
+        if length_warning:
+            out["warning"] = length_warning
         if keep_caption_overlay and caption_overlay_path and os.path.exists(caption_overlay_path):
             out["caption_overlay_path"] = caption_overlay_path
             out["cropped_source_path"] = cropped_path

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "podcli",
-  "version": "2.4.0",
+  "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "podcli",
-      "version": "2.4.0",
+      "version": "2.4.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fontsource/dm-sans": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcli",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "private": true,
   "description": "AI-powered podcast clip generator for TikTok/YouTube Shorts. Transcribe, find viral moments, export vertical clips with burned captions.",
   "type": "module",

--- a/src/ui/client/EpisodeWorkspace.jsx
+++ b/src/ui/client/EpisodeWorkspace.jsx
@@ -1730,6 +1730,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
                               </span>
                             )}
                             {r && !failed && <span> {'\u00B7'} {r.file_size_mb}MB</span>}
+                            {r && !failed && r.warning && <span className="warn"> {'\u00B7'} {r.warning}</span>}
                             {failed && <span className="err"> {'\u00B7'} {r.error?.slice(0, 60)}</span>}
                             {exportStatus === 'rendering' && <span style={{ color: 'var(--accent)' }}> {'\u00B7'} rendering{'\u2026'}</span>}
                           </div>

--- a/src/ui/public/css/styles.css
+++ b/src/ui/public/css/styles.css
@@ -28,6 +28,7 @@
   --blue-subtle: rgba(96, 165, 250, 0.10);
   --blue-border: rgba(96, 165, 250, 0.22);
   --yellow: #facc15;
+  --amber: #fbbf24;
   --glass-bg: rgba(22, 21, 15, 0.6);
   --glass-border: rgba(255, 255, 255, 0.07);
   --glass-hi: rgba(255, 255, 255, 0.06);
@@ -651,6 +652,7 @@ select {
 .clip-title { font-size: 13px; font-weight: 600; line-height: 1.4; overflow-wrap: anywhere; }
 .clip-meta { font-size: 12px; color: var(--text2); margin-top: 2px; }
 .clip-meta .err { color: var(--red); }
+.clip-meta .warn { color: var(--amber); }
 .clip-actions { display: flex; gap: 4px; flex-shrink: 0; }
 .clip-status { width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 11px; font-weight: 700; }
 .clip-status.pending { border: 1.5px dashed var(--border); }


### PR DESCRIPTION
## Problem

Vertical/square clips over 45s **never rendered**. `generate_clip` raised `ValueError("Clip too long...")` before cutting a single frame, so the result card was stuck with a `Retry` button that re-ran the same check and failed forever. After a long wait, you got a dead clip and no file to download.

The actual system ceiling (180s vertical, 300s horizontal) is already enforced upstream in `web-server.ts`, so 45s was only ever a preference, not a real limit.

## Change

- `clip_generator.py`: replace the hard `raise` with a non-blocking `length_warning`, attached to the result as `warning`. The clip renders.
- `EpisodeWorkspace.jsx`: render `r.warning` as an amber note next to the file size. Existing card logic already shows Play / Download / Retry for any successful clip.
- `styles.css`: add `--amber` token and `.clip-meta .warn`, following the existing `--red` / `.err` pattern.
- `claude_suggest.py`: the LLM prompt claimed over-45s clips "WILL FAIL rendering" (now false); corrected to say they render but get flagged. Still steers toward shorter clips.

## Result

The card reads e.g. `12:47 → 13:12 · 99s · 20.1MB · 99s, over the 45s vertical target` in amber, with working Play / Download / Retry.

## Verification

Rendered against a synthetic source (not just typecheck):
- 70s vertical → real 1080x1920, 70.1s, 24MB file, `warning` present
- 30s vertical → renders, no `warning` key (normal path unchanged)
- `tsc --noEmit` clean, 61/61 vitest pass

Patch bump to 2.4.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clips that exceed the target duration can now continue processing instead of stopping outright.
  * Warning messages are now shown in the clip review view when a clip is over the target length.

* **Bug Fixes**
  * Updated clip length handling so longer clips are flagged as “over target” rather than treated as a hard failure.

* **Chores**
  * Updated the app version to 2.4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->