### PR TITLE
Stop the macOS ffmpeg build absorbing the runner's Homebrew libraries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,8 +127,16 @@ jobs:
           # unverified tarball would compile straight into a release asset.
           echo "${FFMPEG_SHA256}  ffmpeg.tar.xz" | shasum -a 256 -c -
           tar xf ffmpeg.tar.xz && cd "ffmpeg-${FFMPEG_VERSION}"
+          # --disable-autodetect, then opt in by name. Without it configure absorbs
+          # whatever happens to sit on the build machine: the runner has Homebrew
+          # X11/xcb, so ffmpeg linked /opt/homebrew dylibs and would not have run
+          # on a user's Mac. VideoToolbox has to come back explicitly — encoder.py
+          # picks h264_videotoolbox on macOS, and losing it would cost more than
+          # Rosetta ever did.
           PKG_CONFIG_PATH="$deps/lib/pkgconfig" ./configure \
+            --disable-autodetect \
             --enable-gpl --enable-libx264 \
+            --enable-videotoolbox --enable-audiotoolbox --enable-zlib \
             --pkg-config-flags=--static \
             --extra-cflags="-I$deps/include" --extra-ldflags="-L$deps/lib" \
             --disable-shared --enable-static \
@@ -149,7 +157,13 @@ jobs:
               echo "$b links a non-system library:"; otool -L "$b"; exit 1
             fi
           done
-          ./ffmpeg-darwin-arm64 -hide_banner -encoders | grep -q libx264
+          # h264_videotoolbox is what encoder.py reaches for on macOS. A build that
+          # quietly lost it would fall back to libx264 and be slower than the
+          # Rosetta binary this job exists to replace, so treat its absence as a
+          # failed build rather than a working one.
+          for enc in libx264 h264_videotoolbox; do
+            ./ffmpeg-darwin-arm64 -hide_banner -encoders | grep -q "$enc" || { echo "missing encoder: $enc"; exit 1; }
+          done
       - uses: actions/upload-artifact@v7
         with:
           name: ffmpeg-darwin-arm64


### PR DESCRIPTION
The first tagged run of `ffmpeg-darwin` (v2.4.6) **failed its own verify step**, and the gate worked exactly as intended: `release` was skipped, so nothing was published and v2.4.5 remains latest.

## What went wrong

ffmpeg's configure autodetects optional libraries. The `macos-14` runner has Homebrew X11/xcb installed, so the build linked them:

```
/opt/homebrew/opt/libxcb/lib/libxcb.1.dylib
/opt/homebrew/opt/libx11/lib/libX11.6.dylib
/opt/homebrew/opt/libxau/lib/libXau.6.dylib
/opt/homebrew/opt/libxdmcp/lib/libXdmcp.6.dylib
```

That binary would have failed on any user's Mac without Homebrew. It never reached one, because the verify step rejects anything linking outside `/usr/lib` and `/System`. My local build didn't reproduce it: my machine has no Homebrew libxcb, so configure never saw it.

## Fix

`--disable-autodetect`, then opt in by name, so the output no longer depends on what happens to be installed on the build machine.

**VideoToolbox is re-enabled explicitly, and this is the important part.** `--disable-autodetect` also turns off VideoToolbox, and `backend/services/encoder.py:34` picks `h264_videotoolbox` on macOS. A build that quietly lost it would fall back to `libx264` and be **slower than the Rosetta binary this job exists to replace** — trading a 2.7x win for a regression, silently. So verify now fails outright if the encoder is absent.

## Verified locally on arm64, with the exact flags

| Check | Result |
|---|---|
| `lipo -archs` | `arm64` |
| Homebrew dylibs | **0** |
| Non-system links | **none** |
| `h264_videotoolbox` | present |
| `libx264`, `loudnorm`, `xfade` | present |

Next release will be tagged v2.4.7; the v2.4.6 tag is orphaned with no release attached, which is harmless since installers and self-update resolve the latest *release*, not tags.