### PR TITLE
Serve native arm64 ffmpeg on Apple Silicon; re-provision wrong-arch runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           go-version: '1.23'
           cache: false # stdlib-only module: no go.sum to key a cache on
+      - name: Sync embedded backend + PodStack commands
+        working-directory: cli
+        shell: bash # go:generate shells out to `sh sync.sh`, which needs sh on PATH
+        run: go generate ./... # files/ and commands/ are generated, not committed; go:embed fails without them
       - name: Build
         working-directory: cli
         run: go build ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,29 @@ on:
     branches: [main]
 
 jobs:
+  go:
+    name: Go build + test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: false # stdlib-only module: no go.sum to key a cache on
+      - name: Build
+        working-directory: cli
+        run: go build ./...
+      - name: Vet
+        working-directory: cli
+        run: go vet ./...
+      - name: Test
+        working-directory: cli
+        run: go test ./...
+
   typescript:
     name: TypeScript build + typecheck
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,54 @@ jobs:
           name: ${{ env.ASSET }}
           path: ${{ env.ASSET }}
 
+  # Apple Silicon only. Linux and Windows already get correct native builds from
+  # the static sources the provisioner uses; macOS has no upstream arm64 static,
+  # and the URL we pointed at serves x86_64 to every Mac, so ffmpeg ran under
+  # Rosetta at roughly a third of native encode speed.
+  ffmpeg-darwin:
+    runs-on: macos-14
+    env:
+      FFMPEG_TAG: n7.1
+    steps:
+      - name: Build ffmpeg (arm64, static libx264)
+        shell: bash
+        run: |
+          brew install --quiet nasm pkg-config
+          deps="$GITHUB_WORKSPACE/deps"
+          # Build x264 static-only: Homebrew's prefix carries libx264.dylib next to
+          # the .a and ld prefers the dylib, which would bake a Homebrew path into a
+          # binary we ship to machines that have no Homebrew.
+          git clone -q --depth 1 -b stable https://code.videolan.org/videolan/x264.git
+          (cd x264 && ./configure --prefix="$deps" --enable-static --enable-pic --disable-cli && make -j"$(sysctl -n hw.ncpu)" && make install)
+          curl -fsSL "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_TAG#n}.tar.xz" -o ffmpeg.tar.xz
+          tar xf ffmpeg.tar.xz && cd "ffmpeg-${FFMPEG_TAG#n}"
+          PKG_CONFIG_PATH="$deps/lib/pkgconfig" ./configure \
+            --enable-gpl --enable-libx264 \
+            --pkg-config-flags=--static \
+            --extra-cflags="-I$deps/include" --extra-ldflags="-L$deps/lib" \
+            --disable-shared --enable-static \
+            --disable-doc --disable-debug --disable-ffplay
+          make -j"$(sysctl -n hw.ncpu)" ffmpeg ffprobe
+          cd ..
+          cp "ffmpeg-${FFMPEG_TAG#n}/ffmpeg" ffmpeg-darwin-arm64
+          cp "ffmpeg-${FFMPEG_TAG#n}/ffprobe" ffprobe-darwin-arm64
+      - name: Verify the binaries are native and self-contained
+        shell: bash
+        run: |
+          for b in ffmpeg-darwin-arm64 ffprobe-darwin-arm64; do
+            file "$b" | grep -q arm64 || { echo "$b is not arm64"; exit 1; }
+            if otool -L "$b" | tail -n +2 | grep -qv -e '/usr/lib/' -e '/System/'; then
+              echo "$b links a non-system library:"; otool -L "$b"; exit 1
+            fi
+          done
+          ./ffmpeg-darwin-arm64 -hide_banner -encoders | grep -q libx264
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ffmpeg-darwin-arm64
+          path: |
+            ffmpeg-darwin-arm64
+            ffprobe-darwin-arm64
+
   studio:
     runs-on: ubuntu-latest
     steps:
@@ -145,7 +193,7 @@ jobs:
           path: ${{ env.ASSET }}
 
   release:
-    needs: [build, whisper, studio, remotion]
+    needs: [build, whisper, studio, remotion, ffmpeg-darwin]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,20 +104,29 @@ jobs:
   ffmpeg-darwin:
     runs-on: macos-14
     env:
