### PR TITLE
Verify every download, honor proxies, and stop uninstall deleting user data

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -7,13 +7,16 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"podcli/internal/paths"
 )
 
 type Config struct {
 	Update struct {
-		Auto *bool `json:"auto,omitempty"`
+		Auto      *bool  `json:"auto,omitempty"`
+		Latest    string `json:"latest,omitempty"`
+		CheckedAt string `json:"checkedAt,omitempty"`
 	} `json:"update"`
 }
 
@@ -50,6 +53,27 @@ func AutoUpdate() bool {
 		return *a
 	}
 	return true
+}
+
+// CachedUpdateCheck returns the last seen release tag when the check is fresher
+// than maxAge, so routine commands skip the network round-trip.
+func CachedUpdateCheck(maxAge time.Duration) (string, bool) {
+	c := Load()
+	if c.Update.Latest == "" || c.Update.CheckedAt == "" {
+		return "", false
+	}
+	at, err := time.Parse(time.RFC3339, c.Update.CheckedAt)
+	if err != nil || time.Since(at) > maxAge {
+		return "", false
+	}
+	return c.Update.Latest, true
+}
+
+func RecordUpdateCheck(latest string) {
+	c := Load()
+	c.Update.Latest = latest
+	c.Update.CheckedAt = time.Now().UTC().Format(time.RFC3339)
+	c.Save()
 }
 
 func Get(key string) (string, error) {

--- a/cli/internal/podstack/podstack.go
+++ b/cli/internal/podstack/podstack.go
@@ -15,6 +15,8 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+
+	"podcli/internal/paths"
 )
 
 //go:generate sh sync.sh
@@ -54,6 +56,23 @@ func IsCommand(name string) bool {
 		}
 	}
 	return false
+}
+
+// warnEmptyKnowledge nudges toward `podcli knowledge init` before a workflow
+// runs against a blank knowledge base. README.md does not count: the studio
+// writes one into the knowledge dir, and it carries no show context.
+func warnEmptyKnowledge() {
+	kb := filepath.Join(paths.Home(), "knowledge")
+	entries, err := os.ReadDir(kb)
+	if err == nil {
+		for _, e := range entries {
+			name := e.Name()
+			if strings.HasSuffix(name, ".md") && !strings.EqualFold(name, "README.md") {
+				return
+			}
+		}
+	}
+	fmt.Fprintf(os.Stderr, "  %sKnowledge base is empty.%s Run %spodcli knowledge init%s first, or %s/bootstrap-knowledge%s in your agent, so the workflow knows your show.\n", colYellow, colReset, colAccent, colReset, colAccent, colReset)
 }
 
 // installCommands writes the embedded slash-command files into
