### PR TITLE
Pin tsconfigRaw so Remotion never resolves ambient TypeScript

### DIFF
--- a/remotion/bundle-cache.mjs
+++ b/remotion/bundle-cache.mjs
@@ -1,0 +1,54 @@
+import { bundle } from "@remotion/bundler";
+import path from "path";
+import fs from "fs";
+import crypto from "crypto";
+import { fileURLToPath } from "url";
+import { webpackOverride } from "./webpack-override.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const CACHE_ROOT = process.env.PODCLI_CACHE_DIR
+  ? path.resolve(process.env.PODCLI_CACHE_DIR)
+  : path.join(PROJECT_ROOT, "data", "cache");
+
+export const CACHE_DIR = path.join(CACHE_ROOT, "remotion-bundle");
+const HASH_FILE = path.join(CACHE_DIR, ".hash");
+const ENTRY_POINT = path.join(__dirname, "src", "index.ts");
+
+/**
+ * A bundle is a product of the compositions and the webpack config, so both
+ * feed the cache key. Keying on either alone silently serves a bundle built
+ * from inputs that no longer exist.
+ */
+function currentHash() {
+  const hash = crypto.createHash("md5");
+
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) hash.update(fs.readFileSync(full));
+    }
+  }
+
+  walk(path.join(__dirname, "src"));
+  hash.update(fs.readFileSync(path.join(__dirname, "webpack-override.mjs")));
+  return hash.digest("hex");
+}
+
+export async function getCachedBundle({ onBundle } = {}) {
+  const want = currentHash();
+  if (fs.existsSync(HASH_FILE) && fs.existsSync(path.join(CACHE_DIR, "index.html"))) {
+    if (fs.readFileSync(HASH_FILE, "utf-8").trim() === want) return CACHE_DIR;
+  }
+
+  onBundle?.();
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  const location = await bundle({
+    entryPoint: ENTRY_POINT,
+    outDir: CACHE_DIR,
+    webpackOverride,
+  });
+  fs.writeFileSync(HASH_FILE, want);
+  return location;
+}

--- a/remotion/remotion.config.ts
+++ b/remotion/remotion.config.ts
@@ -1,4 +1,6 @@
 import { Config } from "@remotion/cli/config";
+import { webpackOverride } from "./webpack-override.mjs";
 
 Config.setVideoImageFormat("jpeg");
 Config.setOverwriteOutput(true);
+Config.overrideWebpackConfig(webpackOverride);

--- a/remotion/render-bookend.mjs
+++ b/remotion/render-bookend.mjs
@@ -15,6 +15,7 @@
  */
 
 import { bundle } from "@remotion/bundler";
+import { webpackOverride } from "./webpack-override.mjs";
 import { renderMedia, selectComposition } from "@remotion/renderer";
 import path from "path";
 import fs from "fs";