-      FFMPEG_TAG: n7.1
+      FFMPEG_VERSION: '7.1'
+      FFMPEG_SHA256: 40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6
+      X264_COMMIT: b35605ace3ddf7c1a5d67a2eb553f034aef41d55 # stable as of 2026-07-12
     steps:
       - name: Build ffmpeg (arm64, static libx264)
         shell: bash
         run: |
+          set -euo pipefail
           brew install --quiet nasm pkg-config
           deps="$GITHUB_WORKSPACE/deps"
-          # Build x264 static-only: Homebrew's prefix carries libx264.dylib next to
-          # the .a and ld prefers the dylib, which would bake a Homebrew path into a
-          # binary we ship to machines that have no Homebrew.
-          git clone -q --depth 1 -b stable https://code.videolan.org/videolan/x264.git
+          # Pin x264 by commit: "stable" moves, and whatever it points at ends up
+          # inside a binary we hand to users. Static-only because Homebrew's prefix
+          # carries libx264.dylib next to the .a and ld prefers the dylib, which
+          # would bake a Homebrew path into a binary shipped to machines with no
+          # Homebrew.
+          git clone -q https://code.videolan.org/videolan/x264.git
+          git -C x264 checkout -q "$X264_COMMIT"
           (cd x264 && ./configure --prefix="$deps" --enable-static --enable-pic --disable-cli && make -j"$(sysctl -n hw.ncpu)" && make install)
-          curl -fsSL "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_TAG#n}.tar.xz" -o ffmpeg.tar.xz
-          tar xf ffmpeg.tar.xz && cd "ffmpeg-${FFMPEG_TAG#n}"
+          curl -fsSL "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" -o ffmpeg.tar.xz
+          # ffmpeg.org publishes no checksum file, so pin the digest here: an
+          # unverified tarball would compile straight into a release asset.
+          echo "${FFMPEG_SHA256}  ffmpeg.tar.xz" | shasum -a 256 -c -
+          tar xf ffmpeg.tar.xz && cd "ffmpeg-${FFMPEG_VERSION}"
           PKG_CONFIG_PATH="$deps/lib/pkgconfig" ./configure \
             --enable-gpl --enable-libx264 \
             --pkg-config-flags=--static \
@@ -126,13 +135,16 @@ jobs:
             --disable-doc --disable-debug --disable-ffplay
           make -j"$(sysctl -n hw.ncpu)" ffmpeg ffprobe
           cd ..
-          cp "ffmpeg-${FFMPEG_TAG#n}/ffmpeg" ffmpeg-darwin-arm64
-          cp "ffmpeg-${FFMPEG_TAG#n}/ffprobe" ffprobe-darwin-arm64
+          cp "ffmpeg-${FFMPEG_VERSION}/ffmpeg" ffmpeg-darwin-arm64
+          cp "ffmpeg-${FFMPEG_VERSION}/ffprobe" ffprobe-darwin-arm64
       - name: Verify the binaries are native and self-contained
         shell: bash
         run: |
+          set -euo pipefail
           for b in ffmpeg-darwin-arm64 ffprobe-darwin-arm64; do
-            file "$b" | grep -q arm64 || { echo "$b is not arm64"; exit 1; }
+            # lipo, not `file | grep arm64`: that also matches a universal binary
+            # carrying an x86_64 slice, which is what we are trying to stop shipping.
+            [ "$(lipo -archs "$b")" = "arm64" ] || { echo "$b is not arm64-only: $(lipo -archs "$b")"; exit 1; }
             if otool -L "$b" | tail -n +2 | grep -qv -e '/usr/lib/' -e '/System/'; then
               echo "$b links a non-system library:"; otool -L "$b"; exit 1
             fi

--- a/cli/internal/backend/sync.sh
+++ b/cli/internal/backend/sync.sh
@@ -7,16 +7,17 @@ src="$here/../../../backend"
 dest="$here/files"
 rm -rf "$dest"
 mkdir -p "$dest"
