### PR TITLE
Use UTF-8 for backend file I/O; fix Windows reel concat

### DIFF
--- a/backend/clip_studio.py
+++ b/backend/clip_studio.py
@@ -58,7 +58,7 @@ BRAND_DEFAULTS = {
 
 def _load_brand() -> dict:
     try:
-        with open(BRAND_PATH) as f:
+        with open(BRAND_PATH, encoding="utf-8") as f:
             return json.load(f)
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
@@ -66,7 +66,7 @@ def _load_brand() -> dict:
 
 def _save_brand(data: dict):
     os.makedirs(os.path.dirname(BRAND_PATH), exist_ok=True)
-    with open(BRAND_PATH, "w") as f:
+    with open(BRAND_PATH, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
 

--- a/backend/services/audio_events.py
+++ b/backend/services/audio_events.py
@@ -47,7 +47,7 @@ _class_index: dict[str, list[int]] = {}
 
 def _load_class_index() -> dict[str, list[int]]:
     names: dict[int, str] = {}
-    with open(_CLASS_MAP_PATH, newline="") as f:
+    with open(_CLASS_MAP_PATH, newline="", encoding="utf-8") as f:
         reader = csv.reader(f)
         next(reader)  # header: index,mid,display_name
         for row in reader:

--- a/backend/services/integrations/youtube/client.py
+++ b/backend/services/integrations/youtube/client.py
@@ -44,7 +44,7 @@ def is_authorized() -> bool:
 def _write_token(creds) -> None:
     # 0o600: the file holds a long-lived refresh token — keep it owner-only.
     fd = os.open(_TOKEN_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as f:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write(creds.to_json())
 
 

--- a/backend/services/reel.py
+++ b/backend/services/reel.py
@@ -57,13 +57,13 @@ class ReelSession:
     def save(self) -> str:
         path = session_path(self.session_id)
         data = asdict(self)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
         return path
 
     @classmethod
     def load(cls, session_id: str) -> "ReelSession":
-        with open(session_path(session_id)) as f:
+        with open(session_path(session_id), encoding="utf-8") as f:
             data = json.load(f)
         data["moments"] = [Moment(**m) for m in data.get("moments", [])]
         return cls(**data)
@@ -249,8 +249,10 @@ def build_reel(session: ReelSession, progress_callback: Optional[Callable] = Non
 
     reel = os.path.join(session.out_dir, "highlights_reel.mp4")
     lst = os.path.join(session.out_dir, "_concat.txt")
-    with open(lst, "w") as f:
-        f.write("".join(f"file '{os.path.abspath(x)}'\n" for x in files))
+    with open(lst, "w", encoding="utf-8") as f:
+        for x in files:
+            p = os.path.abspath(x).replace("\\", "/")
+            f.write(f"file '{p}'\n")
     r = proc_run(["ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", lst,
                   "-c", "copy", reel, "-loglevel", "error"], timeout=300, check=False)
     if r.returncode != 0:
@@ -271,7 +273,7 @@ def list_sessions() -> list[dict]:
             continue
         path = os.path.join(d, name)
         try:
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 data = json.load(f)
         except (json.JSONDecodeError, OSError):
             continue


### PR DESCRIPTION
Follow-up to the prompt-file UTF-8 fix (#78). An audit of every text-mode file operation in the Python backend found 8 more that omit `encoding=`, so they use cp1252 on Windows and crash on non-ASCII content, a real risk given Georgian/CJK captions and filenames.

**Fixed (add `encoding="utf-8"`):**
- brand config read/write (clip_studio.py)
- reel session save/load and `list_sessions` read (reel.py)
- YAMNet class-map CSV read (audio_events.py)
- YouTube OAuth token write (youtube/client.py)

**Also fixed at the same reel line (flagged long ago):** the ffmpeg concat list wrote `os.path.abspath()` paths, which are backslash on Windows and break ffmpeg's concat demuxer. Now normalized to forward slashes.

The `ensure_ascii=False` JSON writes and corrections file were already correct and left untouched. Re-audit confirms no remaining text opens without an encoding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reading and writing brand settings, session data, authentication credentials, and model metadata across different system encodings.
  * Improved video reel processing on Windows by normalizing file paths for media concatenation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->