### PR TITLE
Fix multi-segment export, suggest reliability, and thumbnail extraction

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -557,7 +557,7 @@ def handle_suggest_clips(task_id: str, params: dict):
     )
 
     if clips is None:
-        detail = errors[0] if errors else "check claude/codex login and try again"
+        detail = errors[-1] if errors else "check claude/codex login and try again"
         emit_result(task_id, "error", error=detail)
         return
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -526,7 +526,7 @@ def handle_corrections(task_id: str, params: dict):
 
 def handle_suggest_clips(task_id: str, params: dict):
     """AI-powered clip suggestion using Claude/Codex and PodStack knowledge base."""
-    from services.claude_suggest import suggest_with_claude, _find_ai_cli_candidates
+    from services.claude_suggest import suggest_initial_with_claude, _find_ai_cli_candidates
 
     segments = params.get("segments", [])
     top_n = params.get("top_n", 5)
@@ -548,7 +548,7 @@ def handle_suggest_clips(task_id: str, params: dict):
         return
 
     errors: list[str] = []
-    clips = suggest_with_claude(
+    clips = suggest_initial_with_claude(
         segments=segments,
         top_n=top_n,
         exclude_clips=existing_clips,

--- a/backend/services/claude_suggest.py
+++ b/backend/services/claude_suggest.py
@@ -799,7 +799,7 @@ Transcript:
                     prompt=prompt,
                     prompt_file=prompt_file,
                     project_dir=project_dir,
-                    timeout=300,
+                    timeout=900,
                 )
             except Exception:
                 continue
@@ -896,7 +896,7 @@ def suggest_with_claude(
     top_n: int = 5,
     exclude_clips: list[dict] | None = None,
     progress_callback: Optional[Callable[[int, str], None]] = None,
-    timeout: int = 300,
+    timeout: int = 900,
     error_sink: Optional[list[str]] = None,
 ) -> Optional[list[dict]]:
     """
@@ -1088,7 +1088,9 @@ def suggest_with_claude(
 def suggest_initial_with_claude(
     segments: list[dict],
     top_n: int = 5,
+    exclude_clips: list[dict] | None = None,
     progress_callback: Optional[Callable[[int, str], None]] = None,
+    error_sink: Optional[list[str]] = None,
 ) -> Optional[list[dict]]:
     """
     Initial clip discovery entry point.
@@ -1097,11 +1099,14 @@ def suggest_initial_with_claude(
     quickly and cover the full timeline instead of timing out on one giant
     prompt.
     """
+    exclude_clips = exclude_clips or []
     if not _should_bucket_initial_selection(segments):
         return suggest_with_claude(
             segments=segments,
             top_n=top_n,
+            exclude_clips=exclude_clips,
             progress_callback=progress_callback,
+            error_sink=error_sink,
             timeout=180,
         )
 
@@ -1130,7 +1135,9 @@ def suggest_initial_with_claude(
         return suggest_with_claude(
             segments=segments,
             top_n=top_n,
+            exclude_clips=exclude_clips,
             progress_callback=progress_callback,
+            error_sink=error_sink,
             timeout=180,
         )
 
@@ -1152,7 +1159,7 @@ def suggest_initial_with_claude(
         bucket_clips = suggest_with_claude(
             segments=bucket["segments"],
             top_n=per_bucket_top_n,
-            exclude_clips=aggregated,
+            exclude_clips=exclude_clips + aggregated,
             progress_callback=(
                 None if progress_callback is None
                 else lambda pct, msg, bucket_label=bucket_label: progress_callback(
@@ -1160,6 +1167,7 @@ def suggest_initial_with_claude(
                     f"{bucket_label}: {msg}" if msg else msg,
                 )
             ),
+            error_sink=error_sink,
             timeout=90,
         )
         if not bucket_clips:
@@ -1174,7 +1182,7 @@ def suggest_initial_with_claude(
     fallback_clips = suggest_with_claude(
         segments=segments,
         top_n=top_n,
-        exclude_clips=deduped,
+        exclude_clips=exclude_clips + deduped,
         progress_callback=(
             None if progress_callback is None
             else lambda pct, msg: progress_callback(
@@ -1182,6 +1190,7 @@ def suggest_initial_with_claude(
                 f"global pass: {msg}" if msg else msg,
             )
         ),
+        error_sink=error_sink,
         timeout=120,
     )
     if fallback_clips:

--- a/backend/services/clip_generator.py
+++ b/backend/services/clip_generator.py
@@ -638,10 +638,14 @@ def generate_clip(
         trim_opening = not (keep_segments and len(keep_segments) > 0)
 
     llm_start_second, llm_end_second = start_second, end_second
+    orig_keep_segments = None
     if keep_segments and len(keep_segments) > 0:
         llm_start_second = keep_segments[0]["start"]
         llm_end_second = keep_segments[-1]["end"]
-    llm_total = max(0.01, llm_end_second - llm_start_second)
+        orig_keep_segments = [dict(s) for s in keep_segments if s["end"] > s["start"]]
+        llm_total = max(0.01, sum(s["end"] - s["start"] for s in orig_keep_segments))
+    else:
+        llm_total = max(0.01, llm_end_second - llm_start_second)
 
     # Multi-segment cutting: if keep_segments provided, use those ranges.
     # Otherwise auto-detect silences/fillers and build tight segments.
@@ -710,10 +714,17 @@ def generate_clip(
             file=sys.stderr,
             flush=True,
         )
-        start_second = llm_start_second
-        end_second = llm_end_second
-        keep_segments = None
-        duration = end_second - start_second
+        if orig_keep_segments:
+            keep_segments = [dict(s) for s in orig_keep_segments]
+            keep_segments.sort(key=lambda s: s["start"])
+            start_second = keep_segments[0]["start"]
+            end_second = keep_segments[-1]["end"]
+            duration = sum(s["end"] - s["start"] for s in keep_segments)
+        elif (llm_end_second - llm_start_second) <= spec.dur_max:
+            start_second = llm_start_second
+            end_second = llm_end_second
+            keep_segments = None
+            duration = end_second - start_second
 
     length_warning = None
     if duration > spec.dur_max:

--- a/backend/services/thumbnail_ai.py
+++ b/backend/services/thumbnail_ai.py
@@ -43,6 +43,40 @@ def _load_brand_config() -> dict:
     return defaults
 
 
+def _normalize_roi(gray, target_width: int = 320):
+    import cv2
+    h, w = gray.shape[:2]
+    if w <= 0 or h <= 0:
+        return gray
+    if w == target_width:
+        return gray
+    scale = target_width / w
+    new_h = max(1, int(h * scale))
+    return cv2.resize(gray, (target_width, new_h), interpolation=cv2.INTER_AREA)
+
+
+def _tile_bounds_for_face(gray, face_cx: int) -> tuple[int, int]:
+    import cv2
+    import numpy as np
+    h, w = gray.shape[:2]
+    if w < 640 or h < 1:
+        return 0, w
+    gx = cv2.Sobel(gray, cv2.CV_64F, 1, 0, ksize=3)
+    seam_frac = np.mean(np.abs(gx) > 15, axis=0)
+    col_mean = np.mean(gray, axis=0)
+    col_max = np.max(gray, axis=0)
+    is_boundary = (seam_frac > 0.5) | ((col_mean <= 24) & (col_max <= 48))
+    bounds = [0]
+    for x in range(2, w - 2):
+        if is_boundary[x] and (not bounds or x - bounds[-1] > w * 0.15):
+            bounds.append(x)
+    bounds.append(w)
+    for i in range(len(bounds) - 1):
+        if bounds[i] <= face_cx < bounds[i + 1]:
+            return bounds[i], bounds[i + 1]
+    return 0, w
+
+
 def _frame_sharpness(frame, face_roi=None) -> float:
     """Laplacian variance — higher = sharper. Measures face region if provided."""
     import cv2
@@ -52,6 +86,7 @@ def _frame_sharpness(frame, face_roi=None) -> float:
     else:
         region = frame
     gray = cv2.cvtColor(region, cv2.COLOR_BGR2GRAY)
+    gray = _normalize_roi(gray)
     return cv2.Laplacian(gray, cv2.CV_64F).var()
 
 
@@ -67,9 +102,11 @@ def _face_expression_quality(frame, x1: int, y1: int, x2: int, y2: int) -> float
     region = frame[y1:y2, x1:x2]
     h, w = region.shape[:2]
     if h < 30 or w < 30:
-        return 0.3  # Too small to analyze properly
+        return 0.3
 
     gray = cv2.cvtColor(region, cv2.COLOR_BGR2GRAY)
+    gray = _normalize_roi(gray)
+    h, w = gray.shape[:2]
 
     # 1) Face angle — reject extreme tilt (looking down, sideways)
     #    A front-facing face has the brightest area (forehead) in the top third.
@@ -200,6 +237,9 @@ def extract_candidate_frames(
         end_t = min(duration, duration * 0.9)
     sample_count = max(count * 10, 40)
     candidates = []
+    best_rejected = None
+    expression_floor = 0.25
+    sharpness_floor = 12.0
 
     for i in range(sample_count):
         t = start_t + i * (end_t - start_t) / sample_count
@@ -230,44 +270,27 @@ def extract_candidate_frames(
             if not is_portrait and 0.4 * w < face_cx < 0.6 * w and fw < w * 0.15:
                 continue
 
-            # Sharpness of face region (proxy for eyes open, good expression)
-            sharpness = _frame_sharpness(frame, (x1, y1, x2, y2))
-
-            # Skip very blurry faces (motion blur, out of focus)
-            if sharpness < 12:
-                continue
-
-            # Face expression quality — filter blinking, open mouths
-            expression_quality = _face_expression_quality(frame, x1, y1, x2, y2)
-            if expression_quality < 0.45:
-                continue  # Bad expression (looking down, blinking, mouth open, etc.)
-
-            # Face size as fraction of frame
             face_area_pct = (fw * fh) / (w * h) * 100
+            sharpness = _frame_sharpness(frame, (x1, y1, x2, y2))
+            expression_quality = _face_expression_quality(frame, x1, y1, x2, y2)
 
-            # Score: confidence × sharpness × size_preference × expression
-            # Prefer faces that are 5-25% of frame area (natural portrait)
-            # Penalize extreme close-ups (>35%) and tiny faces (<3%)
+            mid_t = (start_t + end_t) / 2
+            span = max(0.1, end_t - start_t)
+            distance_from_mid = abs(t - mid_t) / (span / 2)
+            position_boost = 1.0 - 0.4 * min(1.0, distance_from_mid)
+
             if face_area_pct > 35:
-                size_factor = 0.4  # Too zoomed in
+                size_factor = 0.4
             elif face_area_pct > 25:
                 size_factor = 0.7
             elif face_area_pct < 3:
-                size_factor = 0.5  # Too small
+                size_factor = 0.5
             else:
-                size_factor = 1.0  # Sweet spot
-
-            # Prefer frames from the middle 60% of the clip — that's where
-            # the emotional peak usually is, and it avoids identical-looking
-            # boundary frames when consecutive clips share the same speaker.
-            mid_t = (start_t + end_t) / 2
-            span = max(0.1, end_t - start_t)
-            distance_from_mid = abs(t - mid_t) / (span / 2)  # 0 = center, 1 = edge
-            position_boost = 1.0 - 0.4 * min(1.0, distance_from_mid)
+                size_factor = 1.0
 
             score = (conf ** 2) * (sharpness ** 0.5) * size_factor * expression_quality * position_boost
 
-            candidates.append({
+            entry = {
                 "frame": frame.copy(),
                 "timestamp": round(t, 1),
                 "confidence": round(float(conf), 3),
@@ -277,9 +300,19 @@ def extract_candidate_frames(
                 "face_h_pct": round(fh / h * 100, 1),
                 "sharpness": round(sharpness, 1),
                 "score": score,
-            })
+            }
+
+            if sharpness < sharpness_floor or expression_quality < expression_floor:
+                if best_rejected is None or score > best_rejected["score"]:
+                    best_rejected = entry
+                continue
+
+            candidates.append(entry)
 
     cap.release()
+
+    if not candidates and best_rejected:
+        candidates.append(best_rejected)
 
     if not candidates:
         return []
@@ -375,15 +408,21 @@ def extract_candidate_frames(
             c["face_x_pct"] = round(face_cx * scale / target_w * 100, 1)
             c["face_y_pct"] = round((face_cy_scaled + y_offset) / target_h * 100, 1)
         else:
-            # Landscape source — crop to 9:16 centered on face
             crop_h = fh
             crop_w = int(crop_h * target_ratio)
             if crop_w > fw:
                 crop_w = fw
                 crop_h = int(crop_w / target_ratio)
 
+            gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            tile_left, tile_right = _tile_bounds_for_face(gray, face_cx)
+            tile_w = tile_right - tile_left
+            if tile_w < crop_w:
+                crop_w = tile_w
+                crop_h = int(crop_w / target_ratio)
+
             crop_x = face_cx - crop_w // 2
-            crop_x = max(0, min(crop_x, fw - crop_w))
+            crop_x = max(tile_left, min(crop_x, tile_right - crop_w))
 
             crop_y = face_cy - int(crop_h * 0.25)
             crop_y = max(0, min(crop_y, fh - crop_h))

--- a/backend/services/thumbnail_ai.py
+++ b/backend/services/thumbnail_ai.py
@@ -421,8 +421,16 @@ def extract_candidate_frames(
                 crop_w = tile_w
                 crop_h = int(crop_w / target_ratio)
 
+            min_crop_w = int(fw * 0.3)
+            if crop_w < min_crop_w:
+                crop_w = min(min_crop_w, fw)
+                crop_h = int(crop_w / target_ratio)
+
             crop_x = face_cx - crop_w // 2
-            crop_x = max(tile_left, min(crop_x, tile_right - crop_w))
+            if crop_w <= tile_w:
+                crop_x = max(tile_left, min(crop_x, tile_right - crop_w))
+            else:
+                crop_x = max(0, min(crop_x, fw - crop_w))
 
             crop_y = face_cy - int(crop_h * 0.25)
             crop_y = max(0, min(crop_y, fh - crop_h))

--- a/cli/internal/backend/embed.go
+++ b/cli/internal/backend/embed.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -22,11 +23,12 @@ var integrityFiles = []string{
 	"cli.py",
 	"services/clip_generator.py",
 	"services/claude_suggest.py",
+	"services/thumbnail_ai.py",
 	"main.py",
 }
 
 func embeddedDigest(rel string) (string, error) {
-	data, err := files.ReadFile(filepath.Join("files", filepath.ToSlash(rel)))
+	data, err := files.ReadFile(path.Join("files", filepath.ToSlash(rel)))
 	if err != nil {
 		return "", err
 	}

--- a/cli/internal/backend/embed.go
+++ b/cli/internal/backend/embed.go
@@ -5,7 +5,9 @@
 package backend
 
 import (
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -15,6 +17,56 @@ import (
 //go:generate sh sync.sh
 //go:embed all:files
 var files embed.FS
+
+var integrityFiles = []string{
+	"cli.py",
+	"services/clip_generator.py",
+	"services/claude_suggest.py",
+	"main.py",
+}
+
+func embeddedDigest(rel string) (string, error) {
+	data, err := files.ReadFile(filepath.Join("files", filepath.ToSlash(rel)))
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func fileDigest(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// ExtractedMatchesEmbedded reports whether dest holds the same bytes as the
+// launcher bundle for a relative backend path.
+func ExtractedMatchesEmbedded(dest, rel string) bool {
+	want, err := embeddedDigest(rel)
+	if err != nil {
+		return false
+	}
+	got, err := fileDigest(filepath.Join(dest, rel))
+	if err != nil {
+		return false
+	}
+	return want == got
+}
+
+// IntegrityMismatches lists embedded backend files that differ on disk.
+func IntegrityMismatches(dest string) []string {
+	var out []string
+	for _, rel := range integrityFiles {
+		if !ExtractedMatchesEmbedded(dest, rel) {
+			out = append(out, rel)
+		}
+	}
+	return out
+}
 
 // stampName matches the marker provision writes for the studio and Remotion
 // bundles, so every version-bound artifact under runtime/ is checked the same way.

--- a/cli/main.go
+++ b/cli/main.go
@@ -272,8 +272,13 @@ func setup(args []string) int {
 	// launcher rather than the one a previous release installed.
 	backendDir := filepath.Join(paths.RuntimeDir(), "backend")
 	if err := backend.Extract(backendDir, Version); err != nil {
-		fmt.Fprintf(os.Stderr, "  backend: skipped (%v) - falling back to repo/PODCLI_BACKEND\n", err)
-		backendDir, _ = engine.BackendRoot()
+		fmt.Fprintf(os.Stderr, "  backend: FAILED (%v)\n", err)
+		backendDir, ok := engine.BackendRoot()
+		if !ok {
+			fmt.Fprintln(os.Stderr, "podcli: setup: no backend available after extract failure")
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "  backend: using fallback %s (may be stale — run `podcli doctor`)\n", backendDir)
 	} else {
 		fmt.Printf("  backend: %s\n", backendDir)
 	}
@@ -606,13 +611,27 @@ func backendStamp(root string) string {
 	if root != filepath.Join(paths.RuntimeDir(), "backend") {
 		return "  (unmanaged - repo or PODCLI_BACKEND)"
 	}
-	switch v := backend.Version(root); v {
+	stamp := backend.Version(root)
+	switch stamp {
 	case Version:
+		if mismatches := backend.IntegrityMismatches(root); len(mismatches) > 0 {
+			return fmt.Sprintf(
+				"  (STALE: stamp %s matches launcher but files differ [%s] - run `podcli setup --refresh`)",
+				stamp,
+				strings.Join(mismatches, ", "),
+			)
+		}
 		return ""
 	case "":
+		if mismatches := backend.IntegrityMismatches(root); len(mismatches) > 0 {
+			return fmt.Sprintf(
+				"  (STALE: unstamped, files differ from launcher [%s] - run `podcli setup --refresh`)",
+				strings.Join(mismatches, ", "),
+			)
+		}
 		return "  (STALE: unstamped - run `podcli setup --refresh`)"
 	default:
-		return fmt.Sprintf("  (STALE: %s - run `podcli setup --refresh`)", v)
+		return fmt.Sprintf("  (STALE: stamped %s, launcher %s - run `podcli setup --refresh`)", stamp, Version)
 	}
 }
 
@@ -630,7 +649,12 @@ func doctor() {
 	}
 	fmt.Println("\nEngine resolution")
 	if root, ok := engine.BackendRoot(); ok {
+		stamp := backend.Version(root)
 		fmt.Printf("  backend:  %s%s\n", root, backendStamp(root))
+		if stamp != "" && stamp != Version {
+			fmt.Printf("  backend stamp: %s (launcher %s)\n", stamp, Version)
+		}
+		fmt.Printf("  note:     Python may report launcher version via PODCLI_VERSION; trust stamp + file hashes above\n")
 	} else {
 		fmt.Printf("  backend:  NOT FOUND (set PODCLI_BACKEND or run inside the repo)\n")
 	}

--- a/cli/main.go
+++ b/cli/main.go
@@ -273,11 +273,13 @@ func setup(args []string) int {
 	backendDir := filepath.Join(paths.RuntimeDir(), "backend")
 	if err := backend.Extract(backendDir, Version); err != nil {
 		fmt.Fprintf(os.Stderr, "  backend: FAILED (%v)\n", err)
-		backendDir, ok := engine.BackendRoot()
+		_ = os.RemoveAll(backendDir)
+		fallback, ok := engine.BackendRoot()
 		if !ok {
 			fmt.Fprintln(os.Stderr, "podcli: setup: no backend available after extract failure")
 			return 1
 		}
+		backendDir = fallback
 		fmt.Fprintf(os.Stderr, "  backend: using fallback %s (may be stale — run `podcli doctor`)\n", backendDir)
 	} else {
 		fmt.Printf("  backend: %s\n", backendDir)
@@ -654,7 +656,9 @@ func doctor() {
 		if stamp != "" && stamp != Version {
 			fmt.Printf("  backend stamp: %s (launcher %s)\n", stamp, Version)
 		}
-		fmt.Printf("  note:     Python may report launcher version via PODCLI_VERSION; trust stamp + file hashes above\n")
+		if root == filepath.Join(paths.RuntimeDir(), "backend") {
+			fmt.Printf("  note:     Python may report launcher version via PODCLI_VERSION; trust stamp + file hashes above\n")
+		}
 	} else {
 		fmt.Printf("  backend:  NOT FOUND (set PODCLI_BACKEND or run inside the repo)\n")
 	}

--- a/src/handlers/batch-clips.handler.ts
+++ b/src/handlers/batch-clips.handler.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "fs";
 import { PythonExecutor } from "../services/python-executor.js";
 import { FileManager } from "../services/file-manager.js";
+import { ClipsHistory } from "../services/clips-history.js";
 import { paths } from "../config/paths.js";
 import { childLogger } from "../utils/logger.js";
 import type {
@@ -14,6 +15,7 @@ import type {
 const log = childLogger("batch-clips");
 const executor = new PythonExecutor();
 const fileManager = new FileManager();
+const history = new ClipsHistory();
 
 /** Load UI state from disk. Returns null if unavailable. */
 function loadState(): UIState | null {
@@ -258,6 +260,22 @@ export async function handleBatchClips(input: BatchClipsInput): Promise<string> 
     throw new Error("Batch clip creation returned no data");
   }
   const data = result.data;
+
+  const recorded = await history.recordBatchResults(data.results, {
+    sourceVideo: videoPath,
+    transcriptWords: transcriptWords,
+    defaultCaptionStyle: settings.captionStyle || "hormozi",
+    defaultCropStrategy: settings.cropStrategy || "speaker",
+    defaultFormat: input.format || settings.format || "vertical",
+  });
+  await history.persistBatchRecipes(data.results, recorded, {
+    transcriptWords: transcriptWords,
+    clipSpecs: clips,
+    logoPath: settings.logoPath || null,
+    outroPath: settings.outroPath || null,
+    introPath: settings.introPath || null,
+    cleanFillers: input.clean_fillers !== false,
+  });
 
   return JSON.stringify({
     total_clips: data.total_clips,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -263,6 +263,7 @@ export interface ClipHistoryEntry {
   created_at: string;
   content_type?: string;
   transcript_slice?: string;
+  keep_segments?: Array<{ start: number; end: number }>;
   thumbnail_config?: ClipThumbnailConfig;
   youtube_video_id?: string;
   metrics?: ClipPerformanceMetrics;

--- a/src/server.ts
+++ b/src/server.ts
@@ -664,7 +664,7 @@ export function createServer(): McpServer {
           const parsed = JSON.parse(finalResult);
 
           // Record to history
-          await history.record({
+          const rec = await history.record({
             source_video: params.video_path as string,
             start_second: params.start_second as number,
             end_second: params.end_second as number,
@@ -678,6 +678,16 @@ export function createServer(): McpServer {
             duration: parsed.duration,
             content_type: parsed.content_type,
             transcript_slice: parsed.transcript_slice,
+          });
+          const uiStateForRecipe = await readUIState().catch(() => null);
+          const recipeSettings = uiStateForRecipe?.settings ?? {};
+          await history.persistClipRecipe(rec, {
+            transcriptWords: params.transcript_words as WordTimestamp[] | undefined,
+            logoPath: (params.logo_path as string) || recipeSettings.logoPath || null,
+            outroPath: (params.outro_path as string) || recipeSettings.outroPath || null,
+            introPath: recipeSettings.introPath || null,
+            cleanFillers: true,
+            keepSegments: keepSegments ?? undefined,
           });
 
           // Notify UI that export is done
@@ -898,16 +908,34 @@ export function createServer(): McpServer {
         }
 
         if (!usedWebServer) {
-          // Fallback: run directly without web server (no UI progress)
           await uiPing({ phase: "exporting" });
 
-          finalResult = await handleBatchClips(params);
+          const batchParams = {
+            ...params,
+            video_path: resolvedVideoPath || params.video_path,
+            clips: resolvedClips || params.clips,
+            transcript_words: resolvedTranscriptWords || params.transcript_words,
+          };
+          finalResult = await handleBatchClips(batchParams);
           const parsed = JSON.parse(finalResult) as BatchClipsResult;
+          const uiState = await readUIState().catch(() => null);
+          const settings = uiState?.settings ?? {};
 
-          // Record each successful clip
-          await history.recordBatchResults(parsed.results, {
-            sourceVideo: params.video_path || "",
-            transcriptWords: params.transcript_words as WordTimestamp[] | undefined,
+          const recorded = await history.recordBatchResults(parsed.results, {
+            sourceVideo: (batchParams.video_path as string) || "",
+            transcriptWords: batchParams.transcript_words as WordTimestamp[] | undefined,
+          });
+          await history.persistBatchRecipes(parsed.results, recorded, {
+            transcriptWords: batchParams.transcript_words as WordTimestamp[] | undefined,
+            clipSpecs: (batchParams.clips || []) as Array<{
+              start_second: number;
+              end_second: number;
+              keep_segments?: Array<{ start: number; end: number }>;
+            }>,
+            logoPath: settings.logoPath || null,
+            outroPath: settings.outroPath || null,
+            introPath: settings.introPath || null,
+            cleanFillers: true,
           });
 
           await uiPing({ phase: "done" });

--- a/src/services/clips-history.ts
+++ b/src/services/clips-history.ts
@@ -31,7 +31,6 @@ export interface BatchRecipeContext {
   introPath?: string | null;
   cleanFillers?: boolean;
   clipSpecs?: BatchClipSpec[];
-  defaultFormat?: Format;
 }
 
 export class ClipsHistory {

--- a/src/services/clips-history.ts
+++ b/src/services/clips-history.ts
@@ -3,7 +3,7 @@ import { existsSync } from "fs";
 import { basename, join } from "path";
 import { v4 as uuidv4 } from "uuid";
 import { paths } from "../config/paths.js";
-import { sliceTranscript } from "../utils/transcript.js";
+import { sliceTranscript, sliceWords } from "../utils/transcript.js";
 import { isDemoMode, demoClips } from "../ui/demo-fixtures.js";
 import type { BatchClipsResult, ClipHistoryEntry, Format, WordTimestamp } from "../models/index.js";
 
@@ -16,6 +16,22 @@ interface BatchRecordContext {
   defaultCropStrategy?: string;
   defaultFormat?: Format;
   contentTypeFor?: (start: number, end: number) => string | undefined;
+}
+
+export interface BatchClipSpec {
+  start_second: number;
+  end_second: number;
+  keep_segments?: Array<{ start: number; end: number }>;
+}
+
+export interface BatchRecipeContext {
+  transcriptWords?: WordTimestamp[] | null;
+  logoPath?: string | null;
+  outroPath?: string | null;
+  introPath?: string | null;
+  cleanFillers?: boolean;
+  clipSpecs?: BatchClipSpec[];
+  defaultFormat?: Format;
 }
 
 export class ClipsHistory {
@@ -113,6 +129,59 @@ export class ClipsHistory {
       );
     }
     return recorded;
+  }
+
+  async persistBatchRecipes(
+    rows: BatchResultRow[] | undefined,
+    recorded: ClipHistoryEntry[],
+    ctx: BatchRecipeContext,
+  ): Promise<void> {
+    if (!rows?.length || !recorded.length) return;
+    let recordedIdx = 0;
+    for (const row of rows) {
+      if (row.status !== "success" || !row.output_path) continue;
+      const rec = recorded[recordedIdx++];
+      if (!rec) continue;
+      const spec =
+        typeof row.clip_index === "number" ? ctx.clipSpecs?.[row.clip_index] : undefined;
+      await this.persistClipRecipe(rec, {
+        transcriptWords: ctx.transcriptWords,
+        logoPath: ctx.logoPath,
+        outroPath: ctx.outroPath,
+        introPath: ctx.introPath,
+        cleanFillers: ctx.cleanFillers,
+        keepSegments: spec?.keep_segments,
+      });
+    }
+  }
+
+  async persistClipRecipe(
+    rec: ClipHistoryEntry,
+    ctx: {
+      transcriptWords?: WordTimestamp[] | null;
+      logoPath?: string | null;
+      outroPath?: string | null;
+      introPath?: string | null;
+      cleanFillers?: boolean;
+      keepSegments?: Array<{ start: number; end: number }>;
+    },
+  ): Promise<void> {
+    const words = sliceWords(ctx.transcriptWords ?? [], rec.start_second, rec.end_second);
+    await this.saveWords(rec.id, words);
+    await this.saveRecipe(rec.id, {
+      caption_style: rec.caption_style,
+      crop_strategy: rec.crop_strategy,
+      format: rec.format || "vertical",
+      logo_path: ctx.logoPath ?? rec.logo_path ?? null,
+      outro_path: ctx.outroPath ?? rec.outro_path ?? null,
+      intro_path: ctx.introPath ?? rec.intro_path ?? null,
+      clean_fillers: ctx.cleanFillers ?? false,
+      transcript_words: words,
+      ...(ctx.keepSegments?.length && { keep_segments: ctx.keepSegments }),
+    });
+    if (ctx.keepSegments?.length) {
+      await this.update(rec.id, { keep_segments: ctx.keepSegments });
+    }
   }
 
   /**

--- a/src/ui/client/ClipDetail.tsx
+++ b/src/ui/client/ClipDetail.tsx
@@ -106,7 +106,7 @@ export default function ClipDetail() {
   };
 
   const loadOptions = async () => {
-    setBusy("options"); setMsg(null);
+    setBusy("options"); setMsg(null); setMsgErr(false);
     try {
       const r = await api(`/clips/${clip.id}/thumbnail/options?texts=6&frames=6`);
       if (r.error) throw new Error(r.error);
@@ -119,7 +119,7 @@ export default function ClipDetail() {
   };
 
   const uploadFrame = async (f: File) => {
-    setBusy("upload"); setMsg(null);
+    setBusy("upload"); setMsg(null); setMsgErr(false);
     try {
       const fd = new FormData(); fd.append("file", f);
       const r = await upload<any>("/upload", fd);
@@ -145,7 +145,7 @@ export default function ClipDetail() {
   // Pull a different frame from the clip (cycles the ranked candidates) and
   // re-render — same one-click flow as Regenerate, but swaps the background frame.
   const newFrame = async () => {
-    setBusy("newframe"); setMsg(null);
+    setBusy("newframe"); setMsg(null); setMsgErr(false);
     try {
       let frames = frameOpts;
       if (!frames.length) {
@@ -405,7 +405,7 @@ export default function ClipDetail() {
           end={clip.end_second}
           caption_style={clip.caption_style}
           onClose={() => setReframing(false)}
-          onDone={() => { setReframing(false); setBust(Date.now()); setMsg("Reframed & re-rendered"); load(); }}
+          onDone={() => { setReframing(false); setBust(Date.now()); setMsg("Reframed & re-rendered"); setMsgErr(false); load(); }}
         />
       )}
     </div>

--- a/src/ui/client/ClipDetail.tsx
+++ b/src/ui/client/ClipDetail.tsx
@@ -172,25 +172,25 @@ export default function ClipDetail() {
   };
 
   const reopen = async () => {
-    setBusy("reopen"); setMsg(null);
+    setBusy("reopen"); setMsg(null); setMsgErr(false);
     try {
       const r = await api(`/clips/${clip.id}/reopen`, { method: "POST", body: "{}" });
       if (r.error) throw new Error(r.error);
       navigate("/episode");
-    } catch (e: any) { setMsg(`Reopen failed: ${e.message}`); setBusy(null); }
+    } catch (e: any) { setMsg(`Reopen failed: ${e.message}`); setMsgErr(true); setBusy(null); }
   };
 
   const exportDavinci = async () => {
-    setBusy("davinci"); setMsg(null);
+    setBusy("davinci"); setMsg(null); setMsgErr(false);
     try {
       const r = await api(`/clips/${clip.id}/davinci`, { method: "POST", body: "{}" });
       if (r.error) throw new Error(r.error);
-      setMsg(r.path ? `DaVinci project: ${r.path}` : "Exported");
-    } catch (e: any) { setMsg(`DaVinci export failed: ${e.message}`); } finally { setBusy(null); }
+      setMsg(r.path ? `DaVinci project: ${r.path}` : "Exported"); setMsgErr(false);
+    } catch (e: any) { setMsg(`DaVinci export failed: ${e.message}`); setMsgErr(true); } finally { setBusy(null); }
   };
 
   const generateContent = async () => {
-    setBusy("content"); setMsg(null);
+    setBusy("content"); setMsg(null); setMsgErr(false);
     try {
       const body = {
         clip: {
@@ -206,16 +206,16 @@ export default function ClipDetail() {
       if (r.error) throw new Error(r.error);
       if (!r.titles?.length && !r.description) throw new Error("AI CLI returned nothing. Is claude/codex installed?");
       load();
-    } catch (e: any) { setMsg(`Content generation failed: ${e.message}`); } finally { setBusy(null); }
+    } catch (e: any) { setMsg(`Content generation failed: ${e.message}`); setMsgErr(true); } finally { setBusy(null); }
   };
 
   const del = async () => {
     if (!window.confirm(`Delete "${clip.title}"? This removes the rendered file too.`)) return;
-    setBusy("delete"); setMsg(null);
+    setBusy("delete"); setMsg(null); setMsgErr(false);
     try {
       await api(`/clips/${clip.id}`, { method: "DELETE" });
       navigate("/");
-    } catch (e: any) { setMsg(`Delete failed: ${e.message}`); setBusy(null); }
+    } catch (e: any) { setMsg(`Delete failed: ${e.message}`); setMsgErr(true); setBusy(null); }
   };
 
   return (
@@ -350,7 +350,7 @@ export default function ClipDetail() {
                       {clip.generated_titles.map((t, i) => {
                         const clean = t.replace(/^\d+\.\s*/, "");
                         return (
-                          <button key={i} className={`title-option ${title === clean ? "selected" : ""}`} onClick={() => { setTitle(clean); setMsg("Title set. Click save to apply"); }}>
+                          <button key={i} className={`title-option ${title === clean ? "selected" : ""}`} onClick={() => { setTitle(clean); setMsg("Title set. Click save to apply"); setMsgErr(false); }}>
                             {t}
                           </button>
                         );

--- a/src/ui/client/ClipDetail.tsx
+++ b/src/ui/client/ClipDetail.tsx
@@ -59,6 +59,7 @@ export default function ClipDetail() {
   const [selFrame, setSelFrame] = useState<{ path: string; info?: any } | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [msg, setMsg] = useState<string | null>(null);
+  const [msgErr, setMsgErr] = useState(false);
   const [bust, setBust] = useState(1);
   const [davinciOn, setDavinciOn] = useState(false);
   const [reframing, setReframing] = useState(false);
@@ -96,12 +97,12 @@ export default function ClipDetail() {
   const patch = (body: any) => api(`/clips/${clip.id}`, { method: "PATCH", body: JSON.stringify(body) });
 
   const save = async () => {
-    setBusy("save"); setMsg(null);
+    setBusy("save"); setMsg(null); setMsgErr(false);
     try {
       const r = await patch({ title, caption_style: captionStyle });
       if (r.error) throw new Error(r.error);
       load();
-    } catch (e: any) { setMsg(`Save failed: ${e.message}`); } finally { setBusy(null); }
+    } catch (e: any) { setMsg(`Save failed: ${e.message}`); setMsgErr(true); } finally { setBusy(null); }
   };
 
   const loadOptions = async () => {
@@ -112,8 +113,9 @@ export default function ClipDetail() {
       setTextOpts(r.texts || []);
       setFrameOpts(r.frames || []);
       if ((r.frames || []).length) setSelFrame({ path: r.frames[0].path, info: r.frames[0] });
-      if (!(r.texts || []).length && !(r.frames || []).length) setMsg("No options. Is the AI CLI installed and the source video available?");
-    } catch (e: any) { setMsg(`Options failed: ${e.message}`); } finally { setBusy(null); }
+      if (!(r.texts || []).length && !(r.frames || []).length) { setMsg("No options. Is the AI CLI installed and the source video available?"); setMsgErr(true); }
+      else if (r.warning) { setMsg(r.warning); setMsgErr(true); }
+    } catch (e: any) { setMsg(`Options failed: ${e.message}`); setMsgErr(true); } finally { setBusy(null); }
   };
 
   const uploadFrame = async (f: File) => {
@@ -123,12 +125,12 @@ export default function ClipDetail() {
       const r = await upload<any>("/upload", fd);
       if (!r.file_path) throw new Error("upload failed");
       setSelFrame({ path: r.file_path });
-    } catch (e: any) { setMsg(`Upload failed: ${e.message}`); } finally { setBusy(null); }
+    } catch (e: any) { setMsg(`Upload failed: ${e.message}`); setMsgErr(true); } finally { setBusy(null); }
   };
 
   const renderThumb = async () => {
-    if (!selFrame) { setMsg("Select or upload a frame first"); return; }
-    setBusy("render"); setMsg(null);
+    if (!selFrame) { setMsg("Select or upload a frame first"); setMsgErr(true); return; }
+    setBusy("render"); setMsg(null); setMsgErr(false);
     try {
       const r = await api(`/clips/${clip.id}/thumbnail/render`, {
         method: "POST",
@@ -136,8 +138,8 @@ export default function ClipDetail() {
       });
       if (r.error) throw new Error(r.error);
       setBust(Date.now()); load();
-      setMsg("Thumbnail generated");
-    } catch (e: any) { setMsg(`Generate failed: ${e.message}`); } finally { setBusy(null); }
+      setMsg("Thumbnail generated"); setMsgErr(false);
+    } catch (e: any) { setMsg(`Generate failed: ${e.message}`); setMsgErr(true); } finally { setBusy(null); }
   };
 
   // Pull a different frame from the clip (cycles the ranked candidates) and
@@ -153,7 +155,7 @@ export default function ClipDetail() {
         setFrameOpts(frames);
         if ((r.texts || []).length) setTextOpts(r.texts);
       }
-      if (!frames.length) { setMsg("No frames found in this clip"); return; }
+      if (!frames.length) { setMsg("No frames found in this clip"); setMsgErr(true); return; }
       const curIdx = frames.findIndex((f: any) => f.path === selFrame?.path);
       const next = ((curIdx < 0 ? frameIdx : curIdx) + 1) % frames.length;
       setFrameIdx(next);
@@ -165,8 +167,8 @@ export default function ClipDetail() {
       });
       if (r.error) throw new Error(r.error);
       setBust(Date.now()); load();
-      setMsg(`New frame from clip (${next + 1}/${frames.length})`);
-    } catch (e: any) { setMsg(`New frame failed: ${e.message}`); } finally { setBusy(null); }
+      setMsg(`New frame from clip (${next + 1}/${frames.length})`); setMsgErr(false);
+    } catch (e: any) { setMsg(`New frame failed: ${e.message}`); setMsgErr(true); } finally { setBusy(null); }
   };
 
   const reopen = async () => {
@@ -243,7 +245,7 @@ export default function ClipDetail() {
         </div>
 
         <div className="clip-detail-editor">
-          {msg && <div className="set-note ok" style={{ wordBreak: "break-all" }}>{msg}</div>}
+          {msg && <div className={`set-note ${msgErr ? "err" : "ok"}`} style={{ wordBreak: "break-all" }}>{msg}</div>}
 
           <div className="section">
             <label style={labelStyle}>Title & captions</label>

--- a/src/ui/client/EpisodeWorkspace.jsx
+++ b/src/ui/client/EpisodeWorkspace.jsx
@@ -677,7 +677,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
         if (editingClip === null) return;
         setSuggestions(prev => {
           const next = [...prev];
-          next[editingClip] = { ...next[editingClip], title: editForm.title, start_second: editForm.start, end_second: editForm.end, duration: Math.round(editForm.end - editForm.start) };
+          next[editingClip] = { ...next[editingClip], title: editForm.title, start_second: editForm.start, end_second: editForm.end, duration: Math.round(editForm.end - editForm.start), segments: undefined };
           return next;
         });
         setEditingClip(null);
@@ -1020,6 +1020,16 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
         }
       };
 
+      const clipExportPayload = (c) => ({
+        start_second: c.start_second,
+        end_second: c.end_second,
+        title: c.title,
+        caption_style: captionStyle,
+        crop_strategy: cropStrategy,
+        format,
+        ...(Array.isArray(c.segments) && c.segments.length > 0 && { keep_segments: c.segments }),
+      });
+
       const startExport = async () => {
         setPhase('exporting'); setResults([]);
         const sc = suggestions.filter((_, i) => !deselected.has(i));
@@ -1027,7 +1037,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
         const data = await api('/batch-clips', {
           method: 'POST', body: JSON.stringify({
             video_path: vp,
-            clips: sc.map(c => ({ start_second: c.start_second, end_second: c.end_second, title: c.title, caption_style: captionStyle, crop_strategy: cropStrategy, format })),
+            clips: sc.map(clipExportPayload),
             transcript_words: transcript?.words || [], logo_path: logoPath || undefined, outro_path: outroPath || undefined, intro_path: introPath || undefined, clean_fillers: cleanFillers || undefined,
           })
         });
@@ -1048,6 +1058,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
             video_path: vp, start_second: c.start_second, end_second: c.end_second,
             title: c.title, caption_style: captionStyle, crop_strategy: cropStrategy, format,
             transcript_words: transcript?.words || [], logo_path: logoPath || undefined, outro_path: outroPath || undefined, intro_path: introPath || undefined, clean_fillers: cleanFillers || undefined,
+            ...(Array.isArray(c.segments) && c.segments.length > 0 && { keep_segments: c.segments }),
           })
         });
         setRetryJobId(data.job_id);
@@ -1145,6 +1156,12 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
           });
           const data = await res.json();
 
+          if (!res.ok) {
+            setPhase('idle');
+            setError(data.error || 'Suggestion failed');
+            return;
+          }
+
           if (data.clips && data.clips.length > 0) {
             // Claude returned suggestions — populate directly
             const mapped = data.clips.map((c, i) => ({
@@ -1153,7 +1170,8 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
               start_second: c.start_second,
               end_second: c.end_second,
               reasoning: c.reasoning || c.content_type || '',
-              duration: Math.round((c.end_second || 0) - (c.start_second || 0)),
+              segments: c.segments,
+              duration: c.duration ?? Math.round((c.end_second || 0) - (c.start_second || 0)),
             }));
             setSuggestions(mapped);
             setEnergyData({});
@@ -1191,6 +1209,11 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       const isProcessing = phase === 'parsing' || phase === 'suggesting' || phase === 'exporting' || transcribing || downloadingVideo;
       const sourceIsUrl = isHttpUrl(videoPath);
       const selectedClips = suggestions.filter((_, i) => !deselected.has(i));
+      const exportStats = phase === 'done' ? {
+        total: selectedClips.length,
+        ok: results.filter(r => r?.status === 'success').length,
+        failed: results.filter(r => r?.status === 'error').length,
+      } : null;
 
       const getExportStatus = (resultIdx) => {
         if (phase !== 'exporting' || !batchStream) return null;
@@ -1755,6 +1778,16 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
                       </div>
                     );
                   })}
+
+                  {phase === 'done' && exportStats && (exportStats.failed > 0 || exportStats.ok < exportStats.total) && (
+                    <div className={`set-note ${exportStats.ok === 0 ? 'err' : ''}`} style={{ marginTop: 14, background: exportStats.ok === 0 ? undefined : 'var(--amber-subtle, rgba(251,191,36,0.1))', color: exportStats.ok === 0 ? undefined : 'var(--amber, #f59e0b)', border: exportStats.ok === 0 ? undefined : '1px solid rgba(251,191,36,0.25)' }}>
+                      {exportStats.ok} of {exportStats.total} clip{exportStats.total !== 1 ? 's' : ''} exported
+                      {exportStats.failed > 0 && ` — ${exportStats.failed} failed`}
+                      {exportStats.failed > 0 && results.filter(r => r?.status === 'error').slice(0, 3).map((r, i) => (
+                        <span key={i} style={{ display: 'block', marginTop: 4, fontSize: 11, opacity: 0.9 }}>{r.error?.slice(0, 120)}</span>
+                      ))}
+                    </div>
+                  )}
 
                   {phase === 'exporting' && batchStream && (
                     <div style={{ marginTop: 14 }}>

--- a/src/ui/client/ThumbnailStudio.tsx
+++ b/src/ui/client/ThumbnailStudio.tsx
@@ -21,6 +21,7 @@ export default function ThumbnailStudio() {
   const [preview, setPreview] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [msg, setMsg] = useState<string | null>(null);
+  const [msgErr, setMsgErr] = useState(false);
   const [bust, setBust] = useState(1);
   const [editingTemplate, setEditingTemplate] = useState(false);
 
@@ -56,8 +57,8 @@ export default function ThumbnailStudio() {
   };
 
   const loadOptions = async () => {
-    if (!title.trim()) { setMsg("Enter a title first, headlines are written from it"); return; }
-    setBusy("options"); setMsg(null);
+    if (!title.trim()) { setMsg("Enter a title first, headlines are written from it"); setMsgErr(true); return; }
+    setBusy("options"); setMsg(null); setMsgErr(false);
     try {
       const r = await api("/thumbnail-studio/options", {
         method: "POST",
@@ -72,8 +73,9 @@ export default function ThumbnailStudio() {
       setFrameOpts(r.frames || []);
       setBust(Date.now());
       if ((r.frames || []).length) setSelFrame({ path: r.frames[0].path, info: r.frames[0] });
-      if (!(r.texts || []).length && !(r.frames || []).length) setMsg("No options. Is the AI CLI installed? Pick a video for frame options.");
-    } catch (e: any) { setMsg(`Options failed: ${e.message}`); } finally { setBusy(null); }
+      if (!(r.texts || []).length && !(r.frames || []).length) { setMsg("No options. Is the AI CLI installed? Pick a video for frame options."); setMsgErr(true); }
+      else if (r.warning) { setMsg(r.warning); setMsgErr(true); }
+    } catch (e: any) { setMsg(`Options failed: ${e.message}`); setMsgErr(true); } finally { setBusy(null); }
   };
 
   const render = async () => {
@@ -118,7 +120,7 @@ export default function ThumbnailStudio() {
         setFrameOpts(frames);
         if ((r.texts || []).length) setTextOpts(r.texts);
       }
-      if (!frames.length) { setMsg("No frames found. Pick a video source first."); return; }
+      if (!frames.length) { setMsg("No frames found. Pick a video source first."); setMsgErr(true); return; }
       const curIdx = frames.findIndex((f: any) => f.path === selFrame?.path);
       const next = ((curIdx < 0 ? frameIdx : curIdx) + 1) % frames.length;
       setFrameIdx(next);
@@ -170,7 +172,7 @@ export default function ThumbnailStudio() {
         </div>
       </div>
 
-      {msg && <div className="set-note ok" style={{ wordBreak: "break-word" }}>{msg}</div>}
+      {msg && <div className={`set-note ${msgErr ? "err" : "ok"}`} style={{ wordBreak: "break-word" }}>{msg}</div>}
 
       <div className="section">
         <label style={labelStyle}>Thumbnail</label>

--- a/src/ui/client/ThumbnailStudio.tsx
+++ b/src/ui/client/ThumbnailStudio.tsx
@@ -79,8 +79,8 @@ export default function ThumbnailStudio() {
   };
 
   const render = async () => {
-    if (!selFrame) { setMsg("Select a frame or upload an image first"); return; }
-    setBusy("render"); setMsg(null);
+    if (!selFrame) { setMsg("Select a frame or upload an image first"); setMsgErr(true); return; }
+    setBusy("render"); setMsg(null); setMsgErr(false);
     try {
       const r = await api("/thumbnail-studio/render", {
         method: "POST",
@@ -95,18 +95,18 @@ export default function ThumbnailStudio() {
       if (!r.path) throw new Error("no thumbnail produced");
       setPreview(r.path);
       setBust(Date.now());
-      setMsg("Thumbnail generated");
-    } catch (e: any) { setMsg(`Generate failed: ${e.message}`); } finally { setBusy(null); }
+      setMsg("Thumbnail generated"); setMsgErr(false);
+    } catch (e: any) { setMsg(`Generate failed: ${e.message}`); setMsgErr(true); } finally { setBusy(null); }
   };
 
   // Pull a different frame from the source (cycles the ranked candidates) and
   // re-render — same one-click flow as Regenerate, but swaps the background frame.
   const newFrame = async () => {
-    setBusy("newframe"); setMsg(null);
+    setBusy("newframe"); setMsg(null); setMsgErr(false);
     try {
       let frames = frameOpts;
       if (!frames.length) {
-        if (!title.trim()) { setMsg("Enter a title first, headlines are written from it"); return; }
+        if (!title.trim()) { setMsg("Enter a title first, headlines are written from it"); setMsgErr(true); return; }
         const r = await api("/thumbnail-studio/options", {
           method: "POST",
           body: JSON.stringify({
@@ -133,8 +133,8 @@ export default function ThumbnailStudio() {
       if (!r.path) throw new Error("no thumbnail produced");
       setPreview(r.path);
       setBust(Date.now());
-      setMsg(`New frame from source (${next + 1}/${frames.length})`);
-    } catch (e: any) { setMsg(`New frame failed: ${e.message}`); } finally { setBusy(null); }
+      setMsg(`New frame from source (${next + 1}/${frames.length})`); setMsgErr(false);
+    } catch (e: any) { setMsg(`New frame failed: ${e.message}`); setMsgErr(true); } finally { setBusy(null); }
   };
 
   return (

--- a/src/ui/client/ThumbnailStudio.tsx
+++ b/src/ui/client/ThumbnailStudio.tsx
@@ -30,17 +30,17 @@ export default function ThumbnailStudio() {
   }
 
   const browse = async () => {
-    setBusy("browse"); setMsg(null);
+    setBusy("browse"); setMsg(null); setMsgErr(false);
     try {
       const r = await api("/browse-file");
       if (r.file_path) setVideo({ path: r.file_path, name: r.filename || basename(r.file_path) });
     } catch (e: any) {
-      if (e.message !== "cancelled") setMsg(`Browse failed: ${e.message}`);
+      if (e.message !== "cancelled") { setMsg(`Browse failed: ${e.message}`); setMsgErr(true); }
     } finally { setBusy(null); }
   };
 
   const uploadFile = async (f: File) => {
-    setBusy("upload"); setMsg(null);
+    setBusy("upload"); setMsg(null); setMsgErr(false);
     try {
       const fd = new FormData();
       fd.append("file", f);
@@ -49,11 +49,11 @@ export default function ThumbnailStudio() {
       if (isImage(f.name)) {
         setSelFrame({ path: r.file_path });
         setPreview(null);
-        setMsg("Image set as the thumbnail background");
+        setMsg("Image set as the thumbnail background"); setMsgErr(false);
       } else {
         setVideo({ path: r.file_path, name: f.name });
       }
-    } catch (e: any) { setMsg(`Upload failed: ${e.message}`); } finally { setBusy(null); }
+    } catch (e: any) { setMsg(`Upload failed: ${e.message}`); setMsgErr(true); } finally { setBusy(null); }
   };
 
   const loadOptions = async () => {

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -40,7 +40,7 @@ import { paths, pythonEnv } from "../config/paths.js";
 import { DEMO_ASSETS_DIR } from "./demo-fixtures.js";
 import { registerConfigIntegrationRoutes } from "../handlers/integrations.routes.js";
 import { childLogger } from "../utils/logger.js";
-import { sliceTranscript, sliceWords, findContentType } from "../utils/transcript.js";
+import { sliceTranscript, sliceWords, findContentType, findSuggestionSegments } from "../utils/transcript.js";
 import { errMsg } from "../utils/errors.js";
 import type {
   AssetType,
@@ -303,6 +303,14 @@ function setExportState(phase: string, activeExportJobId: string | null) {
   persistState();
 }
 
+function enrichClipWithSegments<T extends { start_second: number; end_second: number; keep_segments?: Array<{ start: number; end: number }> }>(
+  clip: T,
+): T {
+  if (clip.keep_segments?.length) return clip;
+  const segments = findSuggestionSegments(uiState.suggestions, clip.start_second, clip.end_second);
+  return segments?.length ? { ...clip, keep_segments: segments } : clip;
+}
+
 function createBatchHistoryRecorder({
   jobId,
   sourceVideo,
@@ -311,6 +319,11 @@ function createBatchHistoryRecorder({
   defaultCropStrategy,
   defaultFormat,
   label,
+  clipSpecs,
+  logoPath,
+  outroPath,
+  introPath,
+  cleanFillers,
 }: {
   jobId: string;
   sourceVideo: string;
@@ -319,6 +332,18 @@ function createBatchHistoryRecorder({
   defaultCropStrategy?: string;
   defaultFormat?: Format;
   label: string;
+  clipSpecs?: Array<{
+    start_second: number;
+    end_second: number;
+    caption_style?: string;
+    crop_strategy?: string;
+    format?: Format;
+    keep_segments?: Array<{ start: number; end: number }>;
+  }>;
+  logoPath?: string | null;
+  outroPath?: string | null;
+  introPath?: string | null;
+  cleanFillers?: boolean;
 }) {
   const recordedClipIndexes = new Set<number>();
   const pendingWrites: Promise<void>[] = [];
@@ -332,6 +357,26 @@ function createBatchHistoryRecorder({
       defaultFormat,
       contentTypeFor: (s, e) => findContentType(uiState.suggestions, s, e),
     });
+    let recordedIdx = 0;
+    for (const row of rows) {
+      if (row.status !== "success" || !row.output_path) continue;
+      const rec = recorded[recordedIdx++];
+      if (!rec) continue;
+      const spec =
+        typeof row.clip_index === "number" ? clipSpecs?.[row.clip_index] : undefined;
+      try {
+        await clipsHistory.persistClipRecipe(rec, {
+          transcriptWords,
+          logoPath,
+          outroPath,
+          introPath,
+          cleanFillers,
+          keepSegments: spec?.keep_segments,
+        });
+      } catch (err) {
+        log.warn(`Failed to save recipe for ${label} clip`, { err: errMsg(err) });
+      }
+    }
     for (const row of rows) {
       if (row.status === "success" && row.output_path && typeof row.clip_index === "number") {
         recordedClipIndexes.add(row.clip_index);
@@ -973,6 +1018,7 @@ app.post("/api/create-clip", async (req, res) => {
     clean_fillers = false,
     allow_ass_fallback = false,
     content_type = null,
+    keep_segments,
   } = req.body;
 
   if (!video_path || !existsSync(video_path)) {
@@ -1041,6 +1087,12 @@ app.post("/api/create-clip", async (req, res) => {
 
   await fileManager.ensureDirectories();
 
+  const enriched = enrichClipWithSegments({
+    start_second,
+    end_second,
+    keep_segments: Array.isArray(keep_segments) ? keep_segments : undefined,
+  });
+
   const jobId = uuidv4();
   const job: JobState = {
     id: jobId,
@@ -1059,8 +1111,8 @@ app.post("/api/create-clip", async (req, res) => {
       "create_clip",
       {
         video_path,
-        start_second,
-        end_second,
+        start_second: enriched.start_second,
+        end_second: enriched.end_second,
         caption_style,
         crop_strategy,
         format,
@@ -1072,6 +1124,7 @@ app.post("/api/create-clip", async (req, res) => {
         intro_path,
         clean_fillers,
         allow_ass_fallback,
+        ...(enriched.keep_segments?.length && { keep_segments: enriched.keep_segments }),
       },
       (event) => {
         job.progress = event.percent;
@@ -1103,11 +1156,13 @@ app.post("/api/create-clip", async (req, res) => {
           content_type: content_type || undefined,
           transcript_slice: sliceTranscript(transcript_words, start_second, end_second),
         });
-        const clipWords = sliceWords(transcript_words, start_second, end_second);
-        await clipsHistory.saveWords(rec.id, clipWords);
-        await clipsHistory.saveRecipe(rec.id, {
-          caption_style, crop_strategy, format, logo_path: logo_path || null, outro_path: outro_path || null,
-          intro_path: intro_path || null, clean_fillers, transcript_words: clipWords,
+        await clipsHistory.persistClipRecipe(rec, {
+          transcriptWords: transcript_words,
+          logoPath: logo_path,
+          outroPath: outro_path,
+          introPath: intro_path,
+          cleanFillers: clean_fillers,
+          keepSegments: enriched.keep_segments,
         });
         broadcastHistoryUpdated(jobId, [rec]);
       } catch (err) {
@@ -1184,6 +1239,10 @@ app.post("/api/batch-clips", async (req, res) => {
 
   await fileManager.ensureDirectories();
 
+  const enrichedClips = clips.map((c: { start_second: number; end_second: number; keep_segments?: Array<{ start: number; end: number }> }) =>
+    enrichClipWithSegments(c),
+  );
+
   const jobId = uuidv4();
   const job: JobState = {
     id: jobId,
@@ -1200,6 +1259,11 @@ app.post("/api/batch-clips", async (req, res) => {
     sourceVideo: video_path,
     transcriptWords: transcript_words,
     label: "batch",
+    clipSpecs: enrichedClips,
+    logoPath: logo_path,
+    outroPath: outro_path,
+    introPath: intro_path,
+    cleanFillers: clean_fillers,
   });
 
   broadcastSSE("export-started", { jobId, clipCount: clips.length });
@@ -1212,7 +1276,7 @@ app.post("/api/batch-clips", async (req, res) => {
       "batch_clips",
       {
         video_path,
-        clips,
+        clips: enrichedClips,
         transcript_words,
         output_dir: paths.output,
         logo_path,
@@ -2045,7 +2109,13 @@ app.get("/api/clips/:id/thumbnail/options", async (req, res) => {
   ]);
   if (r.code !== 0) { res.status(400).json({ error: stripAnsi(r.stderr || r.stdout) || "options failed" }); return; }
   const jsonLine = r.stdout.trim().split("\n").reverse().find((l) => l.trim().startsWith("{"));
-  try { res.json(JSON.parse(jsonLine || "{}")); } catch { res.status(500).json({ error: "bad options output" }); }
+  try {
+    const parsed = JSON.parse(jsonLine || "{}");
+    if (!parsed.frames?.length && (parsed.texts?.length || 0) > 0) {
+      parsed.warning = "No suitable frames found in this clip — try another moment or upload a frame.";
+    }
+    res.json(parsed);
+  } catch { res.status(500).json({ error: "bad options output" }); }
 });
 
 // Render one final thumbnail from a chosen frame + headline (empty lines = AI writes the text).
@@ -2125,7 +2195,13 @@ app.post("/api/thumbnail-studio/options", async (req, res) => {
   const r = await runCli(args);
   if (r.code !== 0) { res.status(400).json({ error: stripAnsi(r.stderr || r.stdout) || "options failed" }); return; }
   const jsonLine = r.stdout.trim().split("\n").reverse().find((l) => l.trim().startsWith("{"));
-  try { res.json(JSON.parse(jsonLine || "{}")); } catch { res.status(500).json({ error: "bad options output" }); }
+  try {
+    const parsed = JSON.parse(jsonLine || "{}");
+    if (!parsed.frames?.length && (parsed.texts?.length || 0) > 0) {
+      parsed.warning = "No suitable frames found — try another moment or upload a frame.";
+    }
+    res.json(parsed);
+  } catch { res.status(500).json({ error: "bad options output" }); }
 });
 
 app.post("/api/thumbnail-studio/render", async (req, res) => {
@@ -2882,15 +2958,19 @@ app.post("/api/claude-suggest", async (req, res) => {
         score: c.score,
         suggested_caption_style: c.suggested_caption_style || "hormozi",
       }));
-      // Deselection is positional; replacing the list invalidates old indices.
       uiState.deselectedIndices = [];
       uiState.phase = "review";
+      broadcastSSE("state-sync", uiState);
+    } else {
+      uiState.phase = "idle";
       broadcastSSE("state-sync", uiState);
     }
 
     res.json({ clips, source: "python" });
   } catch (err: unknown) {
     const msg = errMsg(err);
+    uiState.phase = "idle";
+    broadcastSSE("state-sync", uiState);
     res
       .status(500)
       .json({ error: `Suggestion failed: ${msg.substring(0, 200)}` });
@@ -3203,7 +3283,24 @@ app.post("/api/ui-state", (req, res) => {
   if (body.transcript !== undefined) uiState.transcript = body.transcript;
   if (body.rawTranscriptText !== undefined)
     uiState.rawTranscriptText = body.rawTranscriptText;
-  if (body.suggestions !== undefined) uiState.suggestions = body.suggestions;
+  if (body.suggestions !== undefined) {
+    if (body._source === "ui" && Array.isArray(body.suggestions)) {
+      uiState.suggestions = body.suggestions.map((incoming: SuggestedClip, i: number) => {
+        const existing = uiState.suggestions[i];
+        if (
+          existing?.segments?.length &&
+          !incoming.segments?.length &&
+          Math.abs(existing.start_second - incoming.start_second) < 0.5 &&
+          Math.abs(existing.end_second - incoming.end_second) < 0.5
+        ) {
+          return { ...incoming, segments: existing.segments, duration: existing.duration ?? incoming.duration };
+        }
+        return incoming;
+      });
+    } else {
+      uiState.suggestions = body.suggestions;
+    }
+  }
   if (body.deselectedIndices !== undefined)
     uiState.deselectedIndices = body.deselectedIndices;
   if (body.phase !== undefined) uiState.phase = body.phase;
@@ -3284,18 +3381,18 @@ app.post("/api/mcp/export", async (req, res) => {
   await fileManager.ensureDirectories();
 
   // Apply style settings to clips that don't have their own
-  const styledClips = clips.map((c: any) => ({
-    start_second: c.start_second,
-    end_second: c.end_second,
-    title: c.title || "clip",
-    caption_style: c.caption_style || captionStyle,
-    crop_strategy: c.crop_strategy || cropStrategy,
-    format: c.format || format,
-    allow_ass_fallback: c.allow_ass_fallback === true || allowAssFallback,
-    // Preserve multi-cut segments from suggestions
-    ...(Array.isArray(c.segments) &&
-      c.segments.length > 0 && { keep_segments: c.segments }),
-  }));
+  const styledClips = clips.map((c: any) =>
+    enrichClipWithSegments({
+      start_second: c.start_second,
+      end_second: c.end_second,
+      title: c.title || "clip",
+      caption_style: c.caption_style || captionStyle,
+      crop_strategy: c.crop_strategy || cropStrategy,
+      format: c.format || format,
+      allow_ass_fallback: c.allow_ass_fallback === true || allowAssFallback,
+      keep_segments: Array.isArray(c.segments) && c.segments.length > 0 ? c.segments : c.keep_segments,
+    }),
+  );
 
   const jobId = uuidv4();
   const job: JobState = {
@@ -3316,6 +3413,11 @@ app.post("/api/mcp/export", async (req, res) => {
     defaultCropStrategy: cropStrategy,
     defaultFormat: format,
     label: "MCP export",
+    clipSpecs: styledClips,
+    logoPath,
+    outroPath,
+    introPath,
+    cleanFillers: req.body.clean_fillers === true,
   });
 
   // Broadcast to UI so it can track progress

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -3390,7 +3390,11 @@ app.post("/api/mcp/export", async (req, res) => {
       crop_strategy: c.crop_strategy || cropStrategy,
       format: c.format || format,
       allow_ass_fallback: c.allow_ass_fallback === true || allowAssFallback,
-      keep_segments: Array.isArray(c.segments) && c.segments.length > 0 ? c.segments : c.keep_segments,
+      keep_segments:
+        (Array.isArray(c.segments) && c.segments.length > 0 && c.segments) ||
+        (Array.isArray(c.keep_segments) && c.keep_segments.length > 0 && c.keep_segments) ||
+        (Array.isArray(c.keep_segment) && c.keep_segment.length > 0 && c.keep_segment) ||
+        undefined,
     }),
   );
 

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -3285,17 +3285,20 @@ app.post("/api/ui-state", (req, res) => {
     uiState.rawTranscriptText = body.rawTranscriptText;
   if (body.suggestions !== undefined) {
     if (body._source === "ui" && Array.isArray(body.suggestions)) {
-      uiState.suggestions = body.suggestions.map((incoming: SuggestedClip, i: number) => {
-        const existing = uiState.suggestions[i];
-        if (
-          existing?.segments?.length &&
-          !incoming.segments?.length &&
-          Math.abs(existing.start_second - incoming.start_second) < 0.5 &&
-          Math.abs(existing.end_second - incoming.end_second) < 0.5
-        ) {
-          return { ...incoming, segments: existing.segments, duration: existing.duration ?? incoming.duration };
-        }
-        return incoming;
+      uiState.suggestions = body.suggestions.map((incoming: SuggestedClip) => {
+        if (incoming.segments?.length) return incoming;
+        const segments = findSuggestionSegments(
+          uiState.suggestions,
+          incoming.start_second,
+          incoming.end_second,
+        );
+        if (!segments?.length) return incoming;
+        const existing = uiState.suggestions.find(
+          (s) =>
+            Math.abs(s.start_second - incoming.start_second) < 0.5 &&
+            Math.abs(s.end_second - incoming.end_second) < 0.5,
+        );
+        return { ...incoming, segments, duration: existing?.duration ?? incoming.duration };
       });
     } else {
       uiState.suggestions = body.suggestions;

--- a/src/utils/transcript.ts
+++ b/src/utils/transcript.ts
@@ -42,3 +42,19 @@ export function findContentType(
   );
   return match?.content_type;
 }
+
+export function findSuggestionSegments(
+  suggestions: Array<{
+    start_second: number;
+    end_second: number;
+    segments?: Array<{ start: number; end: number }>;
+  }> | undefined | null,
+  start: number,
+  end: number,
+): Array<{ start: number; end: number }> | undefined {
+  if (!suggestions?.length) return undefined;
+  const match = suggestions.find(
+    (s) => Math.abs(s.start_second - start) < 0.5 && Math.abs(s.end_second - end) < 0.5,
+  );
+  return match?.segments;
+}

--- a/tests/test_ai_fallback.py
+++ b/tests/test_ai_fallback.py
@@ -181,7 +181,7 @@ class AIFallbackTests(unittest.TestCase):
 
         calls = []
 
-        def fake_suggest(*, segments, top_n, exclude_clips=None, progress_callback=None, timeout=300):
+        def fake_suggest(*, segments, top_n, exclude_clips=None, progress_callback=None, timeout=300, error_sink=None):
             calls.append({
                 "start": segments[0]["start"],
                 "end": segments[-1]["end"],


### PR DESCRIPTION
## Summary

- **Multi-segment clips:** Web UI keeps and sends `segments`/`keep_segments`; server re-attaches from session state when missing; `clip_generator` boundary revert uses kept duration and restores original cuts instead of the outer span.
- **Re-render recipes:** Batch, single-clip, MCP export, and MCP direct-fallback paths persist words + recipe sidecars (including `keep_segments`) so reframes survive multi-cut edits.
- **Suggest reliability:** Long episodes use bucketed `suggest_initial_with_claude`; AI timeouts raised to 900s; `/api/claude-suggest` resets `phase` on error/empty and broadcasts state.
- **Thumbnails:** 320px ROI normalization before Laplacian scoring, lower expression floor, best-rejected fallback, tile-seam crop clamping for multi-participant grids; empty-frame warnings in API + UI.
- **Loud failures:** Export summary shows partial batch failures; thumbnail/error toasts use error styling.
- **Launcher diagnostics:** `podcli doctor` SHA256-checks key backend files against the embedded bundle; `podcli setup` fails loudly when backend extract fails with no fallback.

## Test plan

- [ ] Generate multi-cut moments in Studio, export batch — verify kept duration matches segment sum, not outer span
- [ ] Re-render a multi-cut clip after manual reframe — should succeed without "clip too long" on outer span
- [ ] Suggest on a 90+ min episode — should bucket progress; force a failure — UI should leave "suggesting" phase
- [ ] Thumbnail options on 4K Riverside-style footage — frames should appear; crop should not straddle tile seams
- [ ] `podcli doctor` on a healthy install — no STALE; tamper one backend file — should report mismatch
- [ ] Export batch with one invalid clip — summary shows X of Y exported with error snippets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clip suggestions and exports now preserve selected segment ranges, improving consistency across retries, batch runs, and saved history.
  * Thumbnail selection and cropping have been improved for better-looking results, especially for landscape sources.

* **Bug Fixes**
  * Improved handling of export reverts so clip durations stay closer to the requested range.
  * Added clearer error states and messaging in clip and thumbnail workflows.
  * Strengthened backend validation so installation issues and mismatches are reported more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->