-# tar, not rsync: Git Bash on Windows has no rsync, and this runs wherever
-# `go generate` does. Excluding venv up front also beats copying it and
-# deleting it after.
-tar -cf - -C "$src" \
-  --exclude='*__pycache__*' \
-  --exclude='*.pyc' \
-  --exclude='./venv' \
-  --exclude='./.venv' \
-  --exclude='./requirements.txt' \
-  --exclude='./models/res10_300x300_ssd_iter_140000.caffemodel' \
-  --exclude='./models/deploy.prototxt' \
-  . | tar -xf - -C "$dest"
+# Plain cp: this runs wherever `go generate` does, and on Windows Git Bash has
+# no rsync while its tar reads the leading "D:" of an absolute path as a remote
+# host. Skip venv before copying rather than deleting it afterwards.
+for entry in "$src"/*; do
+  case "${entry##*/}" in
+    venv | .venv | requirements.txt) continue ;;
+  esac
+  cp -R "$entry" "$dest"/
+done
+rm -f "$dest/models/res10_300x300_ssd_iter_140000.caffemodel" \
+  "$dest/models/deploy.prototxt"
+find "$dest" -name '__pycache__' -type d -prune -exec rm -rf {} +
+find "$dest" -name '*.pyc' -delete
 echo "synced backend -> $dest"

--- a/cli/internal/backend/sync.sh
+++ b/cli/internal/backend/sync.sh
@@ -7,13 +7,16 @@ src="$here/../../../backend"
 dest="$here/files"
 rm -rf "$dest"
 mkdir -p "$dest"
-rsync -a \
-  --exclude='__pycache__' \
+# tar, not rsync: Git Bash on Windows has no rsync, and this runs wherever
+# `go generate` does. Excluding venv up front also beats copying it and
+# deleting it after.
+tar -cf - -C "$src" \
+  --exclude='*__pycache__*' \
   --exclude='*.pyc' \
-  --exclude='venv' \
-  --exclude='.venv' \
-  --exclude='requirements.txt' \
-  --exclude='models/res10_300x300_ssd_iter_140000.caffemodel' \
-  --exclude='models/deploy.prototxt' \
-  "$src"/ "$dest"/
+  --exclude='./venv' \
+  --exclude='./.venv' \
+  --exclude='./requirements.txt' \
+  --exclude='./models/res10_300x300_ssd_iter_140000.caffemodel' \
+  --exclude='./models/deploy.prototxt' \
+  . | tar -xf - -C "$dest"
 echo "synced backend -> $dest"