@@ -49,7 +50,7 @@ function parseArgs() {
 async function getBundle() {
   // Reuse podcli's cached bundle if present; otherwise build fresh.
   if (fs.existsSync(path.join(CACHE_DIR, "index.html"))) return CACHE_DIR;
-  return await bundle({ entryPoint: ENTRY_POINT, outDir: CACHE_DIR });
+  return await bundle({ entryPoint: ENTRY_POINT, outDir: CACHE_DIR, webpackOverride });
 }
 
 async function main() {

--- a/remotion/render-bookend.mjs
+++ b/remotion/render-bookend.mjs
@@ -14,26 +14,14 @@
  *     [--bg "#0B0B0F"] [--accent "#FFE000"] [--fps 30] [--width 1080] [--height 1920]
  */
 
-import { bundle } from "@remotion/bundler";
-import { webpackOverride } from "./webpack-override.mjs";
 import { renderMedia, selectComposition } from "@remotion/renderer";
+import { getCachedBundle } from "./bundle-cache.mjs";
 import path from "path";
 import fs from "fs";
 import os from "os";
 import crypto from "crypto";
 import { spawnSync } from "child_process";
-import { fileURLToPath } from "url";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PROJECT_ROOT = path.resolve(__dirname, "..");
-// Share the (project-independent) composition bundle with render.mjs via
-// PODCLI_CACHE_DIR so bookends reuse the prewarmed bundle instead of rebuilding
-// into the runtime dir.
-const CACHE_ROOT = process.env.PODCLI_CACHE_DIR
-  ? path.resolve(process.env.PODCLI_CACHE_DIR)
-  : path.join(PROJECT_ROOT, "data", "cache");
-const CACHE_DIR = path.join(CACHE_ROOT, "remotion-bundle");
-const ENTRY_POINT = path.join(__dirname, "src", "index.ts");
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -47,11 +35,6 @@ function parseArgs() {
   return opts;
 }
 
-async function getBundle() {
-  // Reuse podcli's cached bundle if present; otherwise build fresh.
-  if (fs.existsSync(path.join(CACHE_DIR, "index.html"))) return CACHE_DIR;
-  return await bundle({ entryPoint: ENTRY_POINT, outDir: CACHE_DIR, webpackOverride });
-}
 
 async function main() {
   const opts = parseArgs();
@@ -77,7 +60,9 @@ async function main() {
     bookendAccent: opts.accent || "#FFE000",
   };
 
-  const bundleLocation = await getBundle();
+  const bundleLocation = await getCachedBundle({
+    onBundle: () => console.log("  Remotion: bundling (first run, or src/config changed)..."),
+  });
   const composition = await selectComposition({ serveUrl: bundleLocation, id: "Bookend", inputProps });
 
   const seed = `${path.resolve(opts.output)}:${process.pid}`;

--- a/remotion/render.mjs
+++ b/remotion/render.mjs
@@ -17,23 +17,13 @@
  *   node remotion/render.mjs --prebundle   # Bundle only, no render
  */
 
-import { bundle } from "@remotion/bundler";
 import { renderMedia, selectComposition } from "@remotion/renderer";
-import { webpackOverride } from "./webpack-override.mjs";
+import { getCachedBundle } from "./bundle-cache.mjs";
 import path from "path";
 import fs from "fs";
 import os from "os";
 import crypto from "crypto";
-import { fileURLToPath } from "url";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PROJECT_ROOT = path.resolve(__dirname, "..");
-const CACHE_ROOT = process.env.PODCLI_CACHE_DIR
-  ? path.resolve(process.env.PODCLI_CACHE_DIR)
-  : path.join(PROJECT_ROOT, "data", "cache");
-const CACHE_DIR = path.join(CACHE_ROOT, "remotion-bundle");
-const BUNDLE_HASH_FILE = path.join(CACHE_DIR, ".hash");
-const ENTRY_POINT = path.join(__dirname, "src", "index.ts");
 
 const BOOLEAN_FLAGS = new Set(["prebundle", "keep-overlay"]);
 
@@ -54,61 +44,6 @@ function parseArgs() {
   return opts;
 }
 
-/**
- * Hash the remotion/src/ directory to detect changes.
- */
-function hashSrcDir() {
-  const srcDir = path.join(__dirname, "src");
-  const hash = crypto.createHash("md5");
-
-  function walk(dir) {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile()) {
-        hash.update(fs.readFileSync(full));
-      }
-    }
-  }
-
-  walk(srcDir);
-  // The bundle is a product of the webpack config too, so a change to the
-  // override has to invalidate the cache, or a warm cache keeps serving a
-  // bundle built under the old one.
-  hash.update(fs.readFileSync(path.join(__dirname, "webpack-override.mjs")));
-  return hash.digest("hex");
-}
-
-/**
- * Get or create a cached bundle. Only re-bundles when src/ changes.
- */
-async function getCachedBundle() {
-  const currentHash = hashSrcDir();
-
-  // Check if cached bundle is still valid
-  if (fs.existsSync(BUNDLE_HASH_FILE)) {
-    const cachedHash = fs.readFileSync(BUNDLE_HASH_FILE, "utf-8").trim();
-    const bundleIndex = path.join(CACHE_DIR, "index.html");
-    if (cachedHash === currentHash && fs.existsSync(bundleIndex)) {
-      return CACHE_DIR;
-    }
-  }
-
-  // Bundle fresh
-  console.log("  Remotion: bundling (first run or src changed)...");
-  fs.mkdirSync(CACHE_DIR, { recursive: true });
-
-  const bundleLocation = await bundle({
-    entryPoint: ENTRY_POINT,
-    outDir: CACHE_DIR,
-    webpackOverride,
-  });
-
-  // Save hash
-  fs.writeFileSync(BUNDLE_HASH_FILE, currentHash);
-  return bundleLocation;
-}
 
 async function main() {
   const opts = parseArgs();
@@ -116,7 +51,7 @@ async function main() {
   // Prebundle mode — just bundle and exit
   if (opts.prebundle) {
     const t0 = Date.now();
-    const loc = await getCachedBundle();
+    const loc = await getCachedBundle({ onBundle: () => console.log("  Remotion: bundling (first run, or src/config changed)...") });
     console.log(`Remotion bundle ready at ${loc} (${Date.now() - t0}ms)`);
     return;
   }
@@ -137,7 +72,7 @@ async function main() {
 
   // Get cached bundle first (needed to copy assets into it)
   const t0 = Date.now();
-  const bundleLocation = await getCachedBundle();
+  const bundleLocation = await getCachedBundle({ onBundle: () => console.log("  Remotion: bundling (first run, or src/config changed)...") });
   const bundleMs = Date.now() - t0;
   if (bundleMs > 1000) {
     console.log(`  bundled in ${(bundleMs / 1000).toFixed(1)}s`);

--- a/remotion/render.mjs
+++ b/remotion/render.mjs
@@ -73,6 +73,10 @@ function hashSrcDir() {
   }
 
   walk(srcDir);
+  // The bundle is a product of the webpack config too, so a change to the
+  // override has to invalidate the cache, or a warm cache keeps serving a
+  // bundle built under the old one.
+  hash.update(fs.readFileSync(path.join(__dirname, "webpack-override.mjs")));
   return hash.digest("hex");
 }
 

--- a/remotion/render.mjs
+++ b/remotion/render.mjs
@@ -19,6 +19,7 @@
 
 import { bundle } from "@remotion/bundler";
 import { renderMedia, selectComposition } from "@remotion/renderer";
+import { webpackOverride } from "./webpack-override.mjs";
 import path from "path";
 import fs from "fs";
 import os from "os";
@@ -97,6 +98,7 @@ async function getCachedBundle() {
   const bundleLocation = await bundle({
     entryPoint: ENTRY_POINT,
     outDir: CACHE_DIR,
+    webpackOverride,
   });
 
   // Save hash

--- a/remotion/test-render.mjs
+++ b/remotion/test-render.mjs
@@ -11,6 +11,7 @@
  */
 
 import { bundle } from "@remotion/bundler";
+import { webpackOverride } from "./webpack-override.mjs";
 import { renderMedia, selectComposition } from "@remotion/renderer";
 import path from "path";
 import fs from "fs";
@@ -53,7 +54,7 @@ async function getCachedBundle() {
   }
   console.log("Bundling (first run or src changed)...");
   fs.mkdirSync(CACHE_DIR, { recursive: true });
-  const loc = await bundle({ entryPoint: ENTRY_POINT, outDir: CACHE_DIR });
+  const loc = await bundle({ entryPoint: ENTRY_POINT, outDir: CACHE_DIR, webpackOverride });
   fs.writeFileSync(BUNDLE_HASH_FILE, currentHash);
   return loc;
 }

--- a/remotion/test-render.mjs
+++ b/remotion/test-render.mjs
@@ -10,55 +10,15 @@
  *   node remotion/test-render.mjs subtle
  */
 
-import { bundle } from "@remotion/bundler";
-import { webpackOverride } from "./webpack-override.mjs";
 import { renderMedia, selectComposition } from "@remotion/renderer";
+import { getCachedBundle } from "./bundle-cache.mjs";
 import path from "path";
 import fs from "fs";
-import crypto from "crypto";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(__dirname, "..");
-const CACHE_ROOT = process.env.PODCLI_CACHE_DIR
-  ? path.resolve(process.env.PODCLI_CACHE_DIR)
-  : path.join(PROJECT_ROOT, "data", "cache");
-const CACHE_DIR = path.join(CACHE_ROOT, "remotion-bundle");
-const BUNDLE_HASH_FILE = path.join(CACHE_DIR, ".hash");
-const ENTRY_POINT = path.join(__dirname, "src", "index.ts");
 
-function hashSrcDir() {
-  const srcDir = path.join(__dirname, "src");
-  const hash = crypto.createHash("md5");
-  function walk(dir) {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) walk(full);
-      else if (entry.isFile()) hash.update(fs.readFileSync(full));
-    }
-  }
-  walk(srcDir);
-  hash.update(fs.readFileSync(path.join(__dirname, "webpack-override.mjs")));
-  return hash.digest("hex");
-}
-
-async function getCachedBundle() {
-  const currentHash = hashSrcDir();
-  if (fs.existsSync(BUNDLE_HASH_FILE)) {
-    const cachedHash = fs.readFileSync(BUNDLE_HASH_FILE, "utf-8").trim();
-    if (
-      cachedHash === currentHash &&
-      fs.existsSync(path.join(CACHE_DIR, "index.html"))
-    ) {
-      return CACHE_DIR;
-    }
-  }
-  console.log("Bundling (first run or src changed)...");
-  fs.mkdirSync(CACHE_DIR, { recursive: true });
-  const loc = await bundle({ entryPoint: ENTRY_POINT, outDir: CACHE_DIR, webpackOverride });
-  fs.writeFileSync(BUNDLE_HASH_FILE, currentHash);
-  return loc;
-}
 
 const styleName = process.argv[2] || "branded";
 
@@ -113,7 +73,7 @@ const inputProps = {
 
 async function main() {
   const t0 = Date.now();
-  const bundleLocation = await getCachedBundle();
+  const bundleLocation = await getCachedBundle({ onBundle: () => console.log("Bundling (first run, or src/config changed)...") });
   const bundleMs = Date.now() - t0;
   console.log(`Bundle: ${bundleMs}ms (${bundleMs < 100 ? "cached" : "fresh"})`);
 

--- a/remotion/test-render.mjs
+++ b/remotion/test-render.mjs
@@ -38,6 +38,7 @@ function hashSrcDir() {
     }
   }
   walk(srcDir);
+  hash.update(fs.readFileSync(path.join(__dirname, "webpack-override.mjs")));
   return hash.digest("hex");
 }
 

--- a/remotion/webpack-override.mjs
+++ b/remotion/webpack-override.mjs
@@ -1,0 +1,28 @@
+/**
+ * Remotion's esbuild-loader reads a tsconfig via `require('typescript')` unless
+ * `tsconfigRaw` is already set. The runtime lives under the user's home dir, so
+ * Node walks up and resolves whatever TypeScript it finds there — a TypeScript 7
+ * install has no `ts.sys` and hard-crashes the bundle. Pinning tsconfigRaw skips
+ * that lookup. Empty matches the shipped default: the runtime bundle has no
+ * typescript, and every composition imports React, so esbuild's classic JSX
+ * transform is correct.
+ */
+const TSCONFIG_RAW = { compilerOptions: {} };
+
+const pinTsconfig = (entry) =>
+  entry &&
+  typeof entry === "object" &&
+  typeof entry.loader === "string" &&
+  entry.loader.includes("esbuild-loader")
+    ? { ...entry, options: { ...entry.options, tsconfigRaw: TSCONFIG_RAW } }
+    : entry;
+
+export const webpackOverride = (config) => ({
+  ...config,
+  module: {
+    ...config.module,
+    rules: (config.module?.rules ?? []).map((rule) =>
+      Array.isArray(rule?.use) ? { ...rule, use: rule.use.map(pinTsconfig) } : rule,
+    ),
+  },
+});


### PR DESCRIPTION
## Problem

`podcli update` / `setup` / any render fails at the bundling step:

```
TypeError: Cannot read properties of undefined (reading 'readFile')
    at Object.ESBuildLoader (@remotion/bundler/dist/esbuild-loader/index.js:39:81)
  bundle:   deferred to first render (exit status 1)
```

Not a version regression. Remotion's esbuild-loader reads a tsconfig via a bare `require('typescript')` unless `tsconfigRaw` is already set:

```js
if (!('tsconfigRaw' in transformOptions) && isTypescriptInstalled()) {
  const typescript = require('typescript');
  const tsConfig = typescript.readConfigFile(tsConfigPath, typescript.sys.readFile);
}
```

The runtime is provisioned under the user's home directory (`~/Library/Application Support/podcli/runtime/`), so Node's resolution walks **up** past the runtime and out into the home dir. The bundle ships no `typescript`, so on a clean machine nothing resolves and the step is skipped harmlessly. But any TypeScript sitting higher up the tree gets picked up, and a home-dir install of **TypeScript 7** (the native port) has no `ts.sys` -> `typescript.sys.readFile` throws.

Repro on a clean checkout:

```sh
cd ~ && npm i -D typescript@^7   # anything above the runtime
podcli setup                     # bundling crashes
```

## Fix

Pass `tsconfigRaw` explicitly from every bundler entry point, which short-circuits the `require('typescript')` branch. The bundler never consults ambient TypeScript again, from any directory.

`tsconfigRaw` is intentionally empty: that matches what production already does. The runtime bundle contains no typescript, so renders today run with no tsconfig at all, and every composition in `remotion/src` imports React, making esbuild's classic JSX transform the already-proven path. This makes the existing behaviour deterministic rather than changing it.

Applied in one shared `remotion/webpack-override.mjs`, wired into `render.mjs`, `render-bookend.mjs`, `test-render.mjs`, and `remotion.config.ts` (studio). `build-remotion.sh` copies `remotion/` wholesale, so no build change is needed.

## Verification

With TypeScript 7 still installed in the home dir:

- Fresh repo bundle (`render.mjs --prebundle`, cache-busted): builds in 2.1s
- The exact runtime command that crashed: now succeeds
- `podcli setup`: `bundle: prebuilt` instead of `exit status 1`
- Real render (`render-bookend.mjs`): valid 1080x1920 9:16 H.264, decodes clean under ffmpeg
- `tsc --noEmit`: clean

Note CI cannot catch a regression here, since the failure only reproduces when a broken TypeScript exists above the runtime on the filesystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video rendering and preview generation by applying consistent bundling configuration across Remotion workflows.
  * Prevented environment-specific TypeScript settings from affecting JSX processing during video builds.
* **Reliability**
  * Increased consistency for cached bundles, test renders, and final output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->