@@ -121,6 +140,7 @@ func Run(cmd string, args []string) int {
 	if err := installCommands(project); err != nil {
 		fmt.Fprintf(os.Stderr, "  %swarning:%s could not install slash commands: %v\n", colYellow, colReset, err)
 	}
+	warnEmptyKnowledge()
 
 	prompt := "/" + cmd
 	if len(promptArgs) > 0 {

--- a/cli/internal/provision/download_test.go
+++ b/cli/internal/provision/download_test.go
@@ -1,6 +1,7 @@
 package provision
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -16,6 +18,61 @@ func TestDownloadRequiresPinnedChecksum(t *testing.T) {
 	err := download("https://example.invalid/x", filepath.Join(t.TempDir(), "x"), "", "x")
 	if err == nil || !strings.Contains(err.Error(), "no pinned checksum") {
 		t.Fatalf("download with empty checksum should hard-error, got %v", err)
+	}
+}
+
+func TestDownloadReplacesExistingChecksumMismatch(t *testing.T) {
+	payload := []byte("verified payload")
+	want := fmt.Sprintf("%x", sha256.Sum256(payload))
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Write(payload)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "model.bin")
+	if err := os.WriteFile(dest, []byte("unverified payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := download(srv.URL, dest, want, "model"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("download retained existing payload: %q", got)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("replacement download hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestArtifactStateRequiresMatchingKeyAndContents(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "tool")
+	if err := os.WriteFile(bin, []byte("verified"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if artifactAt(dir, "release-a", bin) {
+		t.Fatal("artifact without verification state was trusted")
+	}
+	if err := writeArtifactState(dir, "release-a", bin); err != nil {
+		t.Fatal(err)
+	}
+	if !artifactAt(dir, "release-a", bin) {
+		t.Fatal("matching verified artifact was rejected")
+	}
+	if artifactAt(dir, "release-b", bin) {
+		t.Fatal("artifact verified for an older release was trusted")
+	}
+	if err := os.WriteFile(bin, []byte("mutated"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if artifactAt(dir, "release-a", bin) {
+		t.Fatal("mutated artifact was trusted")
 	}
 }
 

--- a/cli/internal/provision/download_test.go
+++ b/cli/internal/provision/download_test.go
@@ -1,0 +1,177 @@
+package provision
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDownloadRequiresPinnedChecksum(t *testing.T) {
+	err := download("https://example.invalid/x", filepath.Join(t.TempDir(), "x"), "", "x")
+	if err == nil || !strings.Contains(err.Error(), "no pinned checksum") {
+		t.Fatalf("download with empty checksum should hard-error, got %v", err)
+	}
+}
+
+func TestAllModelsPinned(t *testing.T) {
+	for size, m := range models {
+		if len(m.SHA256) != 64 {
+			t.Errorf("model %s has no pinned sha256", size)
+		}
+	}
+}
+
+func TestFFmpegSpecsPinnedAndVersioned(t *testing.T) {
+	for platform, specs := range ffmpegSpecs {
+		for _, a := range specs {
+			if len(a.SHA256) != 64 {
+				t.Errorf("%s: %s has no pinned sha256", platform, a.URL)
+			}
+			for _, mutable := range []string{"latest", "getrelease", "ffmpeg-release-"} {
+				if strings.Contains(a.URL, mutable) {
+					t.Errorf("%s: %s is a mutable URL (%q)", platform, a.URL, mutable)
+				}
+			}
+		}
+	}
+}
+
+func TestVerifyDownloadFailsClosed(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "a.bin")
+	if err := os.WriteFile(archive, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	missing := httptest.NewServer(http.NotFoundHandler())
+	defer missing.Close()
+	if err := verifyDownload(archive, missing.URL, "a.bin"); err == nil {
+		t.Fatal("missing checksums manifest should fail closed")
+	}
+
+	noEntry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "abc123  other.bin")
+	}))
+	defer noEntry.Close()
+	if err := verifyDownload(archive, noEntry.URL, "a.bin"); err == nil {
+		t.Fatal("missing checksum entry should fail closed")
+	}
+}
+
+func TestVerifyReleaseAssetFailsClosedWithoutManifest(t *testing.T) {
+	err := verifyReleaseAsset(map[string]string{}, "whisper-cli-linux-amd64", "/nonexistent")
+	if err == nil || !strings.Contains(err.Error(), "checksums.txt") {
+		t.Fatalf("release without checksums.txt should fail closed, got %v", err)
+	}
+}
+
+func TestAcquireLockReleaseAndStaleTakeover(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "artifact")
+	unlock, err := acquireLock(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(dest + ".lock"); err != nil {
+		t.Fatalf("lock file missing while held: %v", err)
+	}
+	unlock()
+	if _, err := os.Stat(dest + ".lock"); !os.IsNotExist(err) {
+		t.Fatalf("lock file should be gone after release, got %v", err)
+	}
+
+	if err := os.WriteFile(dest+".lock", []byte("999999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stale := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(dest+".lock", stale, stale); err != nil {
+		t.Fatal(err)
+	}
+	unlock, err = acquireLock(dest)
+	if err != nil {
+		t.Fatalf("stale lock should be taken over, got %v", err)
+	}
+	unlock()
+}
+
+func TestDownloadOnceSendsIfRangeAndRestartsOnChange(t *testing.T) {
+	var gotIfRange, gotRange string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIfRange = r.Header.Get("If-Range")
+		gotRange = r.Header.Get("Range")
+		w.Header().Set("ETag", `"v2"`)
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "FRESH")
+	}))
+	defer srv.Close()
+
+	tmp := filepath.Join(t.TempDir(), "f.part")
+	if err := os.WriteFile(tmp, []byte("OLDDATA"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(validatorPath(tmp), []byte(`"v1"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	done, err := downloadOnce(srv.URL, tmp, "test", downloadHTTPClient())
+	if err != nil || !done {
+		t.Fatalf("downloadOnce = %v, %v", done, err)
+	}
+	if gotRange == "" {
+		t.Fatal("resume should send Range")
+	}
+	if gotIfRange != `"v1"` {
+		t.Fatalf("If-Range = %q, want stored validator", gotIfRange)
+	}
+	b, _ := os.ReadFile(tmp)
+	if string(b) != "FRESH" {
+		t.Fatalf("full response should truncate stale part file, got %q", b)
+	}
+	v, _ := os.ReadFile(validatorPath(tmp))
+	if string(v) != `"v2"` {
+		t.Fatalf("validator = %q, want new ETag", v)
+	}
+}
+
+func TestStallGuardAbortsIdleBody(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	g := newStallGuard(pr, 50*time.Millisecond)
+	defer g.stop()
+
+	_, err := g.Read(make([]byte, 1))
+	if err == nil || !strings.Contains(err.Error(), "stalled") {
+		t.Fatalf("idle body should surface a stall error, got %v", err)
+	}
+}
+
+func TestGithubAPIGetRateLimitAndToken(t *testing.T) {
+	limited := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer limited.Close()
+	_, err := githubAPIGet(limited.URL)
+	if err == nil || !strings.Contains(err.Error(), "GITHUB_TOKEN") {
+		t.Fatalf("403 should report the rate limit and suggest GITHUB_TOKEN, got %v", err)
+	}
+
+	var auth string
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		io.WriteString(w, "{}")
+	}))
+	defer ok.Close()
+	t.Setenv("GITHUB_TOKEN", "tok123")
+	resp, err := githubAPIGet(ok.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if auth != "Bearer tok123" {
+		t.Fatalf("Authorization = %q, want bearer token", auth)
+	}
+}

--- a/cli/internal/provision/lock_test.go
+++ b/cli/internal/provision/lock_test.go
@@ -1,0 +1,172 @@
+package provision
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A loaded CI runner can starve the heartbeat goroutine for tens of
+// milliseconds, so keep the stale window far larger than the heartbeat rather
+// than scaling both down together: a tight ratio makes a healthy lock look
+// abandoned, which is the very thing these tests are meant to catch.
+func shortLockTimings(t *testing.T, wait, stale time.Duration) {
+	heartbeat, prevStale, poll, prevWait := lockHeartbeat, lockStale, lockPoll, lockWait
+	t.Cleanup(func() { lockHeartbeat, lockStale, lockPoll, lockWait = heartbeat, prevStale, poll, prevWait })
+	lockHeartbeat, lockStale, lockPoll, lockWait = 20*time.Millisecond, stale, 5*time.Millisecond, wait
+}
+
+func TestHeldLockIsNotStolenAfterStaleWindow(t *testing.T) {
+	shortLockTimings(t, 400*time.Millisecond, 500*time.Millisecond)
+	dest := filepath.Join(t.TempDir(), "artifact")
+	lock := dest + ".lock"
+
+	unlock, err := acquireLock(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(5 * lockStale)
+
+	if dropStaleLock(lock) {
+		t.Fatal("a heartbeated lock was treated as abandoned")
+	}
+	if _, err := os.Stat(lock); err != nil {
+		t.Fatalf("lock file gone while held: %v", err)
+	}
+	if _, err := acquireLock(dest); err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("second process should wait out a live lock, got %v", err)
+	}
+
+	unlock()
+	unlock2, err := acquireLock(dest)
+	if err != nil {
+		t.Fatalf("lock should be free after release, got %v", err)
+	}
+	unlock2()
+}
+
+func TestStaleLockTakeoverIsExclusive(t *testing.T) {
+	// Stale window well past the hold time, so a winner's lock is fresh on its
+	// own creation stamp and exclusivity does not hinge on heartbeat scheduling.
+	shortLockTimings(t, 10*time.Second, 3*time.Second)
+	dest := filepath.Join(t.TempDir(), "artifact")
+	lock := dest + ".lock"
+	if err := os.WriteFile(lock, []byte("999999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stale := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(lock, stale, stale); err != nil {
+		t.Fatal(err)
+	}
+
+	var live, maxLive, failures atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			unlock, err := acquireLock(dest)
+			if err != nil {
+				failures.Add(1)
+				return
+			}
+			defer unlock()
+			n := live.Add(1)
+			for {
+				m := maxLive.Load()
+				if n <= m || maxLive.CompareAndSwap(m, n) {
+					break
+				}
+			}
+			time.Sleep(20 * time.Millisecond)
+			live.Add(-1)
+		}()
+	}
+	wg.Wait()
+
+	if got := maxLive.Load(); got != 1 {
+		t.Fatalf("%d processes held the lock at once; the stale takeover is not exclusive", got)
+	}
+	if got := failures.Load(); got != 0 {
+		t.Fatalf("%d waiters never acquired the lock", got)
+	}
+	if _, err := os.Stat(lock); !os.IsNotExist(err) {
+		t.Fatalf("lock file should be gone after the last release, got %v", err)
+	}
+	if _, err := os.Stat(lock + ".takeover"); !os.IsNotExist(err) {
+		t.Fatalf("takeover token should not outlive the takeover, got %v", err)
+	}
+}
+
+func TestDownloadPathIsUniquePerURL(t *testing.T) {
+	t.Setenv("PODCLI_HOME", t.TempDir())
+	const name = "studio-bundle.tar.gz"
+	v1, err := downloadPath("https://github.com/o/r/releases/download/v2.4.7/"+name, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2, err := downloadPath("https://github.com/o/r/releases/download/v2.4.8/"+name, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v1 == v2 {
+		t.Fatal("an archive cached for one release must not be reused for the next")
+	}
+	if !strings.HasSuffix(v1, name) || !strings.HasSuffix(v2, name) {
+		t.Fatalf("archive names should stay recognizable: %s / %s", v1, v2)
+	}
+	if filepath.Dir(v1) != filepath.Dir(v2) {
+		t.Fatalf("archives should share the downloads dir: %s / %s", v1, v2)
+	}
+}
+
+func TestFetchClearsResumeSidecarsWhenDestExists(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "archive.tar.gz")
+	for _, f := range []string{dest, dest + ".part", validatorPath(dest + ".part")} {
+		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("fetch hit the network for an artifact already on disk")
+	}))
+	defer srv.Close()
+
+	if err := fetch(srv.URL, dest, "archive", downloadHTTPClient()); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{dest + ".part", validatorPath(dest + ".part"), dest + ".lock"} {
+		if _, err := os.Stat(f); !os.IsNotExist(err) {
+			t.Errorf("%s should not survive a completed fetch", filepath.Base(f))
+		}
+	}
+}
+
+func TestFetchRefusesUntrustedRedirectWithoutRetrying(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		http.Redirect(w, r, "https://attacker.example/payload", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "artifact")
+	err := fetch(srv.URL, dest, "artifact", downloadHTTPClient())
+	if err == nil || !strings.Contains(err.Error(), "untrusted host") {
+		t.Fatalf("redirect off the allowlist should fail, got %v", err)
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("a refused redirect is permanent, but it was retried %d times", hits.Load())
+	}
+	if have(dest) {
+		t.Fatal("nothing should be written for a refused download")
+	}
+}

--- a/cli/internal/provision/lock_test.go
+++ b/cli/internal/provision/lock_test.go
@@ -51,6 +51,73 @@ func TestHeldLockIsNotStolenAfterStaleWindow(t *testing.T) {
 	unlock2()
 }
 
+func TestSupersededOwnerCannotHeartbeatOrReleaseReplacement(t *testing.T) {
+	shortLockTimings(t, 400*time.Millisecond, 500*time.Millisecond)
+	dest := filepath.Join(t.TempDir(), "artifact")
+	lock := dest + ".lock"
+
+	unlock, err := acquireLock(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(lock); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lock, []byte("replacement-owner"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	replacementTime := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(lock, replacementTime, replacementTime); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(3 * lockHeartbeat)
+	info, err := os.Stat(lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(replacementTime) {
+		t.Fatalf("superseded owner heartbeated replacement lock: got %v want %v", info.ModTime(), replacementTime)
+	}
+	unlock()
+	got, err := os.ReadFile(lock)
+	if err != nil {
+		t.Fatalf("superseded owner removed replacement lock: %v", err)
+	}
+	if string(got) != "replacement-owner" {
+		t.Fatalf("replacement ownership changed to %q", got)
+	}
+}
+
+func TestLockOwnersReceiveUniqueTokens(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "artifact")
+	lock := dest + ".lock"
+
+	unlock, err := acquireLock(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.ReadFile(lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unlock()
+
+	unlock, err = acquireLock(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unlock()
+
+	if string(first) == string(second) {
+		t.Fatalf("lock ownership token was reused: %q", first)
+	}
+}
+
 func TestStaleLockTakeoverIsExclusive(t *testing.T) {
 	// Stale window well past the hold time, so a winner's lock is fresh on its
 	// own creation stamp and exclusivity does not hinge on heartbeat scheduling.

--- a/cli/internal/provision/offline_test.go
+++ b/cli/internal/provision/offline_test.go
@@ -1,0 +1,113 @@
+package provision
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+)
+
+func writeHealthyPython(t *testing.T) string {
+	t.Helper()
+	bin := PythonBin()
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("python"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	encodings := filepath.Join(pythonRoot(bin), "lib", "python3.12", "encodings", "__init__.py")
+	if runtime.GOOS == "windows" {
+		encodings = filepath.Join(pythonRoot(bin), "Lib", "encodings", "__init__.py")
+	}
+	if err := os.MkdirAll(filepath.Dir(encodings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(encodings, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+// An installed runtime must not depend on the network. Resolving the upstream release
+// on every run made podcli unusable offline, spent a rate-limited GitHub API call per
+// invocation, and re-provisioned whenever upstream published a new build.
+func TestEnsurePythonSkipsNetworkForInstalledRuntime(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Cleanup(func(orig string) func() {
+		return func() { pythonReleasesAPI = orig }
+	}(pythonReleasesAPI))
+	pythonReleasesAPI = srv.URL
+
+	t.Setenv("PODCLI_HOME", t.TempDir())
+	bin := writeHealthyPython(t)
+
+	// A runtime installed before artifact state existed is adopted, not re-downloaded.
+	if _, err := EnsurePython(""); err != nil {
+		t.Fatalf("installed runtime should not need the network: %v", err)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("release API called %d times for an installed runtime, want 0", got)
+	}
+
+	// And again, now that state is recorded.
+	if _, err := EnsurePython(""); err != nil {
+		t.Fatalf("second run should not need the network: %v", err)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("release API called %d times on re-run, want 0", got)
+	}
+
+	// A swapped binary is still rejected: the local check verifies content, it does not
+	// merely note the file exists.
+	if err := os.WriteFile(bin, []byte("tampered"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnsurePython(""); err == nil {
+		t.Fatal("tampered python runtime was trusted")
+	}
+	if hits.Load() == 0 {
+		t.Fatal("tampered python runtime did not trigger re-provisioning")
+	}
+}
+
+// `podcli setup` is the one path that may re-provision, so it is the one path that
+// still asks upstream what the current build is.
+func TestSetupStillVerifiesAgainstUpstream(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Cleanup(func(orig string) func() {
+		return func() { pythonReleasesAPI = orig }
+	}(pythonReleasesAPI))
+	pythonReleasesAPI = srv.URL
+
+	t.Setenv("PODCLI_HOME", t.TempDir())
+	writeHealthyPython(t)
+	if _, err := EnsurePython(""); err != nil {
+		t.Fatal(err)
+	}
+	if hits.Load() != 0 {
+		t.Fatal("baseline run should not have hit the network")
+	}
+
+	VerifyRemote = true
+	t.Cleanup(func() { VerifyRemote = false })
+	if _, err := EnsurePython(""); err == nil {
+		t.Fatal("setup should surface the upstream lookup failure")
+	}
+	if hits.Load() == 0 {
+		t.Fatal("setup did not re-verify against upstream")
+	}
+}

--- a/cli/internal/provision/provision.go
+++ b/cli/internal/provision/provision.go
@@ -211,13 +211,16 @@ func acquireLock(dest string) (func(), error) {
 				os.Remove(lock)
 				return nil, err
 			}
+			if err := f.Close(); err != nil {
+				os.Remove(lock)
+				return nil, err
+			}
 			if _, err := os.Stat(lock + ".takeover"); err == nil {
-				f.Close()
 				removeOwnedLock(lock, token)
 				time.Sleep(lockPoll)
 				continue
 			}
-			return holdLock(lock, token, f), nil
+			return holdLock(lock, token), nil
 		}
 		if os.IsExist(err) {
 			transient = 0
@@ -241,7 +244,7 @@ func acquireLock(dest string) (func(), error) {
 }
 
 // holdLock keeps the lock's mtime fresh until the returned unlock runs.
-func holdLock(lock, token string, f *os.File) func() {
+func holdLock(lock, token string) func() {
 	done := make(chan struct{})
 	stopped := make(chan struct{})
 	go func() {
@@ -251,7 +254,25 @@ func holdLock(lock, token string, f *os.File) func() {
 		for {
 			select {
 			case <-t.C:
-				f.WriteAt([]byte(token), 0)
+				f, err := os.OpenFile(lock, os.O_RDWR, 0)
+				if err != nil {
+					return
+				}
+				owner := make([]byte, len(token))
+				n, readErr := f.ReadAt(owner, 0)
+				if readErr != nil && readErr != io.EOF {
+					f.Close()
+					return
+				}
+				if string(owner[:n]) != token {
+					f.Close()
+					return
+				}
+				if _, err := f.WriteAt([]byte(token), 0); err != nil {
+					f.Close()
+					return
+				}
+				f.Close()
 			case <-done:
 				return
 			}
@@ -262,7 +283,6 @@ func holdLock(lock, token string, f *os.File) func() {
 		once.Do(func() {
 			close(done)
 			<-stopped
-			f.Close()
 			removeOwnedLock(lock, token)
 		})
 	}

--- a/cli/internal/provision/provision.go
+++ b/cli/internal/provision/provision.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"podcli/internal/paths"
@@ -23,7 +26,7 @@ import (
 
 type model struct {
 	URL    string
-	SHA256 string // empty: verification skipped
+	SHA256 string
 }
 
 var models = map[string]model{
@@ -32,10 +35,12 @@ var models = map[string]model{
 		SHA256: "60ed5bc3dd14eea856493d334349b405782ddcaf0028d4b5df4088345fba2efe",
 	},
 	"tiny.en": {
-		URL: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en.bin",
+		URL:    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en.bin",
+		SHA256: "921e4cf8686fdd993dcd081a5da5b6c365bfde1162e72b08d75ac75289920b1f",
 	},
 	"small": {
-		URL: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin",
+		URL:    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin",
+		SHA256: "1be3a9b2063867b937e64e2ec7483364a79917e157fa98c5d94b5c1fffea987b",
 	},
 }
 
@@ -85,19 +90,48 @@ func EnsureVADModel() (string, error) {
 
 const maxAttempts = 6
 
+// Fetch downloads url into dest with resume, progress, and stall detection.
+// Exported so self-update reuses the same download path.
+func Fetch(url, dest, label string) error { return fetch(url, dest, label, downloadHTTPClient()) }
+
+// FetchGuarded is Fetch with a caller-supplied redirect allowlist. Self-update
+// passes its GitHub-only allowlist: provisioning also trusts the model and
+// ffmpeg CDNs, and the podcli binary must not be redirectable to any of them.
+func FetchGuarded(url, dest, label string, allowHost func(string) bool) error {
+	return fetch(url, dest, label, guardedHTTPClient(allowHost, 60*time.Second))
+}
+
 // fetch resumes via HTTP Range across transient stalls rather than restarting,
-// writing to dest atomically.
-func fetch(url, dest, label string) error {
+// writing to dest atomically. A per-destination lock file serializes concurrent
+// podcli processes so they don't append to the same .part file.
+func fetch(url, dest, label string, client *http.Client) error {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 		return err
 	}
+	unlock, err := acquireLock(dest)
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	tmp := dest + ".part"
+	if have(dest) {
+		// Another process finished it while we waited; its .part is gone, but a
+		// resume file from an earlier interrupted attempt may still sit here.
+		os.Remove(tmp)
+		os.Remove(validatorPath(tmp))
+		return nil
+	}
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		done, err := downloadOnce(url, tmp, label)
+		done, err := downloadOnce(url, tmp, label, client)
 		if err == nil && done {
 			lastErr = nil
 			break
+		}
+		if errors.Is(err, ErrUntrustedRedirect) {
+			os.Remove(tmp)
+			os.Remove(validatorPath(tmp))
+			return err
 		}
 		lastErr = err
 		fmt.Fprintf(os.Stderr, "\n  %s interrupted (attempt %d/%d): %v - resuming\n", label, attempt, maxAttempts, err)
@@ -105,18 +139,137 @@ func fetch(url, dest, label string) error {
 	}
 	if lastErr != nil {
 		os.Remove(tmp)
+		os.Remove(validatorPath(tmp))
 		return lastErr
 	}
+	os.Remove(validatorPath(tmp))
 	return os.Rename(tmp, dest)
 }
 
-func download(url, dest, wantSHA, label string) error {
-	if err := fetch(url, dest, label); err != nil {
-		return err
+// downloadPath places transient archives inside the managed dir rather than the
+// world-shared temp dir, where a predictable name could be pre-planted by
+// another local user. The dir persists across runs, so name derives from the
+// source URL: a completed archive is only reused for the exact release it came
+// from, never for the next one published under the same asset name.
+func downloadPath(url, name string) (string, error) {
+	dir := filepath.Join(paths.RuntimeDir(), "downloads")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
 	}
+	sum := sha256.Sum256([]byte(url))
+	return filepath.Join(dir, "podcli-"+hex.EncodeToString(sum[:8])+"-"+name), nil
+}
+
+// removeArchive drops an extracted archive and the sidecars fetch leaves beside
+// it. The downloads dir is persistent, so anything left there outlives the
+// release it belongs to.
+func removeArchive(path string) {
+	os.Remove(path)
+	os.Remove(path + ".part")
+	os.Remove(validatorPath(path + ".part"))
+}
+
+var (
+	lockHeartbeat = 20 * time.Second
+	lockStale     = 2 * time.Minute
+	lockPoll      = time.Second
+	lockWait      = 30 * time.Minute
+	// A sharing violation on Windows clears as soon as the pending delete
+	// completes; anything that outlasts this many polls is a real error.
+	lockTransientRetries = 10
+)
+
+// acquireLock serializes provisioning of one artifact across processes via an
+// O_EXCL sentinel. The holder heartbeats the lock while it works, so a healthy
+// but slow download (ggml-small.bin on a thin link) is never mistaken for a
+// crashed one and stolen mid-flight.
+func acquireLock(dest string) (func(), error) {
+	lock := dest + ".lock"
+	deadline := time.Now().Add(lockWait)
+	transient := 0
+	for {
+		f, err := os.OpenFile(lock, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if err == nil {
+			fmt.Fprintf(f, "%d", os.Getpid())
+			f.Close()
+			return holdLock(lock), nil
+		}
+		if os.IsExist(err) {
+			transient = 0
+			if dropStaleLock(lock) {
+				continue
+			}
+		} else {
+			// Windows reports a sharing violation rather than "already exists"
+			// while another process's delete of the lock is still pending, so a
+			// racing acquirer must retry instead of treating it as fatal.
+			transient++
+			if transient > lockTransientRetries {
+				return nil, err
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for %s (another podcli may be provisioning; delete the file if not)", lock)
+		}
+		time.Sleep(lockPoll)
+	}
+}
+
+// holdLock keeps the lock's mtime fresh until the returned unlock runs.
+func holdLock(lock string) func() {
+	done := make(chan struct{})
+	go func() {
+		t := time.NewTicker(lockHeartbeat)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				now := time.Now()
+				os.Chtimes(lock, now, now)
+			case <-done:
+				return
+			}
+		}
+	}()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			close(done)
+			os.Remove(lock)
+		})
+	}
+}
+
+// dropStaleLock removes a lock whose holder stopped heartbeating, reporting
+// whether it did. Removal is itself serialized by an O_EXCL takeover token:
+// otherwise two processes seeing the same stale lock both remove and recreate
+// it, the second deleting the first's fresh lock, and both then append to the
+// same .part file.
+func dropStaleLock(lock string) bool {
+	token := lock + ".takeover"
+	if fi, err := os.Stat(token); err == nil && time.Since(fi.ModTime()) > lockStale {
+		os.Remove(token) // a process died mid-takeover; retry the takeover next pass
+		return false
+	}
+	f, err := os.OpenFile(token, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return false // another process is taking over; wait for its lock instead
+	}
+	f.Close()
+	defer os.Remove(token)
+	fi, err := os.Stat(lock)
+	if err != nil || time.Since(fi.ModTime()) <= lockStale {
+		return false
+	}
+	return os.Remove(lock) == nil
+}
+
+func download(url, dest, wantSHA, label string) error {
 	if wantSHA == "" {
-		fmt.Fprintf(os.Stderr, "  (no pinned checksum for %s - skipped verification)\n", label)
-		return nil
+		return fmt.Errorf("no pinned checksum for %s - refusing unverified download", label)
+	}
+	if err := fetch(url, dest, label, downloadHTTPClient()); err != nil {
+		return err
 	}
 	got, err := sha256file(dest)
 	if err != nil {
@@ -130,19 +283,16 @@ func download(url, dest, wantSHA, label string) error {
 }
 
 // verifyDownload checks a downloaded archive against an upstream sha256sum-style
-// manifest. Fails closed on a mismatch (removes the file); fails open with a
-// warning when the manifest or its entry can't be fetched, so a transient
-// network issue on the sums file doesn't block provisioning.
+// manifest. Fails closed: a manifest that can't be fetched or has no entry for
+// the asset means the download cannot be trusted.
 func verifyDownload(archive, sumsURL, name string) error {
 	resp, err := downloadHTTPClient().Get(sumsURL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "  (could not fetch checksums for %s - skipped verification)\n", name)
-		return nil
+		return fmt.Errorf("cannot verify %s: fetching checksums failed: %w", name, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		fmt.Fprintf(os.Stderr, "  (no checksums for %s - skipped verification)\n", name)
-		return nil
+		return fmt.Errorf("cannot verify %s: HTTP %d fetching checksums", name, resp.StatusCode)
 	}
 	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
 	if err != nil {
@@ -150,8 +300,7 @@ func verifyDownload(archive, sumsURL, name string) error {
 	}
 	want := ParseChecksums(data)[name]
 	if want == "" {
-		fmt.Fprintf(os.Stderr, "  (no checksum entry for %s - skipped verification)\n", name)
-		return nil
+		return fmt.Errorf("cannot verify %s: no entry in upstream checksums", name)
 	}
 	got, err := sha256file(archive)
 	if err != nil {
@@ -164,7 +313,9 @@ func verifyDownload(archive, sumsURL, name string) error {
 	return nil
 }
 
-func downloadOnce(url, tmp, label string) (bool, error) {
+func validatorPath(tmp string) string { return tmp + ".validator" }
+
+func downloadOnce(url, tmp, label string, client *http.Client) (bool, error) {
 	var start int64
 	if fi, err := os.Stat(tmp); err == nil {
 		start = fi.Size()
@@ -176,8 +327,13 @@ func downloadOnce(url, tmp, label string) (bool, error) {
 	}
 	if start > 0 {
 		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", start))
+		// If-Range makes the server ignore Range when the file changed upstream,
+		// so a resumed .part can't end up stitched from two different builds.
+		if v, err := os.ReadFile(validatorPath(tmp)); err == nil && len(v) > 0 {
+			req.Header.Set("If-Range", strings.TrimSpace(string(v)))
+		}
 	}
-	resp, err := downloadHTTPClient().Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -187,9 +343,16 @@ func downloadOnce(url, tmp, label string) (bool, error) {
 	case http.StatusRequestedRangeNotSatisfiable:
 		return true, nil // already complete on disk
 	case http.StatusOK:
-		if start > 0 { // server ignored Range — restart cleanly
+		if start > 0 { // server ignored Range or the file changed — restart cleanly
 			os.Truncate(tmp, 0)
 			start = 0
+		}
+		if v := resp.Header.Get("ETag"); v != "" {
+			os.WriteFile(validatorPath(tmp), []byte(v), 0o644)
+		} else if v := resp.Header.Get("Last-Modified"); v != "" {
+			os.WriteFile(validatorPath(tmp), []byte(v), 0o644)
+		} else {
+			os.Remove(validatorPath(tmp))
 		}
 	case http.StatusPartialContent:
 	default:
@@ -202,14 +365,48 @@ func downloadOnce(url, tmp, label string) (bool, error) {
 	}
 	defer out.Close()
 
+	body := newStallGuard(resp.Body, 60*time.Second)
+	defer body.stop()
 	pw := &progress{label: label, total: start + resp.ContentLength, written: start}
-	_, copyErr := io.Copy(io.MultiWriter(out, pw), resp.Body)
+	_, copyErr := io.Copy(io.MultiWriter(out, pw), body)
 	if copyErr != nil {
 		return false, copyErr
 	}
 	pw.done()
 	return true, nil
 }
+
+// stallGuard aborts a body read that stops delivering bytes: the timer closes
+// the connection, which surfaces here as a stall error and triggers the retry
+// loop in fetch.
+type stallGuard struct {
+	body    io.ReadCloser
+	timeout time.Duration
+	timer   *time.Timer
+	stalled atomic.Bool
+}
+
+func newStallGuard(body io.ReadCloser, timeout time.Duration) *stallGuard {
+	g := &stallGuard{body: body, timeout: timeout}
+	g.timer = time.AfterFunc(timeout, func() {
+		g.stalled.Store(true)
+		body.Close()
+	})
+	return g
+}
+
+func (g *stallGuard) Read(p []byte) (int, error) {
+	n, err := g.body.Read(p)
+	if n > 0 {
+		g.timer.Reset(g.timeout)
+	}
+	if err != nil && err != io.EOF && g.stalled.Load() {
+		return n, fmt.Errorf("stalled: no data for %s", g.timeout)
+	}
+	return n, err
+}
+
+func (g *stallGuard) stop() { g.timer.Stop() }
 
 // symlinkTargetInside reports whether a symlink at linkPath pointing to linkname
 // resolves within root (root has a trailing separator). Absolute targets and
@@ -274,26 +471,47 @@ func sha256file(path string) (string, error) {
 }
 
 type ffArchive struct {
-	URL  string
-	Bins []string
+	URL    string
+	SHA256 string
+	Bins   []string
 }
 
-// Static ffmpeg sources are not yet pinned by checksum (upstream "latest" URLs).
+// Pinned, versioned upstream archives, verified by SHA-256 before extraction.
 // darwin/arm64 is absent on purpose: evermeet.cx only builds x86_64, so Apple
 // Silicon is served by our own release asset (see releaseFFmpeg).
 var ffmpegSpecs = map[string][]ffArchive{
 	"darwin/amd64": {
-		{URL: "https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip", Bins: []string{"ffmpeg"}},
-		{URL: "https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip", Bins: []string{"ffprobe"}},
+		{
+			URL:    "https://evermeet.cx/ffmpeg/ffmpeg-8.1.2.zip",
+			SHA256: "e91df72a1ee7c26606f90dd2dd4dcccc6a75140ff9ea6fdd50faae828b82ba69",
+			Bins:   []string{"ffmpeg"},
+		},
+		{
+			URL:    "https://evermeet.cx/ffmpeg/ffprobe-8.1.2.zip",
+			SHA256: "399b93f0b9862f69767afa343e90c2f48d7e7958cadbb6deb76a012d0e3b7ce3",
+			Bins:   []string{"ffprobe"},
+		},
 	},
 	"linux/amd64": {
-		{URL: "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz", Bins: []string{"ffmpeg", "ffprobe"}},
+		{
+			URL:    "https://johnvansickle.com/ffmpeg/old-releases/ffmpeg-6.0.1-amd64-static.tar.xz",
+			SHA256: "28268bf402f1083833ea269331587f60a242848880073be8016501d864bd07a5",
+			Bins:   []string{"ffmpeg", "ffprobe"},
+		},
 	},
 	"linux/arm64": {
-		{URL: "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz", Bins: []string{"ffmpeg", "ffprobe"}},
+		{
+			URL:    "https://johnvansickle.com/ffmpeg/old-releases/ffmpeg-6.0.1-arm64-static.tar.xz",
+			SHA256: "7dbd8e2f47bd83de591b9d6ea70e67d32d9aa97e7d47ae402b60c2fe3fd4d0ab",
+			Bins:   []string{"ffmpeg", "ffprobe"},
+		},
 	},
 	"windows/amd64": {
-		{URL: "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip", Bins: []string{"ffmpeg.exe", "ffprobe.exe"}},
+		{
+			URL:    "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-12-13-16/ffmpeg-n8.1.2-22-g94138f6973-win64-gpl-8.1.zip",
+			SHA256: "cb11f1a2628555d1ce3de984ae1dd488a26d85092d23219c574de76efbe2a62e",
+			Bins:   []string{"ffmpeg.exe", "ffprobe.exe"},
+		},
 	},
 }
 
@@ -303,10 +521,40 @@ func WhisperCLIBin() string {
 	return filepath.Join(paths.RuntimeDir(), "whisper", "whisper-cli"+paths.ExeSuffix())
 }
 
-func latestReleaseAssets() (map[string]string, error) {
-	req, _ := http.NewRequest(http.MethodGet, "https://api.github.com/repos/"+podcliRepo+"/releases/latest", nil)
+// githubAPIGet fetches a GitHub API URL, authenticating with GITHUB_TOKEN when
+// set so provisioning doesn't burn the 60/hour unauthenticated quota.
+func githubAPIGet(url string) (*http.Response, error) {
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
 	req.Header.Set("Accept", "application/vnd.github+json")
+	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
 	resp, err := releaseHTTPClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+		resp.Body.Close()
+		return nil, fmt.Errorf("GitHub rate limit (HTTP %d) - retry later or set GITHUB_TOKEN", resp.StatusCode)
+	}
+	return resp, nil
+}
+
+var releaseAssetsOnce sync.Once
+var releaseAssetsMap map[string]string
+var releaseAssetsErr error
+
+// latestReleaseAssets is fetched once per process: setup asks for it per
+// artifact, and unauthenticated GitHub API calls are rate limited.
+func latestReleaseAssets() (map[string]string, error) {
+	releaseAssetsOnce.Do(func() {
+		releaseAssetsMap, releaseAssetsErr = fetchLatestReleaseAssets()
+	})
+	return releaseAssetsMap, releaseAssetsErr
+}
+
+func fetchLatestReleaseAssets() (map[string]string, error) {
+	resp, err := githubAPIGet("https://api.github.com/repos/" + podcliRepo + "/releases/latest")
 	if err != nil {
 		return nil, err
 	}
@@ -352,19 +600,30 @@ func allowedReleaseHost(h string) bool {
 	return strings.HasSuffix(h, ".githubusercontent.com")
 }
 
-func releaseHTTPClient() *http.Client {
+// ErrUntrustedRedirect marks a download diverted off its allowlist. Callers that
+// wrap Fetch in a retry loop must not treat it as a transient failure.
+var ErrUntrustedRedirect = errors.New("refusing redirect to untrusted host")
+
+func guardedHTTPClient(allowHost func(string) bool, headerTimeout time.Duration) *http.Client {
 	return &http.Client{
-		Transport: &http.Transport{ResponseHeaderTimeout: 30 * time.Second},
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			ResponseHeaderTimeout: headerTimeout,
+		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return fmt.Errorf("too many redirects")
 			}
-			if !allowedReleaseHost(req.URL.Hostname()) {
-				return fmt.Errorf("refusing redirect to untrusted host %q", req.URL.Hostname())
+			if !allowHost(req.URL.Hostname()) {
+				return fmt.Errorf("%w %q", ErrUntrustedRedirect, req.URL.Hostname())
 			}
 			return nil
 		},
 	}
+}
+
+func releaseHTTPClient() *http.Client {
+	return guardedHTTPClient(allowedReleaseHost, 30*time.Second)
 }
 
 // allowedDownloadHost pins large-binary/model downloads to their known source
@@ -391,18 +650,7 @@ func allowedDownloadHost(h string) bool {
 }
 
 func downloadHTTPClient() *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{ResponseHeaderTimeout: 60 * time.Second},
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 10 {
-				return fmt.Errorf("too many redirects")
-			}
-			if !allowedDownloadHost(req.URL.Hostname()) {
-				return fmt.Errorf("refusing redirect to untrusted host %q", req.URL.Hostname())
-			}
-			return nil
-		},
-	}
+	return guardedHTTPClient(allowedDownloadHost, 60*time.Second)
 }
 
 func httpGetBytes(url string) ([]byte, error) {
@@ -418,24 +666,21 @@ func httpGetBytes(url string) ([]byte, error) {
 }
 
 // verifyReleaseAsset checks the file at path against the release's checksums.txt.
-// It fails closed on a real checksum mismatch, but fails open (with a warning)
-// when checksums.txt or the asset's entry is absent — so a release published
-// before checksum manifests, or a CI hiccup, never bricks an install.
+// Fails closed: checksums.txt is published with every release, so a missing
+// manifest, a failed fetch, or a missing entry all mean the asset can't be
+// trusted.
 func verifyReleaseAsset(assets map[string]string, assetName, path string) error {
 	sumsURL, ok := assets["checksums.txt"]
 	if !ok {
-		fmt.Fprintf(os.Stderr, "  (no checksums.txt in release - skipped verification of %s)\n", assetName)
-		return nil
+		return fmt.Errorf("cannot verify %s: release has no checksums.txt (it is published with every release - retry later)", assetName)
 	}
 	data, err := httpGetBytes(sumsURL)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "  (could not fetch checksums.txt: %v - skipped verification of %s)\n", err, assetName)
-		return nil
+		return fmt.Errorf("cannot verify %s: fetching checksums.txt failed: %w", assetName, err)
 	}
 	want, ok := ParseChecksums(data)[assetName]
 	if !ok {
-		fmt.Fprintf(os.Stderr, "  (no checksum entry for %s - skipped verification)\n", assetName)
-		return nil
+		return fmt.Errorf("cannot verify %s: no entry in checksums.txt", assetName)
 	}
 	got, err := sha256file(path)
 	if err != nil {
@@ -466,7 +711,7 @@ func EnsureWhisperCpp() (string, error) {
 	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
 		return "", err
 	}
-	if err := fetch(url, bin, "whisper-cli"); err != nil {
+	if err := fetch(url, bin, "whisper-cli", downloadHTTPClient()); err != nil {
 		return "", err
 	}
 	if err := verifyReleaseAsset(assets, name, bin); err != nil {
@@ -503,13 +748,15 @@ func EnsureFFmpeg() (string, error) {
 		return "", fmt.Errorf("no ffmpeg build for %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
 	for _, a := range specs {
-		sum := sha256.Sum256([]byte(a.URL))
-		archive := filepath.Join(os.TempDir(), "podcli-ff-"+hex.EncodeToString(sum[:8]))
-		if err := fetch(a.URL, archive, "ffmpeg-archive"); err != nil {
+		archive, err := downloadPath(a.URL, "ffmpeg-archive")
+		if err != nil {
 			return "", err
 		}
-		err := extractBins(archive, a.Bins, dir)
-		os.Remove(archive)
+		if err := download(a.URL, archive, a.SHA256, "ffmpeg-archive"); err != nil {
+			return "", err
+		}
+		err = extractBins(archive, a.Bins, dir)
+		removeArchive(archive)
 		if err != nil {
 			return "", err
 		}
@@ -535,7 +782,7 @@ func releaseFFmpeg() error {
 			return fmt.Errorf("asset %s not in latest release", name)
 		}
 		os.Remove(bin)
-		if err := fetch(url, bin, tool); err != nil {
+		if err := fetch(url, bin, tool, downloadHTTPClient()); err != nil {
 			return err
 		}
 		if err := verifyReleaseAsset(assets, name, bin); err != nil {
@@ -689,9 +936,7 @@ func pythonAssetURL() (url, name, sumsURL string, err error) {
 	if !ok {
 		return "", "", "", fmt.Errorf("no python build for %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
-	req, _ := http.NewRequest(http.MethodGet, "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest", nil)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	resp, err := releaseHTTPClient().Do(req)
+	resp, err := githubAPIGet("https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest")
 	if err != nil {
 		return "", "", "", err
 	}
@@ -743,18 +988,21 @@ func EnsurePython(requirements string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		sum := sha256.Sum256([]byte(url))
-		archive := filepath.Join(os.TempDir(), "podcli-py-"+hex.EncodeToString(sum[:8])+".tar.gz")
-		if err := fetch(url, archive, "cpython"); err != nil {
+		archive, err := downloadPath(url, "cpython.tar.gz")
+		if err != nil {
 			return "", err
 		}
-		if sumsURL != "" {
-			if err := verifyDownload(archive, sumsURL, name); err != nil {
-				return "", err
-			}
+		if err := fetch(url, archive, "cpython", downloadHTTPClient()); err != nil {
+			return "", err
+		}
+		if sumsURL == "" {
+			return "", fmt.Errorf("cannot verify %s: release has no SHA256SUMS asset", name)
+		}
+		if err := verifyDownload(archive, sumsURL, name); err != nil {
+			return "", err
 		}
 		err = extractTarGz(archive, paths.RuntimeDir())
-		os.Remove(archive)
+		removeArchive(archive)
 		if err != nil {
 			return "", err
 		}
@@ -901,18 +1149,38 @@ func extractTarGz(archive, dest string) error {
 	return nil
 }
 
+// stderrIsTTY gates \r-style in-place progress: piped to a file or CI log, the
+// carriage returns would pile up as one unreadable line, so non-TTY output gets
+// periodic full lines instead.
+var stderrIsTTY = func() bool {
+	fi, err := os.Stderr.Stat()
+	return err == nil && fi.Mode()&os.ModeCharDevice != 0
+}()
+
 type progress struct {
 	label    string
 	total    int64
 	written  int64
 	lastPct  int
 	lastTick time.Time
+	lastLine time.Time
 }
 
 func (p *progress) Write(b []byte) (int, error) {
 	n := len(b)
 	p.written += int64(n)
 	now := time.Now()
+	if !stderrIsTTY {
+		if now.Sub(p.lastLine) >= 5*time.Second {
+			p.lastLine = now
+			if p.total > 0 {
+				fmt.Fprintf(os.Stderr, "  fetching %s ... %d%% (%d/%d MB)\n", p.label, int(p.written*100/p.total), p.written>>20, p.total>>20)
+			} else {
+				fmt.Fprintf(os.Stderr, "  fetching %s ... %d MB\n", p.label, p.written>>20)
+			}
+		}
+		return n, nil
+	}
 	if now.Sub(p.lastTick) < 200*time.Millisecond {
 		return n, nil
 	}
@@ -930,5 +1198,9 @@ func (p *progress) Write(b []byte) (int, error) {
 }
 
 func (p *progress) done() {
+	if !stderrIsTTY {
+		fmt.Fprintf(os.Stderr, "  fetching %s ... done (%d MB)\n", p.label, p.written>>20)
+		return
+	}
 	fmt.Fprintf(os.Stderr, "\r  fetching %s ... done (%d MB)%s\n", p.label, p.written>>20, "          ")
 }

--- a/cli/internal/provision/provision.go
+++ b/cli/internal/provision/provision.go
@@ -5,6 +5,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -27,6 +28,11 @@ import (
 type model struct {
 	URL    string
 	SHA256 string
+}
+
+type artifactState struct {
+	Key   string            `json:"key"`
+	Files map[string]string `json:"files"`
 }
 
 var models = map[string]model{
@@ -64,9 +70,6 @@ func have(p string) bool {
 
 func EnsureModel(size string) (string, error) {
 	dest := ModelPath(size)
-	if have(dest) {
-		return dest, nil
-	}
 	m, ok := models[size]
 	if !ok {
 		return "", fmt.Errorf("unknown model size %q (known: base, tiny.en, small)", size)
@@ -79,9 +82,6 @@ func EnsureModel(size string) (string, error) {
 
 func EnsureVADModel() (string, error) {
 	dest := VADModelPath()
-	if have(dest) {
-		return dest, nil
-	}
 	if err := download(vadURL, dest, vadSHA, "silero-vad"); err != nil {
 		return "", err
 	}
@@ -188,11 +188,36 @@ func acquireLock(dest string) (func(), error) {
 	deadline := time.Now().Add(lockWait)
 	transient := 0
 	for {
+		if _, err := os.Stat(lock + ".takeover"); err == nil {
+			if time.Now().After(deadline) {
+				return nil, fmt.Errorf("timed out waiting for %s (another podcli may be provisioning; delete the file if not)", lock)
+			}
+			time.Sleep(lockPoll)
+			continue
+		}
+		token, err := ownershipToken()
+		if err != nil {
+			return nil, err
+		}
 		f, err := os.OpenFile(lock, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 		if err == nil {
-			fmt.Fprintf(f, "%d", os.Getpid())
-			f.Close()
-			return holdLock(lock), nil
+			if _, err := f.WriteString(token); err != nil {
+				f.Close()
+				os.Remove(lock)
+				return nil, err
+			}
+			if err := f.Sync(); err != nil {
+				f.Close()
+				os.Remove(lock)
+				return nil, err
+			}
+			if _, err := os.Stat(lock + ".takeover"); err == nil {
+				f.Close()
+				removeOwnedLock(lock, token)
+				time.Sleep(lockPoll)
+				continue
+			}
+			return holdLock(lock, token, f), nil
 		}
 		if os.IsExist(err) {
 			transient = 0
@@ -216,16 +241,17 @@ func acquireLock(dest string) (func(), error) {
 }
 
 // holdLock keeps the lock's mtime fresh until the returned unlock runs.
-func holdLock(lock string) func() {
+func holdLock(lock, token string, f *os.File) func() {
 	done := make(chan struct{})
+	stopped := make(chan struct{})
 	go func() {
+		defer close(stopped)
 		t := time.NewTicker(lockHeartbeat)
 		defer t.Stop()
 		for {
 			select {
 			case <-t.C:
-				now := time.Now()
-				os.Chtimes(lock, now, now)
+				f.WriteAt([]byte(token), 0)
 			case <-done:
 				return
 			}
@@ -235,9 +261,35 @@ func holdLock(lock string) func() {
 	return func() {
 		once.Do(func() {
 			close(done)
-			os.Remove(lock)
+			<-stopped
+			f.Close()
+			removeOwnedLock(lock, token)
 		})
 	}
+}
+
+func ownershipToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func lockOwner(lock string) (string, error) {
+	b, err := os.ReadFile(lock)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+func removeOwnedLock(lock, token string) bool {
+	owner, err := lockOwner(lock)
+	if err != nil || owner != token {
+		return false
+	}
+	return os.Remove(lock) == nil
 }
 
 // dropStaleLock removes a lock whose holder stopped heartbeating, reporting
@@ -248,25 +300,53 @@ func holdLock(lock string) func() {
 func dropStaleLock(lock string) bool {
 	token := lock + ".takeover"
 	if fi, err := os.Stat(token); err == nil && time.Since(fi.ModTime()) > lockStale {
-		os.Remove(token) // a process died mid-takeover; retry the takeover next pass
+		if owner, readErr := lockOwner(token); readErr == nil {
+			removeOwnedLock(token, owner)
+		}
+		return false
+	}
+	takeoverOwner, err := ownershipToken()
+	if err != nil {
 		return false
 	}
 	f, err := os.OpenFile(token, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 	if err != nil {
 		return false // another process is taking over; wait for its lock instead
 	}
+	if _, err := f.WriteString(takeoverOwner); err != nil {
+		f.Close()
+		removeOwnedLock(token, takeoverOwner)
+		return false
+	}
 	f.Close()
-	defer os.Remove(token)
+	defer removeOwnedLock(token, takeoverOwner)
 	fi, err := os.Stat(lock)
 	if err != nil || time.Since(fi.ModTime()) <= lockStale {
 		return false
 	}
-	return os.Remove(lock) == nil
+	owner, err := lockOwner(lock)
+	if err != nil {
+		return false
+	}
+	fi, err = os.Stat(lock)
+	if err != nil || time.Since(fi.ModTime()) <= lockStale {
+		return false
+	}
+	return removeOwnedLock(lock, owner)
 }
 
 func download(url, dest, wantSHA, label string) error {
 	if wantSHA == "" {
 		return fmt.Errorf("no pinned checksum for %s - refusing unverified download", label)
+	}
+	if have(dest) {
+		got, err := sha256file(dest)
+		if err == nil && strings.EqualFold(got, wantSHA) {
+			return nil
+		}
+		if err := os.Remove(dest); err != nil {
+			return fmt.Errorf("remove unverified %s: %w", label, err)
+		}
 	}
 	if err := fetch(url, dest, label, downloadHTTPClient()); err != nil {
 		return err
@@ -282,25 +362,63 @@ func download(url, dest, wantSHA, label string) error {
 	return nil
 }
 
+func artifactStatePath(dir string) string {
+	return filepath.Join(dir, ".podcli-artifacts")
+}
+
+func artifactAt(dir, key string, files ...string) bool {
+	b, err := os.ReadFile(artifactStatePath(dir))
+	if err != nil {
+		return false
+	}
+	var state artifactState
+	if json.Unmarshal(b, &state) != nil || state.Key != key || len(state.Files) != len(files) {
+		return false
+	}
+	for _, file := range files {
+		rel, err := filepath.Rel(dir, file)
+		if err != nil {
+			return false
+		}
+		got, err := sha256file(file)
+		if err != nil || !strings.EqualFold(got, state.Files[rel]) {
+			return false
+		}
+	}
+	return true
+}
+
+func writeArtifactState(dir, key string, files ...string) error {
+	state := artifactState{Key: key, Files: make(map[string]string, len(files))}
+	for _, file := range files {
+		rel, err := filepath.Rel(dir, file)
+		if err != nil {
+			return err
+		}
+		sum, err := sha256file(file)
+		if err != nil {
+			return err
+		}
+		state.Files[rel] = sum
+	}
+	b, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	tmp := artifactStatePath(dir) + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, artifactStatePath(dir))
+}
+
 // verifyDownload checks a downloaded archive against an upstream sha256sum-style
 // manifest. Fails closed: a manifest that can't be fetched or has no entry for
 // the asset means the download cannot be trusted.
 func verifyDownload(archive, sumsURL, name string) error {
-	resp, err := downloadHTTPClient().Get(sumsURL)
-	if err != nil {
-		return fmt.Errorf("cannot verify %s: fetching checksums failed: %w", name, err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("cannot verify %s: HTTP %d fetching checksums", name, resp.StatusCode)
-	}
-	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	want, err := downloadChecksum(sumsURL, name)
 	if err != nil {
 		return err
-	}
-	want := ParseChecksums(data)[name]
-	if want == "" {
-		return fmt.Errorf("cannot verify %s: no entry in upstream checksums", name)
 	}
 	got, err := sha256file(archive)
 	if err != nil {
@@ -311,6 +429,26 @@ func verifyDownload(archive, sumsURL, name string) error {
 		return fmt.Errorf("checksum mismatch for %s: got %s want %s", name, got, want)
 	}
 	return nil
+}
+
+func downloadChecksum(sumsURL, name string) (string, error) {
+	resp, err := downloadHTTPClient().Get(sumsURL)
+	if err != nil {
+		return "", fmt.Errorf("cannot verify %s: fetching checksums failed: %w", name, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("cannot verify %s: HTTP %d fetching checksums", name, resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return "", err
+	}
+	want := ParseChecksums(data)[name]
+	if want == "" {
+		return "", fmt.Errorf("cannot verify %s: no entry in upstream checksums", name)
+	}
+	return want, nil
 }
 
 func validatorPath(tmp string) string { return tmp + ".validator" }
@@ -670,17 +808,9 @@ func httpGetBytes(url string) ([]byte, error) {
 // manifest, a failed fetch, or a missing entry all mean the asset can't be
 // trusted.
 func verifyReleaseAsset(assets map[string]string, assetName, path string) error {
-	sumsURL, ok := assets["checksums.txt"]
-	if !ok {
-		return fmt.Errorf("cannot verify %s: release has no checksums.txt (it is published with every release - retry later)", assetName)
-	}
-	data, err := httpGetBytes(sumsURL)
+	want, err := releaseAssetChecksum(assets, assetName)
 	if err != nil {
-		return fmt.Errorf("cannot verify %s: fetching checksums.txt failed: %w", assetName, err)
-	}
-	want, ok := ParseChecksums(data)[assetName]
-	if !ok {
-		return fmt.Errorf("cannot verify %s: no entry in checksums.txt", assetName)
+		return err
 	}
 	got, err := sha256file(path)
 	if err != nil {
@@ -693,12 +823,24 @@ func verifyReleaseAsset(assets map[string]string, assetName, path string) error 
 	return nil
 }
 
+func releaseAssetChecksum(assets map[string]string, assetName string) (string, error) {
+	sumsURL, ok := assets["checksums.txt"]
+	if !ok {
+		return "", fmt.Errorf("cannot verify %s: release has no checksums.txt (it is published with every release - retry later)", assetName)
+	}
+	data, err := httpGetBytes(sumsURL)
+	if err != nil {
+		return "", fmt.Errorf("cannot verify %s: fetching checksums.txt failed: %w", assetName, err)
+	}
+	want, ok := ParseChecksums(data)[assetName]
+	if !ok {
+		return "", fmt.Errorf("cannot verify %s: no entry in checksums.txt", assetName)
+	}
+	return want, nil
+}
+
 func EnsureWhisperCpp() (string, error) {
 	bin := WhisperCLIBin()
-	if nativeBin(bin) {
-		return bin, nil
-	}
-	os.Remove(bin)
 	name := fmt.Sprintf("whisper-cli-%s-%s%s", runtime.GOOS, runtime.GOARCH, paths.ExeSuffix())
 	assets, err := latestReleaseAssets()
 	if err != nil {
@@ -708,17 +850,27 @@ func EnsureWhisperCpp() (string, error) {
 	if !ok {
 		return "", fmt.Errorf("asset %s not in latest release", name)
 	}
+	want, err := releaseAssetChecksum(assets, name)
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(bin)
+	key := name + "|" + want
+	if nativeBin(bin) && artifactAt(dir, key, bin) {
+		return bin, nil
+	}
+	os.Remove(bin)
 	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
 		return "", err
 	}
-	if err := fetch(url, bin, "whisper-cli", downloadHTTPClient()); err != nil {
-		return "", err
-	}
-	if err := verifyReleaseAsset(assets, name, bin); err != nil {
+	if err := download(url, bin, want, "whisper-cli"); err != nil {
 		return "", err
 	}
 	if runtime.GOOS != "windows" {
 		os.Chmod(bin, 0o755)
+	}
+	if err := writeArtifactState(dir, key, bin); err != nil {
+		return "", err
 	}
 	return bin, nil
 }
@@ -733,19 +885,42 @@ func FFprobeBin() string {
 
 func EnsureFFmpeg() (string, error) {
 	bin := FFmpegBin()
-	if nativeBin(bin) && nativeBin(FFprobeBin()) {
-		return bin, nil
-	}
+	probe := FFprobeBin()
 	dir := filepath.Join(paths.RuntimeDir(), "ffmpeg")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
 	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		return bin, releaseFFmpeg()
+		assets, err := latestReleaseAssets()
+		if err != nil {
+			return "", err
+		}
+		key := ""
+		checksums := map[string]string{}
+		for _, tool := range []string{"ffmpeg", "ffprobe"} {
+			name := fmt.Sprintf("%s-%s-%s", tool, runtime.GOOS, runtime.GOARCH)
+			want, err := releaseAssetChecksum(assets, name)
+			if err != nil {
+				return "", err
+			}
+			checksums[name] = want
+			key += name + "|" + want + "\n"
+		}
+		if nativeBin(bin) && nativeBin(probe) && artifactAt(dir, key, bin, probe) {
+			return bin, nil
+		}
+		return bin, releaseFFmpeg(assets, checksums, key)
 	}
 	specs, ok := ffmpegSpecs[runtime.GOOS+"/"+runtime.GOARCH]
 	if !ok {
 		return "", fmt.Errorf("no ffmpeg build for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	key := ""
+	for _, spec := range specs {
+		key += spec.URL + "|" + spec.SHA256 + "\n"
+	}
+	if nativeBin(bin) && nativeBin(probe) && artifactAt(dir, key, bin, probe) {
+		return bin, nil
 	}
 	for _, a := range specs {
 		archive, err := downloadPath(a.URL, "ffmpeg-archive")
@@ -764,17 +939,16 @@ func EnsureFFmpeg() (string, error) {
 	if !have(bin) {
 		return "", fmt.Errorf("ffmpeg missing after extraction in %s", dir)
 	}
+	if err := writeArtifactState(dir, key, bin, probe); err != nil {
+		return "", err
+	}
 	return bin, nil
 }
 
 // Apple Silicon builds ship with the release, checksum-verified like whisper-cli.
 // No upstream publishes an arm64 macOS static, so ffmpeg used to arrive as an
 // x86_64 binary that ran under Rosetta at roughly a third of native encode speed.
-func releaseFFmpeg() error {
-	assets, err := latestReleaseAssets()
-	if err != nil {
-		return err
-	}
+func releaseFFmpeg(assets, checksums map[string]string, key string) error {
 	for tool, bin := range map[string]string{"ffmpeg": FFmpegBin(), "ffprobe": FFprobeBin()} {
 		name := fmt.Sprintf("%s-%s-%s", tool, runtime.GOOS, runtime.GOARCH)
 		url, ok := assets[name]
@@ -782,17 +956,14 @@ func releaseFFmpeg() error {
 			return fmt.Errorf("asset %s not in latest release", name)
 		}
 		os.Remove(bin)
-		if err := fetch(url, bin, tool, downloadHTTPClient()); err != nil {
-			return err
-		}
-		if err := verifyReleaseAsset(assets, name, bin); err != nil {
+		if err := download(url, bin, checksums[name], tool); err != nil {
 			return err
 		}
 		if err := os.Chmod(bin, 0o755); err != nil {
 			return fmt.Errorf("chmod %s: %w", bin, err)
 		}
 	}
-	return nil
+	return writeArtifactState(filepath.Dir(FFmpegBin()), key, FFmpegBin(), FFprobeBin())
 }
 
 func extractBins(archive string, bins []string, dest string) error {
@@ -979,26 +1150,28 @@ func pythonAssetURL() (url, name, sumsURL string, err error) {
 
 func EnsurePython(requirements string) (string, error) {
 	bin := PythonBin()
-	if !pythonHealthy(bin) {
-		root := pythonRoot(bin)
+	url, name, sumsURL, err := pythonAssetURL()
+	if err != nil {
+		return "", err
+	}
+	if sumsURL == "" {
+		return "", fmt.Errorf("cannot verify %s: release has no SHA256SUMS asset", name)
+	}
+	want, err := downloadChecksum(sumsURL, name)
+	if err != nil {
+		return "", err
+	}
+	root := pythonRoot(bin)
+	key := name + "|" + want
+	if !pythonHealthy(bin) || !artifactAt(root, key, bin) {
 		if err := os.RemoveAll(root); err != nil {
 			return "", fmt.Errorf("remove corrupted Python runtime %s: %w (close any running podcli or Python subprocesses)", root, err)
-		}
-		url, name, sumsURL, err := pythonAssetURL()
-		if err != nil {
-			return "", err
 		}
 		archive, err := downloadPath(url, "cpython.tar.gz")
 		if err != nil {
 			return "", err
 		}
-		if err := fetch(url, archive, "cpython", downloadHTTPClient()); err != nil {
-			return "", err
-		}
-		if sumsURL == "" {
-			return "", fmt.Errorf("cannot verify %s: release has no SHA256SUMS asset", name)
-		}
-		if err := verifyDownload(archive, sumsURL, name); err != nil {
+		if err := download(url, archive, want, "cpython"); err != nil {
 			return "", err
 		}
 		err = extractTarGz(archive, paths.RuntimeDir())
@@ -1008,6 +1181,9 @@ func EnsurePython(requirements string) (string, error) {
 		}
 		if !pythonHealthy(bin) {
 			return "", fmt.Errorf("python runtime missing stdlib encodings after extraction")
+		}
+		if err := writeArtifactState(root, key, bin); err != nil {
+			return "", err
 		}
 	}
 	if requirements != "" {

--- a/cli/internal/provision/provision.go
+++ b/cli/internal/provision/provision.go
@@ -386,13 +386,28 @@ func artifactStatePath(dir string) string {
 	return filepath.Join(dir, ".podcli-artifacts")
 }
 
-func artifactAt(dir, key string, files ...string) bool {
+// VerifyRemote makes the Ensure* functions re-resolve the upstream build and
+// re-provision when it differs from what is installed. Only `podcli setup` sets it.
+// Every other command relies on the local artifact state instead: resolving the
+// upstream release on each run left a fully-provisioned install unable to work
+// offline, spent an unauthenticated GitHub API call (60/hr/IP) per invocation, and
+// re-downloaded the runtime whenever upstream published a new build.
+var VerifyRemote bool
+
+func readArtifactState(dir string) (artifactState, bool) {
 	b, err := os.ReadFile(artifactStatePath(dir))
 	if err != nil {
-		return false
+		return artifactState{}, false
 	}
 	var state artifactState
-	if json.Unmarshal(b, &state) != nil || state.Key != key || len(state.Files) != len(files) {
+	if json.Unmarshal(b, &state) != nil {
+		return artifactState{}, false
+	}
+	return state, true
+}
+
+func artifactContentsMatch(dir string, state artifactState, files ...string) bool {
+	if len(state.Files) != len(files) {
 		return false
 	}
 	for _, file := range files {
@@ -406,6 +421,25 @@ func artifactAt(dir, key string, files ...string) bool {
 		}
 	}
 	return true
+}
+
+func artifactAt(dir, key string, files ...string) bool {
+	state, ok := readArtifactState(dir)
+	return ok && state.Key == key && artifactContentsMatch(dir, state, files...)
+}
+
+// artifactReady reports whether an installed artifact can be used without asking the
+// network which build is current. Recorded hashes are re-verified, so a corrupted or
+// swapped binary is still rejected. A runtime installed before artifact state existed
+// is adopted with an empty key: it was checksum-verified at download time, and forcing
+// every existing install to re-download on first run would be worse. The empty key
+// never matches an upstream key, so the next `podcli setup` re-verifies it properly.
+func artifactReady(dir string, files ...string) bool {
+	state, ok := readArtifactState(dir)
+	if !ok {
+		return writeArtifactState(dir, "", files...) == nil
+	}
+	return artifactContentsMatch(dir, state, files...)
 }
 
 func writeArtifactState(dir, key string, files ...string) error {
@@ -861,6 +895,9 @@ func releaseAssetChecksum(assets map[string]string, assetName string) (string, e
 
 func EnsureWhisperCpp() (string, error) {
 	bin := WhisperCLIBin()
+	if !VerifyRemote && nativeBin(bin) && artifactReady(filepath.Dir(bin), bin) {
+		return bin, nil
+	}
 	name := fmt.Sprintf("whisper-cli-%s-%s%s", runtime.GOOS, runtime.GOARCH, paths.ExeSuffix())
 	assets, err := latestReleaseAssets()
 	if err != nil {
@@ -909,6 +946,9 @@ func EnsureFFmpeg() (string, error) {
 	dir := filepath.Join(paths.RuntimeDir(), "ffmpeg")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
+	}
+	if !VerifyRemote && nativeBin(bin) && nativeBin(probe) && artifactReady(dir, bin, probe) {
+		return bin, nil
 	}
 	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 		assets, err := latestReleaseAssets()
@@ -1122,12 +1162,14 @@ func pythonRoot(bin string) string {
 // pythonAssetURL resolves a python-build-standalone install_only tarball for
 // this platform via the GitHub latest-release API, so it tracks upstream
 // without a hardcoded version that rots.
+var pythonReleasesAPI = "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest"
+
 func pythonAssetURL() (url, name, sumsURL string, err error) {
 	triple, ok := pyTriples[runtime.GOOS+"/"+runtime.GOARCH]
 	if !ok {
 		return "", "", "", fmt.Errorf("no python build for %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
-	resp, err := githubAPIGet("https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest")
+	resp, err := githubAPIGet(pythonReleasesAPI)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -1170,40 +1212,42 @@ func pythonAssetURL() (url, name, sumsURL string, err error) {
 
 func EnsurePython(requirements string) (string, error) {
 	bin := PythonBin()
-	url, name, sumsURL, err := pythonAssetURL()
-	if err != nil {
-		return "", err
-	}
-	if sumsURL == "" {
-		return "", fmt.Errorf("cannot verify %s: release has no SHA256SUMS asset", name)
-	}
-	want, err := downloadChecksum(sumsURL, name)
-	if err != nil {
-		return "", err
-	}
 	root := pythonRoot(bin)
-	key := name + "|" + want
-	if !pythonHealthy(bin) || !artifactAt(root, key, bin) {
-		if err := os.RemoveAll(root); err != nil {
-			return "", fmt.Errorf("remove corrupted Python runtime %s: %w (close any running podcli or Python subprocesses)", root, err)
-		}
-		archive, err := downloadPath(url, "cpython.tar.gz")
+	if VerifyRemote || !pythonHealthy(bin) || !artifactReady(root, bin) {
+		url, name, sumsURL, err := pythonAssetURL()
 		if err != nil {
 			return "", err
 		}
-		if err := download(url, archive, want, "cpython"); err != nil {
-			return "", err
+		if sumsURL == "" {
+			return "", fmt.Errorf("cannot verify %s: release has no SHA256SUMS asset", name)
 		}
-		err = extractTarGz(archive, paths.RuntimeDir())
-		removeArchive(archive)
+		want, err := downloadChecksum(sumsURL, name)
 		if err != nil {
 			return "", err
 		}
-		if !pythonHealthy(bin) {
-			return "", fmt.Errorf("python runtime missing stdlib encodings after extraction")
-		}
-		if err := writeArtifactState(root, key, bin); err != nil {
-			return "", err
+		key := name + "|" + want
+		if !pythonHealthy(bin) || !artifactAt(root, key, bin) {
+			if err := os.RemoveAll(root); err != nil {
+				return "", fmt.Errorf("remove corrupted Python runtime %s: %w (close any running podcli or Python subprocesses)", root, err)
+			}
+			archive, err := downloadPath(url, "cpython.tar.gz")
+			if err != nil {
+				return "", err
+			}
+			if err := download(url, archive, want, "cpython"); err != nil {
+				return "", err
+			}
+			err = extractTarGz(archive, paths.RuntimeDir())
+			removeArchive(archive)
+			if err != nil {
+				return "", err
+			}
+			if !pythonHealthy(bin) {
+				return "", fmt.Errorf("python runtime missing stdlib encodings after extraction")
+			}
+			if err := writeArtifactState(root, key, bin); err != nil {
+				return "", err
+			}
 		}
 	}
 	if requirements != "" {

--- a/cli/internal/provision/studio.go
+++ b/cli/internal/provision/studio.go
@@ -53,6 +53,9 @@ func writeBundleStamp(dir, version string) {
 
 func EnsureNode() (string, error) {
 	bin := NodeBin()
+	if !VerifyRemote && nativeBin(bin) && artifactReady(NodeDir(), bin) {
+		return bin, nil
+	}
 	triple, ok := nodeTriples[runtime.GOOS+"/"+runtime.GOARCH]
 	if !ok {
 		return "", fmt.Errorf("no node build for %s/%s", runtime.GOOS, runtime.GOARCH)

--- a/cli/internal/provision/studio.go
+++ b/cli/internal/provision/studio.go
@@ -66,18 +66,20 @@ func EnsureNode() (string, error) {
 	}
 	base := fmt.Sprintf("node-v%s-%s", nodeVersion, triple)
 	url := fmt.Sprintf("https://nodejs.org/dist/v%s/%s.%s", nodeVersion, base, ext)
-	archive := filepath.Join(os.TempDir(), "podcli-"+base+"."+ext)
-	if err := fetch(url, archive, "node"); err != nil {
+	archive, err := downloadPath(url, base+"."+ext)
+	if err != nil {
 		return "", err
 	}
-	defer os.Remove(archive)
+	if err := fetch(url, archive, "node", downloadHTTPClient()); err != nil {
+		return "", err
+	}
+	defer removeArchive(archive)
 	if err := verifyDownload(archive, fmt.Sprintf("https://nodejs.org/dist/v%s/SHASUMS256.txt", nodeVersion), base+"."+ext); err != nil {
 		return "", err
 	}
 	if err := os.RemoveAll(NodeDir()); err != nil {
 		return "", err
 	}
-	var err error
 	if ext == "zip" {
 		err = extractZipStrip1(archive, NodeDir())
 	} else {
@@ -115,11 +117,14 @@ func EnsureRemotion(version string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("asset %s not in latest release", name)
 	}
-	archive := filepath.Join(os.TempDir(), "podcli-"+name)
-	if err := fetch(url, archive, "remotion"); err != nil {
+	archive, err := downloadPath(url, name)
+	if err != nil {
 		return "", err
 	}
-	defer os.Remove(archive)
+	if err := fetch(url, archive, "remotion", downloadHTTPClient()); err != nil {
+		return "", err
+	}
+	defer removeArchive(archive)
 	if err := verifyReleaseAsset(assets, name, archive); err != nil {
 		return "", err
 	}
@@ -183,11 +188,14 @@ func EnsureStudio(version string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("asset studio-bundle.tar.gz not in latest release")
 	}
-	archive := filepath.Join(os.TempDir(), "podcli-studio-bundle.tar.gz")
-	if err := fetch(url, archive, "studio"); err != nil {
+	archive, err := downloadPath(url, "studio-bundle.tar.gz")
+	if err != nil {
 		return "", err
 	}
-	defer os.Remove(archive)
+	if err := fetch(url, archive, "studio", downloadHTTPClient()); err != nil {
+		return "", err
+	}
+	defer removeArchive(archive)
 	if err := verifyReleaseAsset(assets, "studio-bundle.tar.gz", archive); err != nil {
 		return "", err
 	}

--- a/cli/internal/provision/studio.go
+++ b/cli/internal/provision/studio.go
@@ -53,9 +53,6 @@ func writeBundleStamp(dir, version string) {
 
 func EnsureNode() (string, error) {
 	bin := NodeBin()
-	if have(bin) {
-		return bin, nil
-	}
 	triple, ok := nodeTriples[runtime.GOOS+"/"+runtime.GOARCH]
 	if !ok {
 		return "", fmt.Errorf("no node build for %s/%s", runtime.GOOS, runtime.GOARCH)
@@ -66,15 +63,21 @@ func EnsureNode() (string, error) {
 	}
 	base := fmt.Sprintf("node-v%s-%s", nodeVersion, triple)
 	url := fmt.Sprintf("https://nodejs.org/dist/v%s/%s.%s", nodeVersion, base, ext)
+	sumsURL := fmt.Sprintf("https://nodejs.org/dist/v%s/SHASUMS256.txt", nodeVersion)
+	want, err := downloadChecksum(sumsURL, base+"."+ext)
+	if err != nil {
+		return "", err
+	}
+	key := base + "|" + want
+	if nativeBin(bin) && artifactAt(NodeDir(), key, bin) {
+		return bin, nil
+	}
 	archive, err := downloadPath(url, base+"."+ext)
 	if err != nil {
 		return "", err
 	}
-	if err := fetch(url, archive, "node", downloadHTTPClient()); err != nil {
-		return "", err
-	}
 	defer removeArchive(archive)
-	if err := verifyDownload(archive, fmt.Sprintf("https://nodejs.org/dist/v%s/SHASUMS256.txt", nodeVersion), base+"."+ext); err != nil {
+	if err := download(url, archive, want, "node"); err != nil {
 		return "", err
 	}
 	if err := os.RemoveAll(NodeDir()); err != nil {
@@ -93,6 +96,9 @@ func EnsureNode() (string, error) {
 	}
 	if !have(bin) {
 		return "", fmt.Errorf("node missing after extraction in %s", NodeDir())
+	}
+	if err := writeArtifactState(NodeDir(), key, bin); err != nil {
+		return "", err
 	}
 	return bin, nil
 }

--- a/cli/internal/update/update.go
+++ b/cli/internal/update/update.go
@@ -79,7 +79,10 @@ func allowedHost(h string) bool {
 
 func guardedClient() *http.Client {
 	return &http.Client{
-		Transport: &http.Transport{ResponseHeaderTimeout: 30 * time.Second},
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			ResponseHeaderTimeout: 30 * time.Second,
+		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return fmt.Errorf("too many redirects")
@@ -133,19 +136,37 @@ func newer(remote, current string) bool {
 	return false
 }
 
+const checkInterval = 24 * time.Hour
+
 // NotifyIfOutdated prints a one-line notice when a newer release exists. Fast,
-// silent on any error, and respects the off-switch.
+// silent on any error, respects the off-switch, and hits the network at most
+// once per day (result cached in config.json).
 func NotifyIfOutdated(current string) {
 	if !config.AutoUpdate() {
 		return
 	}
-	tag, err := latestTag(1500 * time.Millisecond)
-	if err != nil {
-		return
+	tag, ok := config.CachedUpdateCheck(checkInterval)
+	if !ok {
+		var err error
+		tag, err = latestTag(1500 * time.Millisecond)
+		if err != nil {
+			return
+		}
+		config.RecordUpdateCheck(tag)
 	}
 	if newer(tag, current) {
 		fmt.Fprintf(os.Stderr, "  podcli %s available (you have %s) - run `podcli update`\n", tag, current)
 	}
+}
+
+// CleanupOldBinary removes the podcli.exe.old a Windows self-update leaves
+// behind (the running exe can't be deleted during the swap). Best-effort: the
+// file stays locked while the previous binary is still exiting.
+func CleanupOldBinary() {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	os.Remove(managedBin() + ".old")
 }
 
 func Run(current string) int {
@@ -154,6 +175,7 @@ func Run(current string) int {
 		fmt.Fprintf(os.Stderr, "podcli: update check failed: %v\n", err)
 		return 1
 	}
+	config.RecordUpdateCheck(tag)
 	if !newer(tag, current) {
 		fmt.Printf("podcli %s is up to date.\n", current)
 		return 0
@@ -228,20 +250,16 @@ func apply(tag string) error {
 }
 
 // verifyStaged checks the downloaded binary against the release's checksums.txt.
-// Fails closed on a mismatch; fails open (warning) only when checksums.txt is
-// absent, so an older release without a manifest still updates.
+// Fails closed: updates always target the latest release, and checksums.txt is
+// published with every release, so its absence means the binary can't be trusted.
 func verifyStaged(tag, staged string) error {
 	resp, err := guardedClient().Get(checksumsURL(tag))
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot verify update: fetching checksums.txt failed: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
-		fmt.Fprintln(os.Stderr, "  (no checksums.txt in release - skipped verification)")
-		return nil
-	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP %d fetching checksums.txt", resp.StatusCode)
+		return fmt.Errorf("cannot verify update: HTTP %d fetching checksums.txt (it is published with every release - retry later)", resp.StatusCode)
 	}
 	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
@@ -249,8 +267,7 @@ func verifyStaged(tag, staged string) error {
 	}
 	want, ok := provision.ParseChecksums(data)[assetName()]
 	if !ok {
-		fmt.Fprintf(os.Stderr, "  (no checksum entry for %s - skipped verification)\n", assetName())
-		return nil
+		return fmt.Errorf("cannot verify update: no entry for %s in checksums.txt", assetName())
 	}
 	got, err := provision.Sha256File(staged)
 	if err != nil {
@@ -286,25 +303,10 @@ func swap(staged, dest string) error {
 	return os.Rename(staged, dest)
 }
 
+// downloadFile reuses provisioning's resumable download, but keeps this path's
+// narrower redirect allowlist: provisioning also trusts the model and ffmpeg
+// CDNs, and nothing outside GitHub may serve the podcli binary.
 func downloadFile(url, dest string) error {
-	resp, err := guardedClient().Get(url)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP %d for %s", resp.StatusCode, url)
-	}
-	tmp := dest + ".part"
-	f, err := os.Create(tmp)
-	if err != nil {
-		return err
-	}
-	_, err = io.Copy(f, resp.Body)
-	f.Close()
-	if err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return os.Rename(tmp, dest)
+	os.Remove(dest) // a stale staged binary must not satisfy Fetch's have() check
+	return provision.FetchGuarded(url, dest, "podcli", allowedHost)
 }

--- a/cli/internal/update/update_test.go
+++ b/cli/internal/update/update_test.go
@@ -3,10 +3,16 @@ package update
 import (
 	"bytes"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"podcli/internal/config"
+	"podcli/internal/provision"
 )
 
 func TestSwapReplacesBinary(t *testing.T) {
@@ -47,6 +53,21 @@ func TestNewer(t *testing.T) {
 	}
 }
 
+func TestUpdateCheckCache(t *testing.T) {
+	t.Setenv("PODCLI_HOME", t.TempDir())
+	if _, ok := config.CachedUpdateCheck(24 * time.Hour); ok {
+		t.Fatal("fresh config should have no cached check")
+	}
+	config.RecordUpdateCheck("9.9.9")
+	tag, ok := config.CachedUpdateCheck(24 * time.Hour)
+	if !ok || tag != "9.9.9" {
+		t.Fatalf("cached check = %q, %v; want 9.9.9 within 24h", tag, ok)
+	}
+	if _, ok := config.CachedUpdateCheck(0); ok {
+		t.Fatal("expired cache should force a re-check")
+	}
+}
+
 func TestSelfUpdateFailureOmitsPackageManagerFallback(t *testing.T) {
 	var out bytes.Buffer
 	printSelfUpdateFailure(&out, errors.New("boom"))
@@ -59,6 +80,26 @@ func TestSelfUpdateFailureOmitsPackageManagerFallback(t *testing.T) {
 	}
 	if !strings.Contains(got, "Your installed podcli was left unchanged.") {
 		t.Fatalf("failure output should say the install is unchanged:\n%s", got)
+	}
+}
+
+// The provisioning allowlist also trusts the model and ffmpeg CDNs; a release
+// asset URL that redirects to one of them must still be refused for the binary.
+func TestDownloadFileRefusesRedirectOffGitHub(t *testing.T) {
+	for _, host := range []string{"https://evermeet.cx/payload", "https://huggingface.co/payload"} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, host, http.StatusFound)
+		}))
+		dest := filepath.Join(t.TempDir(), "podcli.new")
+		err := downloadFile(srv.URL, dest)
+		srv.Close()
+
+		if !errors.Is(err, provision.ErrUntrustedRedirect) {
+			t.Fatalf("redirect to %s should be refused, got %v", host, err)
+		}
+		if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+			t.Fatalf("refused download left a staged binary behind: %v", statErr)
+		}
 	}
 }
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -269,6 +269,10 @@ func setup(args []string) int {
 			refresh = true
 		}
 	}
+	// setup is the one path that may re-provision, so it is the one path allowed to ask
+	// upstream what the current build is. Every other command trusts the local artifact
+	// state and stays offline-capable.
+	provision.VerifyRemote = true
 	fmt.Printf("Provisioning into %s\n", paths.Home())
 	// Extracted from the binary, so it costs nothing and can't fail on a bad network.
 	// First, so an interrupted or offline setup still leaves a backend matching this

--- a/cli/main.go
+++ b/cli/main.go
@@ -22,6 +22,7 @@ import (
 
 func main() {
 	os.Setenv("PODCLI_VERSION", Version)
+	update.CleanupOldBinary()
 	args := os.Args[1:]
 	if len(args) == 0 {
 		os.Exit(runEngine(args)) // backend's branded interactive menu
@@ -107,7 +108,9 @@ func refreshStudioBundles() {
 func ensureRuntime() error {
 	if _, ok := engine.BackendRoot(); !ok {
 		fmt.Fprintln(os.Stderr, "First run - setting up podcli (one-time download)...")
-		setup(nil)
+		if setup(nil) != 0 {
+			return fmt.Errorf("first-run setup failed (see errors above) - run `podcli setup` to retry")
+		}
 	} else if err := refreshBackend(); err != nil {
 		return err
 	}
@@ -411,7 +414,7 @@ func mcpInstall() int {
 }
 
 func uninstall(args []string) int {
-	yes, dryRun := false, false
+	yes, dryRun, purge := false, false, false
 	for _, a := range args {
 		switch a {
 		case "--yes", "-y":
@@ -419,7 +422,7 @@ func uninstall(args []string) int {
 		case "--dry-run":
 			dryRun = true
 		case "--purge":
-			// Kept for compatibility; uninstall already removes everything.
+			purge = true
 		case "--help", "-h":
 			printUninstallHelp()
 			return 0
@@ -436,11 +439,16 @@ func uninstall(args []string) int {
 	if !pathContains(paths.BinDir(), self) {
 		self = ""
 	}
-	targets := uninstallTargets(home)
+	targets := uninstallTargets(home, purge)
 	links := podcliLinks(managed, self)
 
 	fmt.Println("podcli uninstall")
-	fmt.Printf("  This will remove podcli and all managed data under: %s\n", home)
+	if purge {
+		fmt.Printf("  This will remove podcli and all managed data under: %s\n", home)
+	} else {
+		fmt.Printf("  This will remove podcli app files under: %s\n", home)
+		fmt.Println("  User data (config, knowledge, presets, assets, history, cache) is kept - pass --purge to remove it too.")
+	}
 	for _, p := range targets {
 		fmt.Printf("  remove: %s\n", p)
 	}
@@ -488,12 +496,26 @@ func uninstall(args []string) int {
 		fmt.Fprintf(os.Stderr, "  note: the running binary is still in use and was left in place: %s\n", self)
 		fmt.Fprintln(os.Stderr, "        Delete it after this command exits, or run the installer script with --uninstall.")
 	}
-	fmt.Println("Done - podcli app files were removed.")
+	if purge {
+		fmt.Println("Done - podcli and all managed data were removed.")
+	} else {
+		fmt.Println("Done - podcli app files were removed (user data kept).")
+	}
 	return 0
 }
 
-func uninstallTargets(home string) []string {
-	return []string{home}
+// uninstallTargets lists what uninstall removes. By default only the app dirs
+// go; user data (config.json, knowledge, presets, assets, history, cache) sits
+// directly under home and survives unless --purge removes the whole dir.
+func uninstallTargets(home string, purge bool) []string {
+	if purge {
+		return []string{home}
+	}
+	return []string{
+		filepath.Join(home, "bin"),
+		filepath.Join(home, "runtime"),
+		filepath.Join(home, "models"),
+	}
 }
 
 func podcliLinks(managed, self string) []string {
@@ -598,12 +620,13 @@ func confirm(prompt string) bool {
 func printUninstallHelp() {
 	fmt.Println(`Usage: podcli uninstall [--yes] [--dry-run] [--purge]
 
-Removes podcli's managed folder, user data, and installer-created links.
+Removes podcli's app files (bin, runtime, models) and installer-created links.
+User data (config, knowledge, presets, assets, history, cache) is kept.
 
 Options:
   -y, --yes     Do not prompt for confirmation
   --dry-run     Show what would be removed without deleting anything
-  --purge       Kept for compatibility; uninstall already removes everything`)
+  --purge       Also remove user data (deletes the entire podcli folder)`)
 }
 
 // backendStamp annotates an unmanaged or out-of-date backend, the drift the

--- a/cli/uninstall_test.go
+++ b/cli/uninstall_test.go
@@ -30,11 +30,32 @@ func TestLinkPointsToAbsoluteAndRelativeSymlinks(t *testing.T) {
 	}
 }
 
-func TestUninstallTargetsRemoveAllByDefault(t *testing.T) {
+func TestUninstallTargetsKeepUserDataByDefault(t *testing.T) {
 	home := filepath.Join(t.TempDir(), "podcli")
-	got := uninstallTargets(home)
+	got := uninstallTargets(home, false)
+	want := map[string]bool{
+		filepath.Join(home, "bin"):     true,
+		filepath.Join(home, "runtime"): true,
+		filepath.Join(home, "models"):  true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("uninstall targets = %v, want app dirs only", got)
+	}
+	for _, p := range got {
+		if p == home {
+			t.Fatalf("default uninstall must not remove the whole home dir")
+		}
+		if !want[p] {
+			t.Fatalf("unexpected uninstall target %s", p)
+		}
+	}
+}
+
+func TestUninstallTargetsPurgeRemovesHome(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "podcli")
+	got := uninstallTargets(home, true)
 	if len(got) != 1 || got[0] != home {
-		t.Fatalf("uninstall targets = %v, want only %s", got, home)
+		t.Fatalf("purge targets = %v, want only %s", got, home)
 	}
 }
 

--- a/install.cmd
+++ b/install.cmd
@@ -2,17 +2,17 @@
 setlocal
 cd /d "%~dp0"
 
-echo Installing podcli - this can take a few minutes (downloads Whisper, Python and Node packages)...
+echo Installing podcli - downloads the prebuilt binary (runtimes are provisioned on first run)...
 echo.
 
-powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0setup.ps1" -Install
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install.ps1"
 set "RC=%ERRORLEVEL%"
 
 echo.
 if not "%RC%"=="0" (
     echo Install failed with code %RC%. Review the messages above.
 ) else (
-    echo Install complete. To open the studio, run:  powershell -ExecutionPolicy Bypass -File setup.ps1 -Ui
+    echo Install complete. Restart your terminal, then run:  podcli
 )
 echo.
 pause

--- a/install.ps1
+++ b/install.ps1
@@ -53,7 +53,7 @@ if ($Uninstall) {
   if ($Purge) {
     $targets = @($homeDir)
   } else {
-    $targets = @($binDir, (Join-Path $homeDir 'runtime'), (Join-Path $homeDir 'models'), (Join-Path $homeDir 'tools'))
+    $targets = @($binDir, (Join-Path $homeDir 'runtime'), (Join-Path $homeDir 'models'))
   }
   foreach ($p in $targets) {
     if (Test-Path $p) {

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@
 # or ffmpeg needed; the binary provisions those itself on first run).
 # Usage: curl -fsSL https://raw.githubusercontent.com/nmbrthirteen/podcli/main/install.sh | sh
 # Uninstall: curl -fsSL https://raw.githubusercontent.com/nmbrthirteen/podcli/main/install.sh | sh -s -- --uninstall
+# Purge:     curl -fsSL https://raw.githubusercontent.com/nmbrthirteen/podcli/main/install.sh | sh -s -- --uninstall --purge
 set -eu
 
 REPO="nmbrthirteen/podcli"
@@ -19,6 +20,8 @@ esac
 bin_dir="$home_dir/bin"
 
 if [ "${1:-}" = "--uninstall" ]; then
+  purge=0
+  [ "${2:-}" = "--purge" ] && purge=1
   echo "Uninstalling podcli..."
   for d in /usr/local/bin "$HOME/.local/bin"; do
     link="$d/podcli"
@@ -30,7 +33,12 @@ if [ "${1:-}" = "--uninstall" ]; then
       fi
     fi
   done
-  for p in "$bin_dir" "$home_dir/runtime" "$home_dir/models" "$home_dir/tools"; do
+  if [ "$purge" = 1 ]; then
+    set -- "$home_dir"
+  else
+    set -- "$bin_dir" "$home_dir/runtime" "$home_dir/models"
+  fi
+  for p in "$@"; do
     if [ -e "$p" ]; then
       if rm -rf "$p"; then
         echo "  removed: $p"
@@ -39,9 +47,13 @@ if [ "${1:-}" = "--uninstall" ]; then
       fi
     fi
   done
-  echo "  removed app files from: $home_dir"
-  echo "  kept user data (config, knowledge, presets, assets, history, cache)."
-  echo "  To remove everything: rm -rf '$home_dir'"
+  if [ "$purge" = 1 ]; then
+    echo "  removed podcli and all managed data from: $home_dir"
+  else
+    echo "  removed app files from: $home_dir"
+    echo "  kept user data (config, knowledge, presets, assets, history, cache)."
+    echo "  To remove everything, re-run with: --uninstall --purge"
+  fi
   exit 0
 fi
 
@@ -52,7 +64,7 @@ case "$arch" in
 esac
 target="${goos}-${goarch}"
 if [ "$target" = "darwin-amd64" ]; then
-  err "Intel Macs aren't supported yet (coming in v2.0.1). Apple Silicon, Linux, and Windows are available."
+  err "Intel Macs aren't supported yet. Apple Silicon, Linux, and Windows are available."
 fi
 mkdir -p "$bin_dir"
 


### PR DESCRIPTION
ffmpeg came from mutable latest URLs on third party hosts with no checksum,
which is the failure the evermeet.cx outage already demonstrated. Every
source is now a pinned version with a SHA256 that was verified by downloading
the archive and checking it extracts.

- Checksum verification fails closed instead of skipping when a manifest is
  unreachable; an unpinned model is a build error
- HTTPS_PROXY and friends are honored on every download and self-update
- uninstall keeps knowledge, presets, assets, and history unless --purge,
  which is what its help text always promised
- Resumed downloads send If-Range, a stalled connection times out, and a
  per artifact lock heartbeats so a slow download is never stolen
- Self-update keeps its GitHub-only redirect allowlist
- First-run setup failures stop with the real error

Part of the product audit. Stacked on `audit-1-docs`, so review only this PR's diff and merge in order.