### PR TITLE
Group Dependabot minor/patch updates to cut PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,27 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: pip
     directory: "/backend"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      pip-minor-patch:
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Bundles minor and patch dependency updates into one PR per ecosystem (npm, pip, github-actions) instead of one PR per package. Major bumps stay as separate PRs so the risky ones remain isolated and easy to review.

Turns the roughly 15-PR first-run flood into about 3 grouped PRs plus any majors.