--- a/cli/internal/provision/arch.go
+++ b/cli/internal/provision/arch.go
@@ -1,0 +1,57 @@
+package provision
+
+import (
+	"debug/elf"
+	"debug/macho"
+	"debug/pe"
+	"runtime"
+)
+
+// nativeArch reports the GOARCH an executable was built for. ok is false when
+// the format is unrecognised (scripts, universal binaries), so callers can tell
+// "wrong arch" apart from "cannot tell".
+func nativeArch(path string) (arch string, ok bool) {
+	if f, err := macho.Open(path); err == nil {
+		defer f.Close()
+		switch f.Cpu {
+		case macho.CpuAmd64:
+			return "amd64", true
+		case macho.CpuArm64:
+			return "arm64", true
+		}
+		return "", false
+	}
+	if f, err := elf.Open(path); err == nil {
+		defer f.Close()
+		switch f.Machine {
+		case elf.EM_X86_64:
+			return "amd64", true
+		case elf.EM_AARCH64:
+			return "arm64", true
+		}
+		return "", false
+	}
+	if f, err := pe.Open(path); err == nil {
+		defer f.Close()
+		switch f.Machine {
+		case pe.IMAGE_FILE_MACHINE_AMD64:
+			return "amd64", true
+		case pe.IMAGE_FILE_MACHINE_ARM64:
+			return "arm64", true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+// nativeBin reports whether path exists and runs natively here. Existence alone
+// is not enough: a runtime provisioned by an earlier install can hold binaries
+// for the wrong arch, which run under emulation at best, and on macOS pin pip to
+// x86_64 wheels that upstream no longer publishes. Callers re-provision instead.
+func nativeBin(path string) bool {
+	if !have(path) {
+		return false
+	}
+	arch, ok := nativeArch(path)
+	return !ok || arch == runtime.GOARCH
+}

--- a/cli/internal/provision/arch_test.go
+++ b/cli/internal/provision/arch_test.go
@@ -1,0 +1,84 @@
+package provision
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// Cross-compiling a trivial program gives the test real Mach-O, ELF and PE
+// headers to read, rather than hand-rolled fixtures that could agree with a
+// broken parser.
+func buildFor(t *testing.T, goos, goarch string) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("go.mod", "module archprobe\n\ngo 1.21\n")
+	write("main.go", "package main\n\nfunc main() {}\n")
+
+	out := filepath.Join(dir, "probe")
+	cmd := exec.Command("go", "build", "-o", out, ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch, "CGO_ENABLED=0")
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("cannot cross-build %s/%s here: %v: %s", goos, goarch, err, b)
+	}
+	return out
+}
+
+func TestNativeArchIdentifiesEveryReleaseTarget(t *testing.T) {
+	for _, tc := range []struct{ goos, goarch string }{
+		{"darwin", "arm64"},
+		{"darwin", "amd64"},
+		{"linux", "amd64"},
+		{"linux", "arm64"},
+		{"windows", "amd64"},
+		{"windows", "arm64"},
+	} {
+		t.Run(tc.goos+"_"+tc.goarch, func(t *testing.T) {
+			got, ok := nativeArch(buildFor(t, tc.goos, tc.goarch))
+			if !ok || got != tc.goarch {
+				t.Fatalf("nativeArch = (%q, %v), want (%q, true)", got, ok, tc.goarch)
+			}
+		})
+	}
+}
+
+// The x86_64 Python that reached Apple Silicon users survived every setup and
+// update because provisioning only checked that the file existed.
+func TestNativeBinRejectsForeignArch(t *testing.T) {
+	foreign := "amd64"
+	if runtime.GOARCH == "amd64" {
+		foreign = "arm64"
+	}
+	if nativeBin(buildFor(t, runtime.GOOS, foreign)) {
+		t.Fatalf("nativeBin accepted a %s binary on %s", foreign, runtime.GOARCH)
+	}
+	if !nativeBin(buildFor(t, runtime.GOOS, runtime.GOARCH)) {
+		t.Fatal("nativeBin rejected a native binary")
+	}
+}
+
+// Scripts and universal binaries have no single arch to compare, and treating
+// "cannot tell" as a mismatch would wipe and re-download a working runtime.
+func TestNativeBinAllowsUnidentifiableFiles(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "script")
+	if err := os.WriteFile(p, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !nativeBin(p) {
+		t.Fatal("nativeBin should accept a format it cannot identify")
+	}
+}
+
+func TestNativeBinRejectsMissingFile(t *testing.T) {
+	if nativeBin(filepath.Join(t.TempDir(), "absent")) {
+		t.Fatal("nativeBin accepted a file that does not exist")
+	}
+}

--- a/cli/internal/provision/provision.go
+++ b/cli/internal/provision/provision.go
@@ -217,11 +217,30 @@ func downloadOnce(url, tmp, label string) (bool, error) {
 // zip-slip defense, since the path guard alone only validates the link's own
 // location, not where it points.
 func symlinkTargetInside(linkPath, linkname, root string) bool {
-	if filepath.IsAbs(linkname) {
+	if rootedAnywhere(linkname) {
 		return false
 	}
 	resolved := filepath.Clean(filepath.Join(filepath.Dir(linkPath), linkname))
 	return strings.HasPrefix(resolved+string(os.PathSeparator), root)
+}
+
+// rootedAnywhere reports whether p is rooted on any host, not merely this one.
+// Archive members carry POSIX paths while filepath.IsAbs answers for the running
+// OS: on Windows it calls "/etc/passwd" relative, so a rooted symlink target
+// would pass the guard and then resolve against the drive root.
+func rootedAnywhere(p string) bool {
+	if p == "" {
+		return false
+	}
+	if filepath.IsAbs(p) || p[0] == '/' || p[0] == '\\' {
+		return true
+	}
+	// "C:/x", and drive-relative "C:x", both leave the destination on Windows.
+	if len(p) >= 2 && p[1] == ':' {
+		c := p[0] | 0x20
+		return c >= 'a' && c <= 'z'
+	}
+	return false
 }
 
 // ParseChecksums parses sha256sum-style "<hex>  <name>" lines into a name->hash

--- a/cli/internal/provision/provision.go
+++ b/cli/internal/provision/provision.go
@@ -259,14 +259,11 @@ type ffArchive struct {
 	Bins []string
 }
 
-// Static ffmpeg sources are not yet pinned by checksum (upstream "latest" URLs);
-// they get our own pinned builds once podcli hosts releases.
+// Static ffmpeg sources are not yet pinned by checksum (upstream "latest" URLs).
+// darwin/arm64 is absent on purpose: evermeet.cx only builds x86_64, so Apple
+// Silicon is served by our own release asset (see releaseFFmpeg).
 var ffmpegSpecs = map[string][]ffArchive{
 	"darwin/amd64": {
-		{URL: "https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip", Bins: []string{"ffmpeg"}},
-		{URL: "https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip", Bins: []string{"ffprobe"}},
-	},
-	"darwin/arm64": {
 		{URL: "https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip", Bins: []string{"ffmpeg"}},
 		{URL: "https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip", Bins: []string{"ffprobe"}},
 	},
@@ -434,9 +431,10 @@ func verifyReleaseAsset(assets map[string]string, assetName, path string) error 
 
 func EnsureWhisperCpp() (string, error) {
 	bin := WhisperCLIBin()
-	if have(bin) {
+	if nativeBin(bin) {
 		return bin, nil
 	}
+	os.Remove(bin)
 	name := fmt.Sprintf("whisper-cli-%s-%s%s", runtime.GOOS, runtime.GOARCH, paths.ExeSuffix())
 	assets, err := latestReleaseAssets()
 	if err != nil {
@@ -465,18 +463,25 @@ func FFmpegBin() string {
 	return filepath.Join(paths.RuntimeDir(), "ffmpeg", "ffmpeg"+paths.ExeSuffix())
 }
 
+func FFprobeBin() string {
+	return filepath.Join(paths.RuntimeDir(), "ffmpeg", "ffprobe"+paths.ExeSuffix())
+}
+
 func EnsureFFmpeg() (string, error) {
 	bin := FFmpegBin()
-	if have(bin) {
+	if nativeBin(bin) && nativeBin(FFprobeBin()) {
 		return bin, nil
-	}
-	specs, ok := ffmpegSpecs[runtime.GOOS+"/"+runtime.GOARCH]
-	if !ok {
-		return "", fmt.Errorf("no ffmpeg build for %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
 	dir := filepath.Join(paths.RuntimeDir(), "ffmpeg")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
+	}
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		return bin, releaseFFmpeg()
+	}
+	specs, ok := ffmpegSpecs[runtime.GOOS+"/"+runtime.GOARCH]
+	if !ok {
+		return "", fmt.Errorf("no ffmpeg build for %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
 	for _, a := range specs {
 		sum := sha256.Sum256([]byte(a.URL))
@@ -494,6 +499,32 @@ func EnsureFFmpeg() (string, error) {
 		return "", fmt.Errorf("ffmpeg missing after extraction in %s", dir)
 	}
 	return bin, nil
+}
+
+// Apple Silicon builds ship with the release, checksum-verified like whisper-cli.
+// No upstream publishes an arm64 macOS static, so ffmpeg used to arrive as an
+// x86_64 binary that ran under Rosetta at roughly a third of native encode speed.
+func releaseFFmpeg() error {
+	assets, err := latestReleaseAssets()
+	if err != nil {
+		return err
+	}
+	for tool, bin := range map[string]string{"ffmpeg": FFmpegBin(), "ffprobe": FFprobeBin()} {
+		name := fmt.Sprintf("%s-%s-%s", tool, runtime.GOOS, runtime.GOARCH)
+		url, ok := assets[name]
+		if !ok {
+			return fmt.Errorf("asset %s not in latest release", name)
+		}
+		os.Remove(bin)
+		if err := fetch(url, bin, tool); err != nil {
+			return err
+		}
+		if err := verifyReleaseAsset(assets, name, bin); err != nil {
+			return err
+		}
+		os.Chmod(bin, 0o755)
+	}
+	return nil
 }
 
 func extractBins(archive string, bins []string, dest string) error {
@@ -611,7 +642,7 @@ func PythonBin() string {
 }
 
 func pythonHealthy(bin string) bool {
-	if !have(bin) {
+	if !nativeBin(bin) {
 		return false
 	}
 	root := pythonRoot(bin)

--- a/cli/internal/provision/provision.go
+++ b/cli/internal/provision/provision.go
@@ -522,7 +522,9 @@ func releaseFFmpeg() error {
 		if err := verifyReleaseAsset(assets, name, bin); err != nil {
 			return err
 		}
-		os.Chmod(bin, 0o755)
+		if err := os.Chmod(bin, 0o755); err != nil {
+			return fmt.Errorf("chmod %s: %w", bin, err)
+		}
 	}
 	return nil
 }

--- a/cli/internal/provision/security_test.go
+++ b/cli/internal/provision/security_test.go
@@ -40,6 +40,12 @@ func TestSymlinkTargetInside(t *testing.T) {
 		{"escape via dotdot", "/tmp/dest/link", "../../etc/passwd", false},
 		{"absolute", "/tmp/dest/link", "/etc/passwd", false},
 		{"deep escape", "/tmp/dest/a/b/link", "../../../outside", false},
+		// Rooted targets must be refused on every host, not just the ones where
+		// filepath.IsAbs happens to recognise them. On Windows it calls
+		// "/etc/passwd" relative, which used to let these through.
+		{"backslash rooted", "/tmp/dest/link", `\Windows\System32`, false},
+		{"drive absolute", "/tmp/dest/link", "C:/Windows/System32", false},
+		{"drive relative", "/tmp/dest/link", "C:evil", false},
 	}
 	for _, c := range cases {
 		if got := symlinkTargetInside(c.linkPath, c.linkname, root); got != c.ok {


### PR DESCRIPTION
Two bugs with the same root cause: provisioning trusted that a binary existed without ever checking it was built for this machine.

## 1. A wrong-arch runtime never self-heals

`pythonHealthy` checked only that the interpreter existed and had an `encodings` dir. So a runtime provisioned by an earlier install survived every `setup` and `update`, even with binaries for the wrong architecture. On Apple Silicon that left an **x86_64 CPython** in place, and pip then had no wheel to satisfy onnxruntime (upstream stopped publishing macOS x86_64 wheels after 1.23.x):

```
ERROR: Could not find a version that satisfies the requirement onnxruntime>=1.27.0
       (from versions: 1.17.0, ..., 1.23.2)
ERROR: No matching distribution found for onnxruntime>=1.27.0
podcli: could not install Python dependencies: exit status 1
```

`podcli setup` could not fix this: it skipped re-provisioning because the file was there.

## 2. ffmpeg is x86_64 on every Apple Silicon Mac

`ffmpegSpecs` gave `darwin/arm64` and `darwin/amd64` the **same evermeet.cx URL**, and evermeet only builds x86_64. Confirmed by downloading it on an arm64 Mac:

```
Mach-O 64-bit executable x86_64
```

So ffmpeg has been running under Rosetta for every M-series user. Measured on a representative clip encode (crop, scale, libx264, loudnorm), which is podcli's hot path:

| ffmpeg | time |
|---|---|
| x86_64 (Rosetta) | 22.0s |
| arm64 (native) | **8.1s** |

It also fails outright on a Mac without Rosetta installed.

## Fix

- **`nativeArch`** reads Mach-O/ELF/PE headers to report the arch a binary was actually built for. Provisioning re-fetches on a mismatch instead of trusting a file that merely exists. "Cannot tell" is deliberately **not** a mismatch, so scripts and universal binaries are left alone rather than triggering a needless re-download.
- **darwin/arm64 ffmpeg/ffprobe are built in CI and published as release assets**, checksum-verified via `checksums.txt` like `whisper-cli`. The job fails if the result is not arm64, or links anything outside `/usr/lib` and `/System`, so a Homebrew path can never be baked into a binary users run. x264 is built static-only for the same reason.

**Linux and Windows are untouched.** Their existing static sources already serve correct native per-arch binaries, so there was no reason to put working platforms at risk.

## Tests

`TestNativeArchIdentifiesEveryReleaseTarget` cross-compiles real binaries for darwin/linux/windows x amd64/arm64 and asserts each is identified correctly, so Mach-O, ELF **and PE** parsing are covered by real artifacts rather than fixtures. `TestNativeBinRejectsForeignArch` reproduces the bug above; `TestNativeBinAllowsUnidentifiableFiles` guards the opposite failure (wiping a working runtime we cannot classify).

`go test ./...`, `go vet`, `gofmt` all clean. The macOS build recipe was compiled and verified locally on arm64 (same as the `macos-14` runner) before being written into the workflow: ffmpeg 7.1, native arm64, no non-system dylibs.

## Note

`release` now needs `ffmpeg-darwin`, so a failed ffmpeg build blocks the release rather than publishing one whose assets the provisioner expects but cannot find. If the asset is missing anyway, `main.go` already degrades to PATH ffmpeg instead of crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native Apple Silicon support for bundled ffmpeg and ffprobe releases.
  - Added architecture checks to ensure downloaded tools match the device.
  - Added checksum verification for release assets.

- **Bug Fixes**
  - Prevented incompatible or invalid ffmpeg, ffprobe, Whisper, and Python binaries from being reused.
  - Improved handling of missing or non-native binaries during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->