### PR TITLE
Point GitHub sponsor button to podcli.com/sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-liberapay: nmbrthirteen
+custom: ["https://podcli.com/sponsors"]


### PR DESCRIPTION
Switches .github/FUNDING.yml from Liberapay to the new sponsors page so the repo's Sponsor button links to podcli.com/sponsors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project sponsorship link to direct supporters to the new sponsorship page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->