### PR TITLE
Cut wasted render passes and let laughter drive clip selection

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -3183,16 +3183,16 @@ def cmd_cache(args):
 
     if action == "clear":
         count = 0
-        if os.path.isdir(cache_dir):
-            for fname in os.listdir(cache_dir):
+        for directory in (
+            cache_dir,
+            os.path.join(cache_dir, "transcripts"),
+            os.path.join(cache_dir, "signals"),
+        ):
+            if not os.path.isdir(directory):
+                continue
+            for fname in os.listdir(directory):
                 if fname.endswith(".json"):
-                    os.unlink(os.path.join(cache_dir, fname))
-                    count += 1
-        transcripts_dir = os.path.join(cache_dir, "transcripts")
-        if os.path.isdir(transcripts_dir):
-            for fname in os.listdir(transcripts_dir):
-                if fname.endswith(".json"):
-                    os.unlink(os.path.join(transcripts_dir, fname))
+                    os.unlink(os.path.join(directory, fname))
                     count += 1
         if count:
             print(f"\n  {green}✓{reset} Cleared {count} cached transcription(s)")

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,6 +29,13 @@ except ImportError:
     pass
 import threading
 import traceback
+from services.audio_analyzer import get_energy_profile
+from services.audio_events import get_event_profile, is_available as audio_events_available
+from services.claude_suggest import (
+    _find_ai_cli_candidates,
+    select_clips_with_signal_scores,
+    suggest_initial_with_claude,
+)
 from version import VERSION
 
 # Serializes event writes so parallel clip workers can't interleave JSON lines.
@@ -583,28 +590,41 @@ def handle_corrections(task_id: str, params: dict):
         emit_result(task_id, "error", error=f"Unknown corrections action: {action}")
 
 
-def _reaction_times_for_suggest(params: dict, segments: list) -> list | None:
-    """Laughter/reaction anchors for the suggestion prompt, if the caller has them."""
-    times = params.get("reaction_times")
-    if times:
-        return [float(t) for t in times]
-
+def _signal_profiles_for_suggest(
+    params: dict,
+    segments: list,
+) -> tuple[list | None, list | None, list | None]:
+    energy_data = params.get("energy_data")
+    events_data = params.get("events_data")
+    reaction_times = params.get("reaction_times")
+    if reaction_times is not None:
+        reaction_times = [float(t) for t in reaction_times]
     video_path = params.get("video_path")
     if not video_path or not os.path.exists(video_path):
-        return None
-    try:
-        from services.audio_events import get_event_profile, is_available
-        if not is_available():
-            return None
-        return get_event_profile(video_path, segments)["reaction_times"]
-    except Exception:
-        return None
+        return energy_data, events_data, reaction_times
+
+    if energy_data is None:
+        try:
+            energy_data = get_energy_profile(video_path, segments)["energy_data"]
+        except Exception:
+            energy_data = None
+
+    if events_data is None or reaction_times is None:
+        try:
+            if audio_events_available():
+                event_profile = get_event_profile(video_path, segments)
+                if events_data is None:
+                    events_data = event_profile["events_data"]
+                if reaction_times is None:
+                    reaction_times = event_profile["reaction_times"]
+        except Exception:
+            pass
+
+    return energy_data, events_data, reaction_times
 
 
 def handle_suggest_clips(task_id: str, params: dict):
     """AI-powered clip suggestion using Claude/Codex and PodStack knowledge base."""
-    from services.claude_suggest import suggest_initial_with_claude, _find_ai_cli_candidates
-
     segments = params.get("segments", [])
     top_n = params.get("top_n", 5)
     existing_clips = params.get("existing_clips", [])
@@ -625,13 +645,15 @@ def handle_suggest_clips(task_id: str, params: dict):
         return
 
     errors: list[str] = []
+    energy_data, events_data, reaction_times = _signal_profiles_for_suggest(params, segments)
+    candidate_top_n = top_n * 2 if energy_data or events_data else top_n
     clips = suggest_initial_with_claude(
         segments=segments,
-        top_n=top_n,
+        top_n=candidate_top_n,
         exclude_clips=existing_clips,
         progress_callback=lambda pct, msg: emit_progress(task_id, "suggesting", pct, msg),
         error_sink=errors,
-        reaction_times=_reaction_times_for_suggest(params, segments),
+        reaction_times=reaction_times,
     )
 
     if clips is None:
@@ -639,6 +661,12 @@ def handle_suggest_clips(task_id: str, params: dict):
         emit_result(task_id, "error", error=detail)
         return
 
+    clips = select_clips_with_signal_scores(
+        clips,
+        top_n=top_n,
+        energy_data=energy_data,
+        events_data=events_data,
+    )
     emit_result(task_id, "success", data={"clips": clips})
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,8 +27,12 @@ try:
     load_dotenv(os.environ.get("PODCLI_ENV_FILE") or os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".env"))
 except ImportError:
     pass
+import threading
 import traceback
 from version import VERSION
+
+# Serializes event writes so parallel clip workers can't interleave JSON lines.
+_emit_lock = threading.Lock()
 
 
 def emit_progress(task_id: str, stage: str, percent: int, message: str, **extra):
@@ -40,7 +44,8 @@ def emit_progress(task_id: str, stage: str, percent: int, message: str, **extra)
         "message": message,
     }
     event.update(extra)
-    print(json.dumps(event), file=sys.stderr, flush=True)
+    with _emit_lock:
+        print(json.dumps(event), file=sys.stderr, flush=True)
 
 
 def emit_result(task_id: str, status: str, data=None, error=None):
@@ -53,7 +58,8 @@ def emit_result(task_id: str, status: str, data=None, error=None):
         result["data"] = data
     if error is not None:
         result["error"] = error
-    print(json.dumps(result), flush=True)
+    with _emit_lock:
+        print(json.dumps(result), flush=True)
 
 
 def handle_ping(task_id: str, params: dict):
@@ -76,6 +82,16 @@ def handle_transcribe(task_id: str, params: dict):
         os.environ["PODCLI_ENGINE"] = engine
     if params.get("assemblyai_api_key"):
         os.environ["ASSEMBLYAI_API_KEY"] = params["assemblyai_api_key"]
+
+    # One shared 16 kHz mono wav feeds transcription, energy and reactions
+    # instead of decoding the source three times.
+    shared_wav = None
+    try:
+        from services.audio_extract import extract_wav_16k_mono
+        shared_wav = extract_wav_16k_mono(file_path)
+    except Exception:
+        shared_wav = None
+
     try:
         result = transcribe_file(
             file_path=file_path,
@@ -85,7 +101,42 @@ def handle_transcribe(task_id: str, params: dict):
             enable_diarization=params.get("enable_diarization", True),
             num_speakers=params.get("num_speakers"),
             progress_callback=lambda pct, msg: emit_progress(task_id, "transcribing", pct, msg),
+            wav_path=shared_wav,
         )
+        # Apply word corrections (Whisper misheard proper nouns)
+        apply_corrections(result.get("words", []), result.get("segments", []))
+
+        # Auto-pack: emit compact LLM-readable markdown alongside raw JSON.
+        # Pulls energy data so the packed view includes peak moments for clip reasoning.
+        try:
+            from services.audio_analyzer import extract_audio_energy
+
+            cache_hash = compute_cache_hash(file_path) + engine_cache_suffix(result.get("engine") or engine)
+            energy_data = None
+            try:
+                energy_data = extract_audio_energy(file_path, wav_path=shared_wav)
+            except Exception:
+                pass  # energy is a nice-to-have
+
+            events_data = None
+            try:
+                from services.audio_events import extract_audio_events
+                events_data = extract_audio_events(file_path, wav_path=shared_wav)
+            except Exception:
+                pass  # reactions are a nice-to-have
+
+            packed_path, packed_md = write_packed(
+                result,
+                cache_hash,
+                source_label=os.path.basename(file_path),
+                energy_data=energy_data,
+                events_data=events_data,
+            )
+            result["packed_path"] = packed_path
+            result["packed_size_bytes"] = len(packed_md.encode("utf-8"))
+        except Exception as e:
+            # Non-fatal — transcription result is still useful without the packed view
+            emit_progress(task_id, "packing", 99, f"Packer skipped: {e}")
     finally:
         if previous_engine is None:
             os.environ.pop("PODCLI_ENGINE", None)
@@ -95,40 +146,11 @@ def handle_transcribe(task_id: str, params: dict):
             os.environ.pop("ASSEMBLYAI_API_KEY", None)
         else:
             os.environ["ASSEMBLYAI_API_KEY"] = previous_assemblyai_key
-    # Apply word corrections (Whisper misheard proper nouns)
-    apply_corrections(result.get("words", []), result.get("segments", []))
-
-    # Auto-pack: emit compact LLM-readable markdown alongside raw JSON.
-    # Pulls energy data so the packed view includes peak moments for clip reasoning.
-    try:
-        from services.audio_analyzer import extract_audio_energy
-
-        cache_hash = compute_cache_hash(file_path) + engine_cache_suffix(result.get("engine") or engine)
-        energy_data = None
-        try:
-            energy_data = extract_audio_energy(file_path)
-        except Exception:
-            pass  # energy is a nice-to-have
-
-        events_data = None
-        try:
-            from services.audio_events import extract_audio_events
-            events_data = extract_audio_events(file_path)
-        except Exception:
-            pass  # reactions are a nice-to-have
-
-        packed_path, packed_md = write_packed(
-            result,
-            cache_hash,
-            source_label=os.path.basename(file_path),
-            energy_data=energy_data,
-            events_data=events_data,
-        )
-        result["packed_path"] = packed_path
-        result["packed_size_bytes"] = len(packed_md.encode("utf-8"))
-    except Exception as e:
-        # Non-fatal — transcription result is still useful without the packed view
-        emit_progress(task_id, "packing", 99, f"Packer skipped: {e}")
+        if shared_wav and os.path.exists(shared_wav):
+            try:
+                os.unlink(shared_wav)
+            except OSError:
+                pass
 
     emit_result(task_id, "success", data=result)
 
@@ -164,65 +186,102 @@ def handle_create_clip(task_id: str, params: dict):
     emit_result(task_id, "success", data=result)
 
 
+def _render_concurrency() -> int:
+    raw = (os.environ.get("PODCLI_RENDER_CONCURRENCY") or "").strip()
+    if raw:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            pass
+    return 2 if (os.cpu_count() or 1) >= 8 else 1
+
+
 def handle_batch_clips(task_id: str, params: dict):
-    """Create multiple clips in sequence."""
+    """Create multiple clips with a bounded worker pool."""
+    from concurrent.futures import ThreadPoolExecutor
     from services.clip_generator import generate_clip
     from services import asset_store
 
     clips = params["clips"]
-    results = []
     total = len(clips)
+    results = [None] * total
+    completed = 0
+    completed_lock = threading.Lock()
 
-    for i, clip in enumerate(clips):
+    def render_one(i: int, clip: dict) -> dict:
         emit_progress(
             task_id,
             "batch",
             int((i / total) * 100),
             f"Processing clip {i + 1}/{total}...",
         )
+        result = generate_clip(
+            video_path=params["video_path"],
+            start_second=clip["start_second"],
+            end_second=clip["end_second"],
+            caption_style=clip.get("caption_style", "hormozi"),
+            crop_strategy=clip.get("crop_strategy", "face"),
+            format=clip.get("format", params.get("format", "vertical")),
+            transcript_words=params.get("transcript_words", []),
+            title=clip.get("title", f"clip_{i + 1}"),
+            output_dir=params.get("output_dir"),
+            logo_path=asset_store.resolve(clip.get("logo_path") or params.get("logo_path")),
+            outro_path=asset_store.resolve(params.get("outro_path")),
+            intro_path=asset_store.resolve(clip.get("intro_path") or params.get("intro_path")),
+            clean_fillers=params.get("clean_fillers", True),
+            face_map=params.get("face_map"),
+            keep_segments=clip.get("keep_segments"),
+            allow_ass_fallback=clip.get("allow_ass_fallback", params.get("allow_ass_fallback", False)),
+            use_ass_captions=clip.get("use_ass_captions", params.get("use_ass_captions", False)),
+            keep_caption_overlay=clip.get(
+                "keep_caption_overlay", params.get("keep_caption_overlay", False)
+            ),
+            progress_callback=lambda pct, msg, _i=i: emit_progress(
+                task_id, "batch", int((_i / total) * 100 + pct / total), msg
+            ),
+        )
+        return {
+            "clip_index": i,
+            "status": "success",
+            "start_second": clip["start_second"],
+            "end_second": clip["end_second"],
+            **result,
+        }
+
+    def run_and_record(i: int, clip: dict) -> None:
+        nonlocal completed
         try:
-            result = generate_clip(
-                video_path=params["video_path"],
-                start_second=clip["start_second"],
-                end_second=clip["end_second"],
-                caption_style=clip.get("caption_style", "hormozi"),
-                crop_strategy=clip.get("crop_strategy", "face"),
-                format=clip.get("format", params.get("format", "vertical")),
-                transcript_words=params.get("transcript_words", []),
-                title=clip.get("title", f"clip_{i + 1}"),
-                output_dir=params.get("output_dir"),
-                logo_path=asset_store.resolve(clip.get("logo_path") or params.get("logo_path")),
-                outro_path=asset_store.resolve(params.get("outro_path")),
-                intro_path=asset_store.resolve(clip.get("intro_path") or params.get("intro_path")),
-                clean_fillers=params.get("clean_fillers", True),
-                face_map=params.get("face_map"),
-                keep_segments=clip.get("keep_segments"),
-                allow_ass_fallback=clip.get("allow_ass_fallback", params.get("allow_ass_fallback", False)),
-                use_ass_captions=clip.get("use_ass_captions", params.get("use_ass_captions", False)),
-                keep_caption_overlay=clip.get(
-                    "keep_caption_overlay", params.get("keep_caption_overlay", False)
-                ),
-                progress_callback=lambda pct, msg, _i=i: emit_progress(
-                    task_id, "batch", int((_i / total) * 100 + pct / total), msg
-                ),
-            )
-            row = {
-                "clip_index": i,
-                "status": "success",
-                "start_second": clip["start_second"],
-                "end_second": clip["end_second"],
-                **result,
-            }
-            results.append(row)
-            emit_progress(
-                task_id,
-                "clip_complete",
-                int(((i + 1) / total) * 100),
-                f"Clip {i + 1}/{total} complete",
-                clip_result=row,
-            )
+            row = results[i] = render_one(i, clip)
+            message = f"Clip {i + 1}/{total} complete"
         except Exception as e:
-            results.append({"clip_index": i, "status": "error", "error": str(e)})
+            row = results[i] = {
+                "clip_index": i,
+                "status": "error",
+                "start_second": clip.get("start_second"),
+                "end_second": clip.get("end_second"),
+                "error": str(e),
+            }
+            message = f"Clip {i + 1}/{total} failed"
+        with completed_lock:
+            completed += 1
+            done = completed
+        emit_progress(
+            task_id,
+            "clip_complete",
+            int((done / total) * 100),
+            message,
+            clip_result=row,
+        )
+
+    workers = min(_render_concurrency(), max(1, total))
+    if workers <= 1:
+        for i, clip in enumerate(clips):
+            run_and_record(i, clip)
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [pool.submit(run_and_record, i, clip) for i, clip in enumerate(clips)]
+            for f in futures:
+                f.result()
 
     emit_result(
         task_id,
@@ -230,7 +289,7 @@ def handle_batch_clips(task_id: str, params: dict):
         data={
             "results": results,
             "total_clips": total,
-            "successful_clips": sum(1 for r in results if r["status"] == "success"),
+            "successful_clips": sum(1 for r in results if r and r["status"] == "success"),
         },
     )
 
@@ -524,6 +583,24 @@ def handle_corrections(task_id: str, params: dict):
         emit_result(task_id, "error", error=f"Unknown corrections action: {action}")
 
 
+def _reaction_times_for_suggest(params: dict, segments: list) -> list | None:
+    """Laughter/reaction anchors for the suggestion prompt, if the caller has them."""
+    times = params.get("reaction_times")
+    if times:
+        return [float(t) for t in times]
+
+    video_path = params.get("video_path")
+    if not video_path or not os.path.exists(video_path):
+        return None
+    try:
+        from services.audio_events import get_event_profile, is_available
+        if not is_available():
+            return None
+        return get_event_profile(video_path, segments)["reaction_times"]
+    except Exception:
+        return None
+
+
 def handle_suggest_clips(task_id: str, params: dict):
     """AI-powered clip suggestion using Claude/Codex and PodStack knowledge base."""
     from services.claude_suggest import suggest_initial_with_claude, _find_ai_cli_candidates
@@ -554,6 +631,7 @@ def handle_suggest_clips(task_id: str, params: dict):
         exclude_clips=existing_clips,
         progress_callback=lambda pct, msg: emit_progress(task_id, "suggesting", pct, msg),
         error_sink=errors,
+        reaction_times=_reaction_times_for_suggest(params, segments),
     )
 
     if clips is None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,13 +29,6 @@ except ImportError:
     pass
 import threading
 import traceback
-from services.audio_analyzer import get_energy_profile
-from services.audio_events import get_event_profile, is_available as audio_events_available
-from services.claude_suggest import (
-    _find_ai_cli_candidates,
-    select_clips_with_signal_scores,
-    suggest_initial_with_claude,
-)
 from version import VERSION
 
 # Serializes event writes so parallel clip workers can't interleave JSON lines.
@@ -113,25 +106,28 @@ def handle_transcribe(task_id: str, params: dict):
         # Apply word corrections (Whisper misheard proper nouns)
         apply_corrections(result.get("words", []), result.get("segments", []))
 
+        energy_data = None
+        try:
+            from services.audio_analyzer import extract_audio_energy
+            energy_data = extract_audio_energy(file_path, wav_path=shared_wav)
+        except Exception:
+            pass  # energy is a nice-to-have
+
+        events_data = None
+        try:
+            from services.audio_events import extract_audio_events
+            events_data = extract_audio_events(file_path, wav_path=shared_wav)
+        except Exception:
+            pass  # reactions are a nice-to-have
+
+        # Cached so clip suggestion reuses these instead of decoding the source again.
+        from services.signal_cache import save_signals
+        save_signals(file_path, energy_data=energy_data, events_data=events_data)
+
         # Auto-pack: emit compact LLM-readable markdown alongside raw JSON.
         # Pulls energy data so the packed view includes peak moments for clip reasoning.
         try:
-            from services.audio_analyzer import extract_audio_energy
-
             cache_hash = compute_cache_hash(file_path) + engine_cache_suffix(result.get("engine") or engine)
-            energy_data = None
-            try:
-                energy_data = extract_audio_energy(file_path, wav_path=shared_wav)
-            except Exception:
-                pass  # energy is a nice-to-have
-
-            events_data = None
-            try:
-                from services.audio_events import extract_audio_events
-                events_data = extract_audio_events(file_path, wav_path=shared_wav)
-            except Exception:
-                pass  # reactions are a nice-to-have
-
             packed_path, packed_md = write_packed(
                 result,
                 cache_hash,
@@ -590,41 +586,102 @@ def handle_corrections(task_id: str, params: dict):
         emit_result(task_id, "error", error=f"Unknown corrections action: {action}")
 
 
+def _extract_signals(
+    task_id: str,
+    video_path: str,
+    want_energy: bool,
+    want_events: bool,
+) -> tuple[list | None, list | None]:
+    """Decode the source once and derive whichever profiles aren't cached yet."""
+    from services.audio_events import is_available as audio_events_available
+
+    want_events = want_events and audio_events_available()
+    if not want_energy and not want_events:
+        return None, None
+
+    wav_path = None
+    try:
+        from services.audio_extract import extract_wav_16k_mono
+        emit_progress(task_id, "suggesting", 2, "Extracting audio...")
+        wav_path = extract_wav_16k_mono(video_path)
+    except Exception:
+        wav_path = None
+
+    energy_data = None
+    events_data = None
+    try:
+        if want_energy:
+            emit_progress(task_id, "suggesting", 5, "Analyzing audio energy...")
+            try:
+                from services.audio_analyzer import extract_audio_energy
+                energy_data = extract_audio_energy(video_path, wav_path=wav_path)
+            except Exception:
+                pass  # energy is a nice-to-have
+        if want_events:
+            emit_progress(task_id, "suggesting", 15, "Detecting laughter and reactions...")
+            try:
+                from services.audio_events import extract_audio_events
+                events_data = extract_audio_events(video_path, wav_path=wav_path)
+            except Exception:
+                pass  # reactions are a nice-to-have
+    finally:
+        if wav_path and os.path.exists(wav_path):
+            try:
+                os.unlink(wav_path)
+            except OSError:
+                pass
+
+    return energy_data, events_data
+
+
 def _signal_profiles_for_suggest(
+    task_id: str,
     params: dict,
-    segments: list,
 ) -> tuple[list | None, list | None, list | None]:
+    """Energy and reaction profiles for the suggester: caller-supplied first, then
+    what transcription cached for this video, and only then a fresh analysis."""
+    from services.audio_events import reaction_times as reaction_times_from_events
+    from services.signal_cache import load_signals, save_signals
+
     energy_data = params.get("energy_data")
     events_data = params.get("events_data")
-    reaction_times = params.get("reaction_times")
-    if reaction_times is not None:
-        reaction_times = [float(t) for t in reaction_times]
+    anchors = params.get("reaction_times")
+    if anchors is not None:
+        anchors = [float(t) for t in anchors]
+
     video_path = params.get("video_path")
-    if not video_path or not os.path.exists(video_path):
-        return energy_data, events_data, reaction_times
+    if video_path and os.path.exists(video_path) and (energy_data is None or events_data is None):
+        cached = load_signals(video_path)
+        if energy_data is None:
+            energy_data = cached.get("energy_data")
+        if events_data is None:
+            events_data = cached.get("events_data")
 
-    if energy_data is None:
-        try:
-            energy_data = get_energy_profile(video_path, segments)["energy_data"]
-        except Exception:
-            energy_data = None
+        if energy_data is None or events_data is None:
+            fresh_energy, fresh_events = _extract_signals(
+                task_id,
+                video_path,
+                want_energy=energy_data is None,
+                want_events=events_data is None,
+            )
+            save_signals(video_path, energy_data=fresh_energy, events_data=fresh_events)
+            energy_data = energy_data if energy_data is not None else fresh_energy
+            events_data = events_data if events_data is not None else fresh_events
 
-    if events_data is None or reaction_times is None:
-        try:
-            if audio_events_available():
-                event_profile = get_event_profile(video_path, segments)
-                if events_data is None:
-                    events_data = event_profile["events_data"]
-                if reaction_times is None:
-                    reaction_times = event_profile["reaction_times"]
-        except Exception:
-            pass
+    if anchors is None and events_data:
+        anchors = reaction_times_from_events(events_data)
 
-    return energy_data, events_data, reaction_times
+    return energy_data, events_data, anchors
 
 
 def handle_suggest_clips(task_id: str, params: dict):
     """AI-powered clip suggestion using Claude/Codex and PodStack knowledge base."""
+    from services.claude_suggest import (
+        _find_ai_cli_candidates,
+        select_clips_with_signal_scores,
+        suggest_initial_with_claude,
+    )
+
     segments = params.get("segments", [])
     top_n = params.get("top_n", 5)
     existing_clips = params.get("existing_clips", [])
@@ -645,7 +702,7 @@ def handle_suggest_clips(task_id: str, params: dict):
         return
 
     errors: list[str] = []
-    energy_data, events_data, reaction_times = _signal_profiles_for_suggest(params, segments)
+    energy_data, events_data, reaction_times = _signal_profiles_for_suggest(task_id, params)
     candidate_top_n = top_n * 2 if energy_data or events_data else top_n
     clips = suggest_initial_with_claude(
         segments=segments,

--- a/backend/services/audio_analyzer.py
+++ b/backend/services/audio_analyzer.py
@@ -6,6 +6,7 @@ then identifies energy peaks (loud moments, laughs, emphasis).
 Used by the clip suggestor to boost scores for high-energy segments.
 """
 
+import os
 import subprocess
 import json
 import re
@@ -14,22 +15,32 @@ from typing import Optional, Callable
 from utils.proc import run as proc_run
 
 
+_ANALYSIS_RATE = 16000
+
+
 def extract_audio_energy(
     video_path: str,
     window_sec: float = 1.0,
+    wav_path: str = None,
 ) -> list[dict]:
     """
-    Extract per-second RMS energy levels from a video's audio track.
+    Extract per-window RMS energy levels from a video's audio track.
 
     Returns list of {time, rms, peak} dicts, one per window.
+    wav_path: optional pre-extracted 16 kHz mono WAV — skips decoding the
+    video again when the orchestration layer already extracted the audio.
     """
-    # Use ffmpeg astats filter on audio only (-vn skips video decoding,
-    # which is the main bottleneck on long podcasts).
+    input_path = wav_path if wav_path and os.path.exists(wav_path) else video_path
+    # astats' reset counts filter frames, not seconds, so pin the frame size
+    # to exactly one window with asetnsamples and reset every frame.
+    # (-vn skips video decoding, the main bottleneck on long podcasts.)
+    window_samples = max(1, int(_ANALYSIS_RATE * window_sec))
     cmd = [
         "ffmpeg",
-        "-i", video_path,
+        "-i", input_path,
         "-vn",
-        "-af", f"astats=metadata=1:reset={int(1/window_sec)},"
+        "-af", f"aresample={_ANALYSIS_RATE},asetnsamples=n={window_samples},"
+               f"astats=metadata=1:reset=1,"
                f"ametadata=print:key=lavfi.astats.Overall.RMS_level:file=-",
         "-f", "null", "-",
     ]
@@ -59,7 +70,7 @@ def extract_audio_energy(
 
     if not energy_data:
         # Fallback: use volumedetect for a simpler analysis
-        return _fallback_energy(video_path)
+        return _fallback_energy(input_path)
 
     return energy_data
 
@@ -167,6 +178,7 @@ def get_energy_profile(
     video_path: str,
     segments: list[dict],
     progress_callback: Optional[Callable] = None,
+    wav_path: str = None,
 ) -> dict:
     """
     Full pipeline: extract energy data and score all segments.
@@ -176,7 +188,7 @@ def get_energy_profile(
     if progress_callback:
         progress_callback(0, "Analyzing audio energy...")
 
-    energy_data = extract_audio_energy(video_path)
+    energy_data = extract_audio_energy(video_path, wav_path=wav_path)
 
     if progress_callback:
         progress_callback(70, "Scoring segments by energy...")

--- a/backend/services/audio_events.py
+++ b/backend/services/audio_events.py
@@ -14,6 +14,7 @@ for extending a clip backwards to the moment that caused the reaction.
 """
 
 import csv
+import os
 import subprocess
 import tempfile
 import wave
@@ -84,9 +85,26 @@ def is_available() -> bool:
     return _ORT_AVAILABLE and _MODEL_PATH.exists()
 
 
-def _read_waveform_16k_mono(video_path: str) -> Optional[np.ndarray]:
-    """Extract audio as a float32 [-1, 1] mono waveform at 16 kHz via ffmpeg."""
-    with tempfile.NamedTemporaryFile(suffix=".wav", delete=True) as tmp:
+def _read_waveform_16k_mono(video_path: str, wav_path: Optional[str] = None) -> Optional[np.ndarray]:
+    """Extract audio as a float32 [-1, 1] mono waveform at 16 kHz via ffmpeg.
+
+    wav_path: optional pre-extracted 16 kHz mono WAV — read directly, no decode.
+    """
+    if wav_path and os.path.exists(wav_path):
+        try:
+            with wave.open(wav_path) as w:
+                frames = w.readframes(w.getnframes())
+        except (wave.Error, OSError):
+            return None
+        if not frames:
+            return None
+        return np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+
+    # delete=False + manual unlink: on Windows the open NamedTemporaryFile
+    # handle blocks ffmpeg from writing to the same path.
+    tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+    tmp.close()
+    try:
         cmd = [
             "ffmpeg", "-y", "-i", video_path,
             "-vn", "-ar", "16000", "-ac", "1",
@@ -95,14 +113,22 @@ def _read_waveform_16k_mono(video_path: str) -> Optional[np.ndarray]:
         result = proc_run(cmd, timeout=600, check=False)
         if result.returncode != 0:
             return None
-        with wave.open(tmp.name) as w:
-            frames = w.readframes(w.getnframes())
+        try:
+            with wave.open(tmp.name) as w:
+                frames = w.readframes(w.getnframes())
+        except (wave.Error, OSError):
+            return None
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
     if not frames:
         return None
     return np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
 
 
-def extract_audio_events(video_path: str) -> list[dict]:
+def extract_audio_events(video_path: str, wav_path: Optional[str] = None) -> list[dict]:
     """
     Run YAMNet over a video's audio and return per-frame reaction probabilities.
 
@@ -114,7 +140,7 @@ def extract_audio_events(video_path: str) -> list[dict]:
     if session is None:
         return []
 
-    waveform = _read_waveform_16k_mono(video_path)
+    waveform = _read_waveform_16k_mono(video_path, wav_path=wav_path)
     if waveform is None or waveform.size == 0:
         return []
 
@@ -201,6 +227,7 @@ def get_event_profile(
     segments: list[dict],
     progress_callback: Optional[Callable] = None,
     reaction_threshold: float = 0.15,
+    wav_path: Optional[str] = None,
 ) -> dict:
     """
     Full pipeline: detect audio events and score all segments.
@@ -215,7 +242,7 @@ def get_event_profile(
     if progress_callback:
         progress_callback(0, "Detecting laughter and reactions...")
 
-    events_data = extract_audio_events(video_path)
+    events_data = extract_audio_events(video_path, wav_path=wav_path)
 
     if progress_callback:
         progress_callback(70, "Scoring segments by reaction...")

--- a/backend/services/audio_events.py
+++ b/backend/services/audio_events.py
@@ -13,6 +13,8 @@ it anti-correlates with speech at the frame level, which makes it a reliable anc
 for extending a clip backwards to the moment that caused the reaction.
 """
 
+from __future__ import annotations
+
 import csv
 import os
 import subprocess
@@ -21,15 +23,16 @@ import wave
 from pathlib import Path
 from typing import Optional, Callable
 
-import numpy as np
-
 from utils.proc import run as proc_run
 
+# Guarded together: on a partial runtime, reaction detection turns itself off rather
+# than taking down every other backend task with an import error.
 try:
+    import numpy as np
     import onnxruntime as ort
-    _ORT_AVAILABLE = True
+    _RUNTIME_AVAILABLE = True
 except ImportError:
-    _ORT_AVAILABLE = False
+    _RUNTIME_AVAILABLE = False
 
 _MODELS_DIR = Path(__file__).resolve().parents[1] / "models"
 _MODEL_PATH = _MODELS_DIR / "yamnet.onnx"
@@ -41,6 +44,9 @@ _LAUGHTER_KEYS = ("laugh", "giggle", "chuckle", "snicker", "chortle")
 _CHEER_NAMES = ("Cheering", "Applause", "Whoop")
 _SCREAM_NAMES = ("Screaming",)
 _SPEECH_NAMES = ("Speech",)
+
+_REACTION_CHANNELS = ("laughter", "cheering", "screaming")
+REACTION_THRESHOLD = 0.15
 
 _session = None
 _class_index: dict[str, list[int]] = {}
@@ -70,7 +76,7 @@ def _load_class_index() -> dict[str, list[int]]:
 
 def _get_session():
     global _session, _class_index
-    if not _ORT_AVAILABLE or not _MODEL_PATH.exists():
+    if not _RUNTIME_AVAILABLE or not _MODEL_PATH.exists():
         return None
     if _session is None:
         _session = ort.InferenceSession(
@@ -81,8 +87,8 @@ def _get_session():
 
 
 def is_available() -> bool:
-    """True if onnxruntime and the YAMNet model are both present."""
-    return _ORT_AVAILABLE and _MODEL_PATH.exists()
+    """True if onnxruntime, numpy and the YAMNet model are all present."""
+    return _RUNTIME_AVAILABLE and _MODEL_PATH.exists()
 
 
 def _read_waveform_16k_mono(video_path: str, wav_path: Optional[str] = None) -> Optional[np.ndarray]:
@@ -189,7 +195,27 @@ def extract_audio_events(video_path: str, wav_path: Optional[str] = None) -> lis
 
 def _reaction_level(event: dict) -> float:
     """Combined reaction strength for one frame: the loudest reaction channel."""
-    return max(event["laughter"], event["cheering"], event["screaming"])
+    return max(event[channel] for channel in _REACTION_CHANNELS)
+
+
+def reaction_times(
+    events_data: list[dict],
+    threshold: float = REACTION_THRESHOLD,
+) -> list[float]:
+    """Timestamps of frames whose reaction level clears `threshold`."""
+    return [e["time"] for e in events_data if _reaction_level(e) >= threshold]
+
+
+def dominant_reaction(events_data: list[dict], start: float, end: float) -> Optional[str]:
+    """Name of the strongest reaction channel in [start, end]: laughter, cheering
+    or screaming. None if nothing reacted in that range."""
+    frames = [e for e in events_data if start <= e["time"] <= end]
+    if not frames:
+        return None
+    peak = max(frames, key=_reaction_level)
+    if _reaction_level(peak) <= 0:
+        return None
+    return max(_REACTION_CHANNELS, key=lambda channel: peak[channel])
 
 
 def compute_event_scores(
@@ -226,7 +252,7 @@ def get_event_profile(
     video_path: str,
     segments: list[dict],
     progress_callback: Optional[Callable] = None,
-    reaction_threshold: float = 0.15,
+    reaction_threshold: float = REACTION_THRESHOLD,
     wav_path: Optional[str] = None,
 ) -> dict:
     """
@@ -249,15 +275,11 @@ def get_event_profile(
 
     segment_scores = compute_event_scores(events_data, segments)
 
-    reaction_times = [
-        e["time"] for e in events_data if _reaction_level(e) >= reaction_threshold
-    ]
-
     if progress_callback:
         progress_callback(100, "Reaction analysis complete")
 
     return {
         "events_data": events_data,
         "segment_scores": segment_scores,
-        "reaction_times": reaction_times,
+        "reaction_times": reaction_times(events_data, reaction_threshold),
     }

--- a/backend/services/audio_extract.py
+++ b/backend/services/audio_extract.py
@@ -22,7 +22,8 @@ def extract_wav_16k_mono(
 
     When wav_path is None a temp file is created; the caller owns cleanup.
     """
-    if wav_path is None:
+    owns_wav = wav_path is None
+    if owns_wav:
         fd, wav_path = tempfile.mkstemp(prefix="podcli_audio_", suffix=".wav")
         os.close(fd)
     cmd = [
@@ -34,7 +35,15 @@ def extract_wav_16k_mono(
         "-ac", "1",
         wav_path,
     ]
-    result = proc_run(cmd, timeout=timeout, check=False)
-    if result.returncode != 0:
-        raise RuntimeError(f"Audio extraction failed: {(result.stderr or '')[-300:]}")
+    try:
+        result = proc_run(cmd, timeout=timeout, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(f"Audio extraction failed: {(result.stderr or '')[-300:]}")
+    except Exception:
+        if owns_wav:
+            try:
+                os.unlink(wav_path)
+            except OSError:
+                pass
+        raise
     return wav_path

--- a/backend/services/audio_extract.py
+++ b/backend/services/audio_extract.py
@@ -1,0 +1,40 @@
+"""Shared 16 kHz mono WAV extraction.
+
+The transcription, energy, and reaction analyzers all consume the same
+16 kHz mono PCM audio. Extracting it once in the orchestration layer and
+passing the wav path down avoids decoding a long source video 3-5 times
+per run.
+"""
+
+import os
+import tempfile
+from typing import Optional
+
+from utils.proc import run as proc_run
+
+
+def extract_wav_16k_mono(
+    media_path: str,
+    wav_path: Optional[str] = None,
+    timeout: int = 1800,
+) -> str:
+    """Extract audio as 16 kHz mono 16-bit PCM WAV. Returns the wav path.
+
+    When wav_path is None a temp file is created; the caller owns cleanup.
+    """
+    if wav_path is None:
+        fd, wav_path = tempfile.mkstemp(prefix="podcli_audio_", suffix=".wav")
+        os.close(fd)
+    cmd = [
+        "ffmpeg", "-y", "-loglevel", "error",
+        "-i", media_path,
+        "-vn",
+        "-acodec", "pcm_s16le",
+        "-ar", "16000",
+        "-ac", "1",
+        wav_path,
+    ]
+    result = proc_run(cmd, timeout=timeout, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"Audio extraction failed: {(result.stderr or '')[-300:]}")
+    return wav_path

--- a/backend/services/caption_renderer.py
+++ b/backend/services/caption_renderer.py
@@ -133,6 +133,36 @@ def render_captions(
 
 
 CAPTION_GAP_FILL_MAX = 0.4  # seconds
+CHUNK_BREAK_GAP = 0.8  # seconds of silence that forces a new caption chunk
+_TERMINAL_PUNCTUATION = (".", "?", "!")
+
+
+def _chunk_words(words: list[dict], chunk_size: int) -> list[list[dict]]:
+    """Group words into caption chunks.
+
+    Fixed word counts alone straddle sentence ends, speaker turns and pauses,
+    so a chunk also breaks after terminal punctuation, on a speaker change,
+    or across an inter-word gap longer than CHUNK_BREAK_GAP.
+    """
+    chunks: list[list[dict]] = []
+    current: list[dict] = []
+    for w in words:
+        if current:
+            prev = current[-1]
+            gap_break = float(w.get("start", 0)) - float(prev.get("end", 0)) > CHUNK_BREAK_GAP
+            speaker_break = (
+                w.get("speaker") is not None
+                and prev.get("speaker") is not None
+                and w.get("speaker") != prev.get("speaker")
+            )
+            sentence_break = str(prev.get("word", "")).strip().endswith(_TERMINAL_PUNCTUATION)
+            if len(current) >= chunk_size or gap_break or speaker_break or sentence_break:
+                chunks.append(current)
+                current = []
+        current.append(w)
+    if current:
+        chunks.append(current)
+    return chunks
 
 
 def _hold_through_gap(chunks: list[list[dict]], idx: int, end: float, offset: float) -> float:
@@ -157,10 +187,7 @@ def _render_hormozi(words: list[dict], style: dict, offset: float) -> str:
     chunk_size = style["words_per_chunk"]
     uppercase = style["uppercase"]
 
-    chunks = []
-    for i in range(0, len(words), chunk_size):
-        chunk = words[i : i + chunk_size]
-        chunks.append(chunk)
+    chunks = _chunk_words(words, chunk_size)
 
     for idx, chunk in enumerate(chunks):
         if not chunk:
@@ -200,9 +227,7 @@ def _render_karaoke(words: list[dict], style: dict, offset: float) -> str:
     events = []
 
     sentence_size = style.get("words_per_chunk", 5)
-    sentences = []
-    for i in range(0, len(words), sentence_size):
-        sentences.append(words[i : i + sentence_size])
+    sentences = _chunk_words(words, sentence_size)
 
     for idx, sentence in enumerate(sentences):
         if not sentence:
@@ -238,9 +263,7 @@ def _render_subtle(words: list[dict], style: dict, offset: float) -> str:
     events = []
 
     line_size = style.get("words_per_chunk", 5)
-    lines = []
-    for i in range(0, len(words), line_size):
-        lines.append(words[i : i + line_size])
+    lines = _chunk_words(words, line_size)
 
     for idx, line_words in enumerate(lines):
         if not line_words:
@@ -502,11 +525,7 @@ def _render_branded(words: list[dict], style: dict, offset: float) -> str:
     play_res_y = 1920
     spacing = 2  # ASS Spacing field from header
 
-    # Group words into chunks
-    chunks = []
-    for i in range(0, len(words), chunk_size):
-        chunk = words[i : i + chunk_size]
-        chunks.append(chunk)
+    chunks = _chunk_words(words, chunk_size)
 
     for chunk_idx, chunk in enumerate(chunks):
         if not chunk:
@@ -582,7 +601,24 @@ def _render_branded(words: list[dict], style: dict, offset: float) -> str:
             line_left_x = (play_res_x - full_line_w) // 2
             line_geometry.append((line_center_ys[li], line_left_x, full_line_w, raw_space_w))
 
-        # For each word: emit pill + text (both explicitly positioned)
+        chunk_start_ts = seconds_to_ass(chunk_start)
+        chunk_end_ts = seconds_to_ass(chunk_end)
+
+        # Layer 1: the text layout is static for the whole chunk, so each word
+        # is emitted once for the chunk span. Only the karaoke pill below needs
+        # per-word events.
+        for li, line in enumerate(lines):
+            lcy_l, llx_l, _, asp_w = line_geometry[li]
+            wx = llx_l
+            for pi, (_, text, ww) in enumerate(line):
+                wcx = int(wx + ww // 2)
+                events.append(
+                    f"Dialogue: 1,{chunk_start_ts},{chunk_end_ts},BrandedNormal,,0,0,0,,"
+                    f"{{\\an5\\pos({wcx},{lcy_l})}}{text}"
+                )
+                wx += ww + asp_w
+
+        # Layer 0: per-word pill behind the active word
         for wi, w in enumerate(chunk):
             w_start = max(0, w["start"] - offset)
 
@@ -632,7 +668,6 @@ def _render_branded(words: list[dict], style: dict, offset: float) -> str:
             draw_offset_x = pill_w // 2
             draw_offset_y = pill_h // 2
 
-            # Layer 0: Pill — positioned at word center with \an5
             events.append(
                 f"Dialogue: 0,{start_ts},{end_ts},BrandedNormal,,0,0,0,,"
                 f"{{\\an7\\pos({word_cx - draw_offset_x},{line_cy - draw_offset_y})"
@@ -641,17 +676,5 @@ def _render_branded(words: list[dict], style: dict, offset: float) -> str:
                 f"}}"
                 f"{drawing}{{\\p0}}"
             )
-
-            # Layer 1: Each word positioned with \an5\pos for perfect pill alignment
-            for li, line in enumerate(lines):
-                lcy_l, llx_l, _, asp_w = line_geometry[li]
-                wx = llx_l
-                for pi, (_, text, ww) in enumerate(line):
-                    wcx = int(wx + ww // 2)
-                    events.append(
-                        f"Dialogue: 1,{start_ts},{end_ts},BrandedNormal,,0,0,0,,"
-                        f"{{\\an5\\pos({wcx},{lcy_l})}}{text}"
-                    )
-                    wx += ww + asp_w
 
     return header + "\n".join(events) + "\n"

--- a/backend/services/claude_suggest.py
+++ b/backend/services/claude_suggest.py
@@ -473,12 +473,31 @@ def _load_existing_shorts(episodes_path: str) -> list[str]:
         return []
 
 
+MAX_REACTION_ANCHORS = 40
+
+
+def _format_reaction_anchors(reaction_times: list[float] | None) -> str:
+    """Prompt block listing detected laughter/reaction peaks as anchor moments."""
+    if not reaction_times:
+        return ""
+    anchors = sorted({round(float(t), 1) for t in reaction_times})[:MAX_REACTION_ANCHORS]
+    times = ", ".join(f"{t:.1f}s" for t in anchors)
+    return (
+        "\nAUDIENCE REACTION ANCHORS (detected laughter/cheering peaks, in seconds):\n"
+        f"{times}\n"
+        "The moment that CAUSED each reaction sits just before its anchor. "
+        "Clips that contain or lead into an anchor are strong candidates — "
+        "prefer them when quality is otherwise equal.\n"
+    )
+
+
 def _build_prompt(
     transcript_text: str,
     segment_count: int,
     duration_min: float,
     top_n: int,
     exclude_clips: list[dict] | None = None,
+    reaction_times: list[float] | None = None,
 ) -> str:
     """Build the prompt for Claude to extract clips.
 
@@ -487,7 +506,8 @@ def _build_prompt(
     """
 
     # Load knowledge base files inline — prioritized by relevance to clip selection
-    kb_context = ""
+    from services.knowledge_base import load_kb_context, warn_missing_context
+
     kb_dir = paths["knowledge"]
     # (filename, max_chars) — higher priority files get more budget
     _kb_files = [
@@ -500,18 +520,9 @@ def _build_prompt(
         ("08-topics-themes.md", 1000),            # topic areas, audience interest map
         ("00-master-instructions.md", 1500),      # quality gate, auto-detection rules
     ]
-    for fname, max_chars in _kb_files:
-        fpath = os.path.join(kb_dir, fname)
-        if os.path.exists(fpath):
-            try:
-                with open(fpath, encoding="utf-8") as f:
-                    content = f.read().strip()
-                # Skip template-only files (uncustomized placeholders)
-                if content.count("[Your Show Name]") > 2 and len(content) < 500:
-                    continue
-                kb_context += f"\n--- {fname} ---\n{content[:max_chars]}\n"
-            except Exception:
-                pass
+    kb_context = load_kb_context(_kb_files, kb_dir)
+    if not kb_context:
+        warn_missing_context("clip scoring")
 
     # Load existing shorts from episode database for duplicate avoidance
     episodes_path = os.path.join(kb_dir, "03-episodes-database.md")
@@ -568,7 +579,7 @@ MOMENT SELECTION (think like a TikTok editor):
 {f"KNOWLEDGE BASE:{kb_context}" if kb_context else ""}
 
 {f"EXISTING SHORTS (avoid duplicating these moments):{chr(10).join('- ' + s for s in existing_shorts)}" if existing_shorts else ""}
-{excluded_ranges}
+{excluded_ranges}{_format_reaction_anchors(reaction_times)}
 
 Score each moment on 4 dimensions (1-5 each):
 - standalone: Makes sense without episode context?
@@ -898,6 +909,7 @@ def suggest_with_claude(
     progress_callback: Optional[Callable[[int, str], None]] = None,
     timeout: int = 900,
     error_sink: Optional[list[str]] = None,
+    reaction_times: list[float] | None = None,
 ) -> Optional[list[dict]]:
     """
     Use an AI CLI (Claude Code or Codex) to extract the best clip moments.
@@ -926,6 +938,7 @@ def suggest_with_claude(
         duration_min,
         top_n,
         exclude_clips=exclude_clips,
+        reaction_times=reaction_times,
     )
 
     # Write prompt to temp file to avoid shell escaping issues.
@@ -1091,6 +1104,7 @@ def suggest_initial_with_claude(
     exclude_clips: list[dict] | None = None,
     progress_callback: Optional[Callable[[int, str], None]] = None,
     error_sink: Optional[list[str]] = None,
+    reaction_times: list[float] | None = None,
 ) -> Optional[list[dict]]:
     """
     Initial clip discovery entry point.
@@ -1108,6 +1122,7 @@ def suggest_initial_with_claude(
             progress_callback=progress_callback,
             error_sink=error_sink,
             timeout=180,
+            reaction_times=reaction_times,
         )
 
     start_bound = float(segments[0].get("start", 0))
@@ -1139,6 +1154,7 @@ def suggest_initial_with_claude(
             progress_callback=progress_callback,
             error_sink=error_sink,
             timeout=180,
+            reaction_times=reaction_times,
         )
 
     if progress_callback:
@@ -1169,6 +1185,9 @@ def suggest_initial_with_claude(
             ),
             error_sink=error_sink,
             timeout=90,
+            reaction_times=[
+                t for t in (reaction_times or []) if bucket["start"] <= t <= bucket["end"]
+            ] or None,
         )
         if not bucket_clips:
             continue
@@ -1192,11 +1211,54 @@ def suggest_initial_with_claude(
         ),
         error_sink=error_sink,
         timeout=120,
+        reaction_times=reaction_times,
     )
     if fallback_clips:
         deduped = _dedupe_clips_by_range(deduped + fallback_clips)
 
     return _select_top_by_score(deduped, top_n) if deduped else None
+
+
+REACTION_BLEND_WEIGHT = 0.2
+ENERGY_BLEND_WEIGHT = 0.1
+
+
+def blend_signal_scores(
+    clips: list[dict],
+    energy_data: list[dict] | None = None,
+    events_data: list[dict] | None = None,
+    reaction_weight: float = REACTION_BLEND_WEIGHT,
+    energy_weight: float = ENERGY_BLEND_WEIGHT,
+) -> list[dict]:
+    """Blend per-clip reaction/energy peaks into AI-selected clip scores.
+
+    The AI score (0-20) stays primary: the 0-10 signal scores are added at
+    modest weight (max +3 combined), so laughter or an energy spike breaks
+    ties rather than overruling editorial judgment. Mutates and returns
+    `clips`, preserving their order.
+    """
+    if not clips or (not energy_data and not events_data):
+        return clips
+
+    from services.audio_analyzer import compute_energy_scores
+    from services.audio_events import compute_event_scores
+
+    ranges = [
+        {"start": float(c.get("start_second", 0)), "end": float(c.get("end_second", 0))}
+        for c in clips
+    ]
+    reaction_scores = compute_event_scores(events_data or [], ranges)
+    energy_scores = compute_energy_scores(energy_data or [], ranges)
+
+    for clip, r_score, e_score in zip(clips, reaction_scores, energy_scores):
+        boost = round(reaction_weight * r_score + energy_weight * e_score, 2)
+        if boost <= 0:
+            continue
+        clip["signal_boost"] = boost
+        clip["score"] = round(float(clip.get("score", 0)) + boost, 2)
+        if r_score > 3 and "laughter" not in (clip.get("reasons") or []):
+            clip.setdefault("reasons", []).append("laughter")
+    return clips
 
 
 def _bucket_coverage_seconds(existing_clips: list[dict], start: float, end: float) -> float:

--- a/backend/services/claude_suggest.py
+++ b/backend/services/claude_suggest.py
@@ -17,7 +17,7 @@ from typing import Optional, Callable
 
 from config.paths import paths
 from services.audio_analyzer import compute_energy_scores
-from services.audio_events import compute_event_scores
+from services.audio_events import compute_event_scores, dominant_reaction
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from presets import MIN_CLIP_DURATION, MAX_CLIP_DURATION, TARGET_CLIP_DURATION_MIN, TARGET_CLIP_DURATION_MAX
@@ -1249,14 +1249,16 @@ def blend_signal_scores(
     reaction_scores = compute_event_scores(events_data or [], ranges)
     energy_scores = compute_energy_scores(energy_data or [], ranges)
 
-    for clip, r_score, e_score in zip(clips, reaction_scores, energy_scores):
+    for clip, rng, r_score, e_score in zip(clips, ranges, reaction_scores, energy_scores):
         boost = round(reaction_weight * r_score + energy_weight * e_score, 2)
         if boost <= 0:
             continue
         clip["signal_boost"] = boost
         clip["score"] = round(float(clip.get("score", 0)) + boost, 2)
-        if r_score > 3 and "laughter" not in (clip.get("reasons") or []):
-            clip.setdefault("reasons", []).append("laughter")
+        if r_score > 3:
+            label = dominant_reaction(events_data or [], rng["start"], rng["end"]) or "reaction"
+            if label not in (clip.get("reasons") or []):
+                clip.setdefault("reasons", []).append(label)
     return clips
 
 

--- a/backend/services/claude_suggest.py
+++ b/backend/services/claude_suggest.py
@@ -16,6 +16,8 @@ import tempfile
 from typing import Optional, Callable
 
 from config.paths import paths
+from services.audio_analyzer import compute_energy_scores
+from services.audio_events import compute_event_scores
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from presets import MIN_CLIP_DURATION, MAX_CLIP_DURATION, TARGET_CLIP_DURATION_MIN, TARGET_CLIP_DURATION_MAX
@@ -1240,9 +1242,6 @@ def blend_signal_scores(
     if not clips or (not energy_data and not events_data):
         return clips
 
-    from services.audio_analyzer import compute_energy_scores
-    from services.audio_events import compute_event_scores
-
     ranges = [
         {"start": float(c.get("start_second", 0)), "end": float(c.get("end_second", 0))}
         for c in clips
@@ -1259,6 +1258,16 @@ def blend_signal_scores(
         if r_score > 3 and "laughter" not in (clip.get("reasons") or []):
             clip.setdefault("reasons", []).append("laughter")
     return clips
+
+
+def select_clips_with_signal_scores(
+    clips: list[dict],
+    top_n: int,
+    energy_data: list[dict] | None = None,
+    events_data: list[dict] | None = None,
+) -> list[dict]:
+    blended = blend_signal_scores(clips, energy_data=energy_data, events_data=events_data)
+    return _select_top_by_score(blended, top_n)
 
 
 def _bucket_coverage_seconds(existing_clips: list[dict], start: float, end: float) -> float:

--- a/backend/services/clip_generator.py
+++ b/backend/services/clip_generator.py
@@ -11,6 +11,7 @@ import tempfile
 import shutil
 import subprocess
 import re
+import threading
 from typing import Optional, Callable
 
 from utils.proc import run as proc_run, ProcError
@@ -232,6 +233,65 @@ def _apply_local_transition_smoothing(
         return result.returncode == 0 and os.path.exists(output_path)
     except Exception:
         return False
+
+
+_output_path_lock = threading.Lock()
+_reserved_output_paths: set[str] = set()
+
+
+def _reserve_output_path(output_dir: str, stem: str, ext: str) -> str:
+    """Claim an output path no other clip in this run can take.
+
+    Titles come from an LLM and are not deduped, so two clips in one batch can
+    share a stem. Rendering both to the same path would interleave the copy and
+    the in-place autofix re-encode into one corrupt file while both report
+    success. Reservations are per-process, so re-rendering a clip in a later run
+    still overwrites its own output instead of piling up suffixes.
+    """
+    with _output_path_lock:
+        candidate = os.path.join(output_dir, f"{stem}{ext}")
+        n = 2
+        while candidate in _reserved_output_paths:
+            candidate = os.path.join(output_dir, f"{stem}-{n}{ext}")
+            n += 1
+        _reserved_output_paths.add(candidate)
+        return candidate
+
+
+def _reframe_can_jump(
+    reframe: bool,
+    crop_strategy: str,
+    crop_keyframes: list = None,
+    keep_segments: list = None,
+) -> bool:
+    """Whether this render can contain hard visual jumps worth an autofix pass.
+
+    The pass is only skipped where a jump is impossible: no reframe at all, a
+    fixed centre crop, or a manual crop held on a single keyframe. Every
+    tracked strategy can snap the crop between subjects, so it gets smoothed.
+    Speaker labels are not consulted: the default whisper.cpp engine skips
+    diarization, so they are absent exactly when face tracking is doing the
+    most snapping.
+    """
+    if keep_segments and len(keep_segments) > 1:
+        return True
+    if not reframe:
+        return False
+    if crop_strategy == "center":
+        return False
+    if crop_strategy == "manual":
+        return bool(crop_keyframes and len(crop_keyframes) > 1)
+    return True
+
+
+def _transition_autofix_passes(jumps_possible: bool) -> int:
+    raw = (os.environ.get("PODCLI_TRANSITION_AUTOFIX_PASSES") or "").strip()
+    if raw:
+        try:
+            return max(0, min(int(raw), 2))
+        except ValueError:
+            pass
+    return 2 if jumps_possible else 0
 
 
 def _auto_fix_transition_jumps(video_path: str, max_passes: int = 1) -> bool:
@@ -916,20 +976,27 @@ def generate_clip(
         if progress_callback:
             progress_callback(95, "Saving final clip...")
 
-        output_filename = f"{safe_filename(title)}_short.mp4"
-
         if output_dir:
             os.makedirs(output_dir, exist_ok=True)
-            final_path = os.path.join(output_dir, output_filename)
+            final_path = _reserve_output_path(output_dir, f"{safe_filename(title)}_short", ".mp4")
         else:
-            final_path = os.path.join(work_dir, output_filename)
+            fd, final_path = tempfile.mkstemp(
+                prefix=f"{safe_filename(title)}_short_", suffix=".mp4"
+            )
+            os.close(fd)
 
         shutil.copy2(final_video_path, final_path)
 
         # Optional bounded QA/autofix pass for transition jumps.
         # Hard-capped to avoid any infinite rerender loop.
-        max_autofix_passes = int(os.environ.get("PODCLI_TRANSITION_AUTOFIX_PASSES", "2") or "2")
-        max_autofix_passes = max(0, min(max_autofix_passes, 2))
+        max_autofix_passes = _transition_autofix_passes(
+            _reframe_can_jump(
+                reframe=spec.reframe,
+                crop_strategy=crop_strategy,
+                crop_keyframes=crop_keyframes,
+                keep_segments=keep_segments,
+            )
+        )
         if max_autofix_passes > 0:
             if progress_callback:
                 progress_callback(97, "Quality gate: checking transitions...")
@@ -956,11 +1023,17 @@ def generate_clip(
         if length_warning:
             out["warning"] = length_warning
         if keep_caption_overlay and caption_overlay_path and os.path.exists(caption_overlay_path):
-            out["caption_overlay_path"] = caption_overlay_path
-            out["cropped_source_path"] = cropped_path
+            # Copy out of work_dir before cleanup so the returned paths survive.
+            base, _ = os.path.splitext(final_path)
+            persisted_overlay = f"{base}_captions.mov"
+            shutil.copy2(caption_overlay_path, persisted_overlay)
+            out["caption_overlay_path"] = persisted_overlay
+            if os.path.exists(cropped_path):
+                persisted_source = f"{base}_source.mp4"
+                shutil.copy2(cropped_path, persisted_source)
+                out["cropped_source_path"] = persisted_source
         return out
 
     finally:
-        # Clean up temp files (but not if output is in work_dir)
-        if output_dir and os.path.exists(work_dir):
+        if os.path.exists(work_dir):
             shutil.rmtree(work_dir, ignore_errors=True)

--- a/backend/services/content_generator.py
+++ b/backend/services/content_generator.py
@@ -12,8 +12,8 @@ import tempfile
 import threading
 from typing import Optional, Callable
 
-from config.paths import paths
 from services.claude_suggest import _engine_label, _find_ai_cli_candidates, _run_ai_command
+from services.knowledge_base import load_kb_context as kb_load_context, warn_missing_context
 
 
 CONTENT_KB_FILES = [
@@ -25,22 +25,14 @@ CONTENT_KB_FILES = [
 ]
 
 
-def load_kb_context(files: Optional[list[tuple[str, int]]] = None) -> str:
+def load_kb_context(
+    files: Optional[list[tuple[str, int]]] = None,
+    task: str = "content generation",
+) -> str:
     """Load PodStack knowledge base files as inline prompt context."""
-    kb_dir = paths["knowledge"]
-    kb_context = ""
-    for fname, max_chars in files if files is not None else CONTENT_KB_FILES:
-        fpath = os.path.join(kb_dir, fname)
-        if os.path.exists(fpath):
-            try:
-                with open(fpath, encoding="utf-8") as kf:
-                    content = kf.read().strip()
-                # Skip uncustomized templates
-                if content.count("[Your Show Name]") > 2 and len(content) < 500:
-                    continue
-                kb_context += f"\n--- {fname} ---\n{content[:max_chars]}\n"
-            except Exception:
-                pass
+    kb_context = kb_load_context(files if files is not None else CONTENT_KB_FILES)
+    if not kb_context:
+        warn_missing_context(task)
     return kb_context
 
 
@@ -278,7 +270,7 @@ def generate_clip_content(
     if progress_callback:
         progress_callback(0, f"Generating content via {label}...")
 
-    kb_context = load_kb_context()
+    kb_context = load_kb_context(task="title and description generation")
 
     # Extract transcript text for this clip's time range
     clip_start = clip.get("start_second", 0)

--- a/backend/services/knowledge_base.py
+++ b/backend/services/knowledge_base.py
@@ -1,0 +1,121 @@
+"""Knowledge base helpers shared by the CLI and the AI prompt builders."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+from config.paths import paths
+
+TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates" / "knowledge"
+
+# The studio writes README.md into the knowledge dir; it is not user content.
+IGNORED_FILES = {"readme.md"}
+
+_PLACEHOLDER = re.compile(r"\[[^\[\]\n]{1,120}\]")
+_MD_LINK = re.compile(r"\[[^\]\n]+\]\([^)\n]*\)")
+_CODE_FENCE = re.compile(r"```.*?```", re.DOTALL)
+_TABLE_RULE = set("|-: ")
+
+# Tuned against the shipped templates (line ratio 0.62-0.92, char ratio 0.34-0.73) and
+# against filled files, which keep the odd legitimate bracket ("[guest]", "[00:00]").
+MIN_PLACEHOLDERS = 3
+PLACEHOLDER_LINE_RATIO = 0.6
+PLACEHOLDER_CHAR_RATIO = 0.3
+
+
+def _body_lines(content: str) -> list[str]:
+    text = _CODE_FENCE.sub("", content)
+    text = _MD_LINK.sub("", text)
+    lines = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if set(line) <= _TABLE_RULE:
+            continue
+        lines.append(line)
+    return lines
+
+
+def is_unfilled_template(content: str, filename: str | None = None) -> bool:
+    """True when a knowledge file is still a starter template nobody filled in."""
+    stripped = content.strip()
+    if not stripped:
+        return True
+
+    if filename:
+        shipped = TEMPLATES_DIR / os.path.basename(filename)
+        try:
+            if shipped.is_file() and shipped.read_text(encoding="utf-8").strip() == stripped:
+                return True
+        except OSError:
+            pass
+
+    lines = _body_lines(stripped)
+    if not lines:
+        return True
+    body = "\n".join(lines)
+    placeholders = _PLACEHOLDER.findall(body)
+    if len(placeholders) < MIN_PLACEHOLDERS:
+        return False
+    char_ratio = sum(len(p) for p in placeholders) / len(body)
+    line_ratio = sum(1 for line in lines if _PLACEHOLDER.search(line)) / len(lines)
+    return line_ratio >= PLACEHOLDER_LINE_RATIO or char_ratio >= PLACEHOLDER_CHAR_RATIO
+
+
+def kb_files(kb_dir: str | None = None) -> list[str]:
+    """Markdown files in the knowledge base that the user owns."""
+    directory = kb_dir or paths["knowledge"]
+    if not os.path.isdir(directory):
+        return []
+    return sorted(
+        f for f in os.listdir(directory)
+        if f.endswith(".md") and f.lower() not in IGNORED_FILES
+    )
+
+
+def is_empty(kb_dir: str | None = None) -> bool:
+    return not kb_files(kb_dir)
+
+
+def load_kb_context(files: list[tuple[str, int]], kb_dir: str | None = None) -> str:
+    """Inline knowledge base files as prompt context, skipping unfilled templates."""
+    directory = kb_dir or paths["knowledge"]
+    kb_context = ""
+    for fname, max_chars in files:
+        fpath = os.path.join(directory, fname)
+        if not os.path.exists(fpath):
+            continue
+        try:
+            with open(fpath, encoding="utf-8") as f:
+                content = f.read().strip()
+        except OSError:
+            continue
+        if is_unfilled_template(content, fname):
+            continue
+        kb_context += f"\n--- {fname} ---\n{content[:max_chars]}\n"
+    return kb_context
+
+
+SETUP_HINT = (
+    "Run: podcli knowledge init, then fill in the [brackets], "
+    "or run /bootstrap-knowledge in your agent to draft them from an existing channel."
+)
+
+_warned = False
+
+
+def warn_missing_context(task: str) -> None:
+    """One stderr line per run when the knowledge base holds no usable show context."""
+    global _warned
+    if _warned:
+        return
+    _warned = True
+    print(
+        f"Warning: no show context in the knowledge base, {task} is running without it. {SETUP_HINT}",
+        file=sys.stderr,
+        flush=True,
+    )

--- a/backend/services/saliency.py
+++ b/backend/services/saliency.py
@@ -230,6 +230,9 @@ def detect_highlights(
     words: Optional[list[dict]] = None,
     reaction_threshold: float = 0.06,
     progress_callback: Optional[Callable] = None,
+    energy_data: Optional[list[dict]] = None,
+    events_data: Optional[list[dict]] = None,
+    wav_path: Optional[str] = None,
 ) -> list[dict]:
     """
     Generate highlight clips from a video's fused signal curve.
@@ -239,21 +242,26 @@ def detect_highlights(
     preferred over `segments`. Without any transcript, boundaries snap to audio lulls.
     `reaction_threshold` is the laughter/cheer level that counts as a reaction — low
     (~0.06) for conversational chuckles, higher for loud belly-laughs/crowds.
+    `energy_data`/`events_data` accept the profiles the orchestration layer already
+    computed so the source audio isn't decoded again; `wav_path` is a pre-extracted
+    16 kHz mono WAV used when extraction is still needed.
     Returns clip dicts compatible with the render pipeline:
     {title, start_second, end_second, duration, score, reasons, preview}.
     """
     profile = get_profile(profile_name)
     snap_units = sentences_from_words(words) if words else segments
 
-    if progress_callback:
-        progress_callback(10, "Analyzing audio energy...")
-    energy_data = extract_audio_energy(video_path)
-
-    events_data = []
-    if audio_events_available():
+    if energy_data is None:
         if progress_callback:
-            progress_callback(40, "Detecting laughter and reactions...")
-        events_data = extract_audio_events(video_path)
+            progress_callback(10, "Analyzing audio energy...")
+        energy_data = extract_audio_energy(video_path, wav_path=wav_path)
+
+    if events_data is None:
+        events_data = []
+        if audio_events_available():
+            if progress_callback:
+                progress_callback(40, "Detecting laughter and reactions...")
+            events_data = extract_audio_events(video_path, wav_path=wav_path)
 
     last_times = [e["time"] for e in energy_data] + [e["time"] for e in events_data]
     if not last_times:

--- a/backend/services/signal_cache.py
+++ b/backend/services/signal_cache.py
@@ -1,0 +1,52 @@
+"""Disk cache for a video's audio signals (energy, reactions).
+
+Transcription already decodes the audio and runs both analyzers, so clip
+suggestion reads the profiles from here instead of decoding the source again.
+Keyed on the video's content hash, not the engine: the signals come from the
+audio, not from the transcript.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Optional
+
+from config.paths import paths
+from services.transcript_packer import compute_cache_hash
+
+
+def _signals_path(video_path: str) -> str:
+    return os.path.join(paths["cache"], "signals", f"{compute_cache_hash(video_path)}.json")
+
+
+def load_signals(video_path: str) -> dict[str, Any]:
+    """Cached {energy_data, events_data} for a video, or {} if absent."""
+    try:
+        with open(_signals_path(video_path), encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return {}
+
+
+def save_signals(
+    video_path: str,
+    energy_data: Optional[list[dict]] = None,
+    events_data: Optional[list[dict]] = None,
+) -> None:
+    """Merge the given profiles into the cache. Best-effort: a cache miss later
+    only costs a re-analysis."""
+    payload = load_signals(video_path)
+    if energy_data is not None:
+        payload["energy_data"] = energy_data
+    if events_data is not None:
+        payload["events_data"] = events_data
+    if not payload:
+        return
+    try:
+        path = _signals_path(video_path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+    except (OSError, ValueError):
+        pass

--- a/backend/services/speaker_detection.py
+++ b/backend/services/speaker_detection.py
@@ -235,8 +235,9 @@ def assign_speakers_to_words(
     """
     Assign speaker labels to individual words.
 
-    Uses the midpoint of each word's timestamp to determine
-    which speaker segment it falls within.
+    Picks the speaker whose diarization segment overlaps the word the most —
+    at turn boundaries several segments can touch a word, and the first
+    match is often the previous speaker trailing off.
     """
     if not speaker_segments:
         for w in words:
@@ -244,16 +245,21 @@ def assign_speakers_to_words(
         return words
 
     for w in words:
-        midpoint = (w["start"] + w["end"]) / 2
-
-        # Find which speaker segment contains this midpoint
-        assigned = None
+        speaker_overlap = {}
         for sp in speaker_segments:
-            if sp["start"] <= midpoint <= sp["end"]:
-                assigned = sp["speaker"]
-                break
+            overlap = min(w["end"], sp["end"]) - max(w["start"], sp["start"])
+            if overlap > 0:
+                speaker_overlap[sp["speaker"]] = speaker_overlap.get(sp["speaker"], 0) + overlap
 
-        w["speaker"] = assigned
+        if speaker_overlap:
+            w["speaker"] = max(speaker_overlap, key=speaker_overlap.get)
+        else:
+            # Zero-length or gap words: fall back to midpoint containment.
+            midpoint = (w["start"] + w["end"]) / 2
+            w["speaker"] = next(
+                (sp["speaker"] for sp in speaker_segments if sp["start"] <= midpoint <= sp["end"]),
+                None,
+            )
 
     return words
 

--- a/backend/services/transcription.py
+++ b/backend/services/transcription.py
@@ -58,7 +58,7 @@ def _whispercpp_ready(model_size: str) -> bool:
     return _whispercpp_cli() is not None and os.path.exists(_whispercpp_model(model_size))
 
 
-def _transcribe_with_whispercpp(file_path, model_size, language, progress_callback):
+def _transcribe_with_whispercpp(file_path, model_size, language, progress_callback, wav_path=None):
     from services import transcription_whispercpp as wcpp
 
     if progress_callback:
@@ -80,6 +80,7 @@ def _transcribe_with_whispercpp(file_path, model_size, language, progress_callba
         language=language,
         vad=vad,
         vad_model=os.environ.get("PODCLI_WHISPERCPP_VAD_MODEL") or None,
+        wav_path=wav_path,
     )
     if progress_callback:
         progress_callback(50, "Transcription complete")
@@ -334,6 +335,7 @@ def _attach_speakers_and_faces(
     enable_diarization,
     num_speakers,
     progress_callback,
+    wav_path=None,
 ):
     """Merge speaker diarization + face analysis into a transcribed result.
     Shared by both engines; face analysis (OpenCV) runs even when diarization
@@ -359,17 +361,22 @@ def _attach_speakers_and_faces(
             if progress_callback:
                 progress_callback(55, "Extracting audio for speaker detection...")
 
-            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
-                wav_path = tmp.name
+            shared_wav = wav_path if wav_path and os.path.exists(wav_path) else None
+            if shared_wav:
+                diar_wav = shared_wav
+            else:
+                with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                    diar_wav = tmp.name
 
             try:
-                extract_audio_wav(file_path, wav_path)
+                if not shared_wav:
+                    extract_audio_wav(file_path, diar_wav)
 
                 if progress_callback:
                     progress_callback(60, "Running speaker diarization...")
 
                 speaker_segments = run_diarization(
-                    wav_path,
+                    diar_wav,
                     num_speakers=num_speakers,
                     progress_callback=lambda pct, msg: (
                         progress_callback(60 + int(pct * 0.3), msg) if progress_callback else None
@@ -391,8 +398,8 @@ def _attach_speakers_and_faces(
                         )
 
             finally:
-                if os.path.exists(wav_path):
-                    os.unlink(wav_path)
+                if not shared_wav and os.path.exists(diar_wav):
+                    os.unlink(diar_wav)
 
         except ImportError as e:
             diarization_warning = f"Speaker detection unavailable: {e}"
@@ -447,9 +454,13 @@ def transcribe_file(
     enable_diarization: bool = True,
     num_speakers: Optional[int] = None,
     progress_callback: Optional[Callable[[int, str], None]] = None,
+    wav_path: Optional[str] = None,
 ) -> dict:
     """
     Transcribe a video/audio file with word-level timestamps and speaker detection.
+
+    wav_path: optional pre-extracted 16 kHz mono WAV shared across analysis
+    stages — used by whisper.cpp and diarization instead of re-decoding.
 
     Returns:
         {
@@ -496,7 +507,9 @@ def transcribe_file(
                 ) from e
 
     if use_cpp:
-        base = _transcribe_with_whispercpp(file_path, model_size, language, progress_callback)
+        base = _transcribe_with_whispercpp(
+            file_path, model_size, language, progress_callback, wav_path=wav_path
+        )
         base["engine"] = "whispercpp"
         # whisper.cpp is the no-torch path: importing torch for diarization can
         # hard-crash native runtimes. Skip diarization, keep face analysis (OpenCV).
@@ -588,5 +601,6 @@ def transcribe_file(
         "engine": "whisper-py",
     }
     return _attach_speakers_and_faces(
-        file_path, base, enable_diarization, num_speakers, progress_callback
+        file_path, base, enable_diarization, num_speakers, progress_callback,
+        wav_path=wav_path,
     )

--- a/backend/services/transcription_whispercpp.py
+++ b/backend/services/transcription_whispercpp.py
@@ -146,6 +146,7 @@ def transcribe_file(
     threads: int = 4,
     vad: bool = False,
     vad_model: Optional[str] = None,
+    wav_path: Optional[str] = None,
     **_ignored,
 ) -> dict:
     if not os.path.exists(file_path):
@@ -154,10 +155,13 @@ def transcribe_file(
         raise FileNotFoundError(f"ggml model not found: {model_path}")
 
     tmpdir = tempfile.mkdtemp(prefix="wcpp_")
-    wav = os.path.join(tmpdir, "audio.wav")
     out_base = os.path.join(tmpdir, "out")
     try:
-        _extract_wav(file_path, wav, ffmpeg)
+        if wav_path and os.path.exists(wav_path):
+            wav = wav_path
+        else:
+            wav = os.path.join(tmpdir, "audio.wav")
+            _extract_wav(file_path, wav, ffmpeg)
 
         cmd = [whisper_cli, "-m", model_path, "-f", wav, "-ojf",
                "-of", out_base, "-t", str(threads)]

--- a/backend/services/video_cut.py
+++ b/backend/services/video_cut.py
@@ -21,10 +21,14 @@ def cut_segment(
 ) -> str:
     """Extract a single time segment from a video file.
 
-    Uses `-ss` before `-i` with re-encoding for frame-accurate
-    timestamps. The fast preset + CRF 18 is a deliberate quality
-    trade-off: we'll re-encode again in the final pipeline, so this
-    pass prioritizes speed.
+    Always re-encodes with `-ss` before `-i` for frame-accurate timestamps.
+    Stream copy is not an option here: with `-c copy` ffmpeg can only start at
+    the keyframe at-or-before the cut point, so any boundary off the GOP grid
+    silently emits up to a full GOP of earlier content while the duration still
+    checks out, which offsets every burned-in caption. CRF 16 keeps this
+    intermediate visually lossless through the later crop/caption/audio
+    re-encodes; the fast preset holds the speed cost to a few percent
+    over the old CRF 18 pass.
     """
     duration = end_second - start_second
 
@@ -33,7 +37,7 @@ def cut_segment(
         "-ss", str(start_second),
         "-i", input_path,
         "-t", str(duration),
-        "-c:v", "libx264", "-crf", "18", "-preset", "fast", "-profile:v", "high",
+        "-c:v", "libx264", "-crf", "16", "-preset", "fast", "-profile:v", "high",
         "-c:a", "aac", "-b:a", "192k",
         "-avoid_negative_ts", "make_zero",
         output_path,

--- a/backend/services/video_processor.py
+++ b/backend/services/video_processor.py
@@ -959,6 +959,27 @@ def _pick_tracking_face(
     return face, side_ok or near_anchor
 
 
+def _face_sample_indices(total_frames: int, fps: float) -> list[int]:
+    """Frame indices for face sampling: every frame for the first 0.5s, every
+    other frame until 1s (to catch a face before gestures), then ~10 fps."""
+    sample_step = max(1, int(fps / 10))
+    dense_end_frame = int(fps * 0.5)
+    semi_dense_end_frame = int(fps * 1.0)
+    semi_dense_step = max(1, sample_step // 2)
+
+    indices = []
+    frame_idx = 0
+    while frame_idx < total_frames:
+        indices.append(frame_idx)
+        if frame_idx < dense_end_frame:
+            frame_idx += 1
+        elif frame_idx < semi_dense_end_frame:
+            frame_idx += semi_dense_step
+        else:
+            frame_idx += sample_step
+    return indices
+
+
 def _track_and_crop(
     input_path: str,
     output_path: str,
@@ -1006,31 +1027,26 @@ def _track_and_crop(
         return None
 
     # ── Dense face sampling (~10 fps, 2× at clip start) ──────────
-    sample_step = max(1, int(fps / 10))
-    # Sample every frame for the first 0.5s, then every other frame
-    # until 1s, to maximise the chance of catching a face before gestures.
-    dense_end_frame = int(fps * 0.5)
-    semi_dense_end_frame = int(fps * 1.0)
-    dense_step = 1
-    semi_dense_step = max(1, sample_step // 2)
+    # grab() advances cheaply, retrieve() decodes only sampled frames — far
+    # cheaper than a cap.set() seek (keyframe re-decode) per sample.
+    sample_indices = _face_sample_indices(total_frames, fps)
     detections = []  # [(time, faces), ...]
 
-    frame_idx = 0
-    while frame_idx < total_frames:
-        cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
-        ret, frame = cap.read()
+    next_pos = 0
+    frame_idx = -1
+    while next_pos < len(sample_indices):
+        if not cap.grab():
+            break
+        frame_idx += 1
+        if frame_idx < sample_indices[next_pos]:
+            continue
+        next_pos += 1
+        ret, frame = cap.retrieve()
         if not ret:
-            frame_idx += sample_step
             continue
         t = frame_idx / fps
         faces = detect_faces(detector, frame, width, height)
         detections.append((t, faces))
-        if frame_idx < dense_end_frame:
-            frame_idx += dense_step
-        elif frame_idx < semi_dense_end_frame:
-            frame_idx += semi_dense_step
-        else:
-            frame_idx += sample_step
 
     cap.release()
 

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -2928,7 +2928,12 @@ app.post("/api/claude-suggest", async (req, res) => {
       ...uiState.suggestions.map((s) => ({ start_second: s.start_second, end_second: s.end_second, title: s.title })),
     ];
 
-    const params: Record<string, unknown> = { segments: segs, top_n, existing_clips };
+    const params: Record<string, unknown> = {
+      segments: segs,
+      top_n,
+      existing_clips,
+      video_path: uiState.videoPath || undefined,
+    };
     if (min_duration) params.min_duration = min_duration;
     if (max_duration) params.max_duration = max_duration;
     const result = await executor.execute<{ clips?: SuggestedClip[] }>(

--- a/tests/parity/golden/branded.ass.expected
+++ b/tests/parity/golden/branded.ass.expected
@@ -12,41 +12,23 @@ Style: BrandedNormal,Arial,80,&H00FFFFFF,&H00FFFFFF,&H90000000,&H00000000,-1,0,0
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 1,0:00:00.00,0:00:01.05,BrandedNormal,,0,0,0,,{\an5\pos(320,1380)}The
+Dialogue: 1,0:00:00.00,0:00:01.05,BrandedNormal,,0,0,0,,{\an5\pos(520,1380)}james
+Dialogue: 1,0:00:00.00,0:00:01.05,BrandedNormal,,0,0,0,,{\an5\pos(740,1380)}webb
 Dialogue: 0,0:00:00.00,0:00:00.34,BrandedNormal,,0,0,0,,{\an7\pos(240,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 145 0 b 153 0 160 7 160 15 l 160 85 b 160 93 153 100 145 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
-Dialogue: 1,0:00:00.00,0:00:00.34,BrandedNormal,,0,0,0,,{\an5\pos(320,1380)}The
-Dialogue: 1,0:00:00.00,0:00:00.34,BrandedNormal,,0,0,0,,{\an5\pos(520,1380)}james
-Dialogue: 1,0:00:00.00,0:00:00.34,BrandedNormal,,0,0,0,,{\an5\pos(740,1380)}webb
 Dialogue: 0,0:00:00.34,0:00:00.72,BrandedNormal,,0,0,0,,{\an7\pos(400,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 225 0 b 233 0 240 7 240 15 l 240 85 b 240 93 233 100 225 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
-Dialogue: 1,0:00:00.34,0:00:00.72,BrandedNormal,,0,0,0,,{\an5\pos(320,1380)}The
-Dialogue: 1,0:00:00.34,0:00:00.72,BrandedNormal,,0,0,0,,{\an5\pos(520,1380)}james
-Dialogue: 1,0:00:00.34,0:00:00.72,BrandedNormal,,0,0,0,,{\an5\pos(740,1380)}webb
 Dialogue: 0,0:00:00.72,0:00:01.05,BrandedNormal,,0,0,0,,{\an7\pos(640,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 185 0 b 193 0 200 7 200 15 l 200 85 b 200 93 193 100 185 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
-Dialogue: 1,0:00:00.72,0:00:01.05,BrandedNormal,,0,0,0,,{\an5\pos(320,1380)}The
-Dialogue: 1,0:00:00.72,0:00:01.05,BrandedNormal,,0,0,0,,{\an5\pos(520,1380)}james
-Dialogue: 1,0:00:00.72,0:00:01.05,BrandedNormal,,0,0,0,,{\an5\pos(740,1380)}webb
+Dialogue: 1,0:00:01.05,0:00:02.40,BrandedNormal,,0,0,0,,{\an5\pos(360,1380)}Telescope
+Dialogue: 1,0:00:01.05,0:00:02.40,BrandedNormal,,0,0,0,,{\an5\pos(660,1380)}cost
+Dialogue: 1,0:00:01.05,0:00:02.40,BrandedNormal,,0,0,0,,{\an5\pos(840,1380)}$10
 Dialogue: 0,0:00:01.05,0:00:01.62,BrandedNormal,,0,0,0,,{\an7\pos(160,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 385 0 b 393 0 400 7 400 15 l 400 85 b 400 93 393 100 385 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
-Dialogue: 1,0:00:01.05,0:00:01.62,BrandedNormal,,0,0,0,,{\an5\pos(360,1380)}Telescope
-Dialogue: 1,0:00:01.05,0:00:01.62,BrandedNormal,,0,0,0,,{\an5\pos(660,1380)}cost
-Dialogue: 1,0:00:01.05,0:00:01.62,BrandedNormal,,0,0,0,,{\an5\pos(840,1380)}$10
 Dialogue: 0,0:00:01.62,0:00:01.95,BrandedNormal,,0,0,0,,{\an7\pos(560,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 185 0 b 193 0 200 7 200 15 l 200 85 b 200 93 193 100 185 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
-Dialogue: 1,0:00:01.62,0:00:01.95,BrandedNormal,,0,0,0,,{\an5\pos(360,1380)}Telescope
-Dialogue: 1,0:00:01.62,0:00:01.95,BrandedNormal,,0,0,0,,{\an5\pos(660,1380)}cost
-Dialogue: 1,0:00:01.62,0:00:01.95,BrandedNormal,,0,0,0,,{\an5\pos(840,1380)}$10
 Dialogue: 0,0:00:01.95,0:00:02.40,BrandedNormal,,0,0,0,,{\an7\pos(760,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 145 0 b 153 0 160 7 160 15 l 160 85 b 160 93 153 100 145 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
-Dialogue: 1,0:00:01.95,0:00:02.40,BrandedNormal,,0,0,0,,{\an5\pos(360,1380)}Telescope
-Dialogue: 1,0:00:01.95,0:00:02.40,BrandedNormal,,0,0,0,,{\an5\pos(660,1380)}cost
-Dialogue: 1,0:00:01.95,0:00:02.40,BrandedNormal,,0,0,0,,{\an5\pos(840,1380)}$10
-Dialogue: 0,0:00:02.40,0:00:03.10,BrandedNormal,,0,0,0,,{\an7\pos(120,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 345 0 b 353 0 360 7 360 15 l 360 85 b 360 93 353 100 345 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
-Dialogue: 1,0:00:02.40,0:00:03.10,BrandedNormal,,0,0,0,,{\an5\pos(300,1380)}Billion.
-Dialogue: 1,0:00:02.40,0:00:03.10,BrandedNormal,,0,0,0,,{\an5\pos(620,1380)}wasn't
-Dialogue: 1,0:00:02.40,0:00:03.10,BrandedNormal,,0,0,0,,{\an5\pos(860,1380)}that
-Dialogue: 0,0:00:03.10,0:00:03.55,BrandedNormal,,0,0,0,,{\an7\pos(480,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 265 0 b 273 0 280 7 280 15 l 280 85 b 280 93 273 100 265 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
-Dialogue: 1,0:00:03.10,0:00:03.55,BrandedNormal,,0,0,0,,{\an5\pos(300,1380)}Billion.
-Dialogue: 1,0:00:03.10,0:00:03.55,BrandedNormal,,0,0,0,,{\an5\pos(620,1380)}wasn't
-Dialogue: 1,0:00:03.10,0:00:03.55,BrandedNormal,,0,0,0,,{\an5\pos(860,1380)}that
-Dialogue: 0,0:00:03.55,0:00:03.60,BrandedNormal,,0,0,0,,{\an7\pos(760,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 185 0 b 193 0 200 7 200 15 l 200 85 b 200 93 193 100 185 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
-Dialogue: 1,0:00:03.55,0:00:03.60,BrandedNormal,,0,0,0,,{\an5\pos(300,1380)}Billion.
-Dialogue: 1,0:00:03.55,0:00:03.60,BrandedNormal,,0,0,0,,{\an5\pos(620,1380)}wasn't
-Dialogue: 1,0:00:03.55,0:00:03.60,BrandedNormal,,0,0,0,,{\an5\pos(860,1380)}that
-Dialogue: 0,0:00:03.55,0:00:04.20,BrandedNormal,,0,0,0,,{\an7\pos(320,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 425 0 b 433 0 440 7 440 15 l 440 85 b 440 93 433 100 425 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
-Dialogue: 1,0:00:03.55,0:00:04.20,BrandedNormal,,0,0,0,,{\an5\pos(540,1380)}Expensive?
+Dialogue: 1,0:00:02.40,0:00:03.10,BrandedNormal,,0,0,0,,{\an5\pos(540,1380)}Billion.
+Dialogue: 0,0:00:02.40,0:00:03.10,BrandedNormal,,0,0,0,,{\an7\pos(360,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 345 0 b 353 0 360 7 360 15 l 360 85 b 360 93 353 100 345 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
+Dialogue: 1,0:00:03.10,0:00:04.20,BrandedNormal,,0,0,0,,{\an5\pos(220,1380)}Wasn't
+Dialogue: 1,0:00:03.10,0:00:04.20,BrandedNormal,,0,0,0,,{\an5\pos(460,1380)}that
+Dialogue: 1,0:00:03.10,0:00:04.20,BrandedNormal,,0,0,0,,{\an5\pos(780,1380)}expensive?
+Dialogue: 0,0:00:03.10,0:00:03.55,BrandedNormal,,0,0,0,,{\an7\pos(80,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 265 0 b 273 0 280 7 280 15 l 280 85 b 280 93 273 100 265 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
+Dialogue: 0,0:00:03.55,0:00:03.65,BrandedNormal,,0,0,0,,{\an7\pos(360,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 185 0 b 193 0 200 7 200 15 l 200 85 b 200 93 193 100 185 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}
+Dialogue: 0,0:00:03.55,0:00:04.20,BrandedNormal,,0,0,0,,{\an7\pos(560,1330)\p1\c&H00000000&\bord0\shad0\1a&HFF&\t(0,80,\1a&H30&)}m 15 0 l 425 0 b 433 0 440 7 440 15 l 440 85 b 440 93 433 100 425 100 l 15 100 b 7 100 0 93 0 85 l 0 15 b 0 7 7 0 15 0{\p0}

--- a/tests/parity/golden/hormozi.ass.expected
+++ b/tests/parity/golden/hormozi.ass.expected
@@ -14,5 +14,5 @@ Style: Default,Arial,80,&H00FFFFFF,&H00FFFFFF,&H00000000,&H80000000,-1,0,0,0,100
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 Dialogue: 0,0:00:00.00,0:00:01.05,Default,,0,0,0,,{\c&H0000FFFF\2c&H00FFFFFF}{\kf34}THE {\kf37}JAMES {\kf33}WEBB
 Dialogue: 0,0:00:01.05,0:00:02.40,Default,,0,0,0,,{\c&H0000FFFF\2c&H00FFFFFF}{\kf57}TELESCOPE {\kf32}COST {\kf44}$10
-Dialogue: 0,0:00:02.40,0:00:03.60,Default,,0,0,0,,{\c&H0000FFFF\2c&H00FFFFFF}{\kf55}BILLION. {\kf44}WASN'T {\kf4}THAT
-Dialogue: 0,0:00:03.55,0:00:04.20,Default,,0,0,0,,{\c&H0000FFFF\2c&H00FFFFFF}{\kf65}EXPENSIVE?
+Dialogue: 0,0:00:02.40,0:00:03.10,Default,,0,0,0,,{\c&H0000FFFF\2c&H00FFFFFF}{\kf55}BILLION.
+Dialogue: 0,0:00:03.10,0:00:04.20,Default,,0,0,0,,{\c&H0000FFFF\2c&H00FFFFFF}{\kf44}WASN'T {\kf4}THAT {\kf65}EXPENSIVE?

--- a/tests/parity/golden/karaoke.ass.expected
+++ b/tests/parity/golden/karaoke.ass.expected
@@ -13,4 +13,5 @@ Style: Default,Arial,60,&H00808080,&H00808080,&H00000000,&H80000000,0,0,0,0,100,
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 Dialogue: 0,0:00:00.00,0:00:01.95,Default,,0,0,0,,{\c&H00FFFFFF}{\2c&H00808080}{\kf34}The {\kf37}James {\kf33}Webb {\kf57}telescope {\kf32}cost
-Dialogue: 0,0:00:01.95,0:00:04.20,Default,,0,0,0,,{\c&H00FFFFFF}{\2c&H00808080}{\kf44}$10 {\kf55}billion. {\kf44}Wasn't {\kf4}that {\kf65}expensive?
+Dialogue: 0,0:00:01.95,0:00:03.10,Default,,0,0,0,,{\c&H00FFFFFF}{\2c&H00808080}{\kf44}$10 {\kf55}billion.
+Dialogue: 0,0:00:03.10,0:00:04.20,Default,,0,0,0,,{\c&H00FFFFFF}{\2c&H00808080}{\kf44}Wasn't {\kf4}that {\kf65}expensive?

--- a/tests/parity/golden/subtle.ass.expected
+++ b/tests/parity/golden/subtle.ass.expected
@@ -13,4 +13,5 @@ Style: Default,Arial,52,&H00FFFFFF,&H00FFFFFF,&H00000000,&H80000000,0,0,0,0,100,
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 Dialogue: 0,0:00:00.00,0:00:01.95,Default,,0,0,0,,The James Webb telescope cost
-Dialogue: 0,0:00:01.95,0:00:04.20,Default,,0,0,0,,$10 billion. Wasn't that expensive?
+Dialogue: 0,0:00:01.95,0:00:03.10,Default,,0,0,0,,$10 billion.
+Dialogue: 0,0:00:03.10,0:00:04.20,Default,,0,0,0,,Wasn't that expensive?

--- a/tests/test_ai_fallback.py
+++ b/tests/test_ai_fallback.py
@@ -181,7 +181,7 @@ class AIFallbackTests(unittest.TestCase):
 
         calls = []
 
-        def fake_suggest(*, segments, top_n, exclude_clips=None, progress_callback=None, timeout=300, error_sink=None):
+        def fake_suggest(*, segments, top_n, exclude_clips=None, progress_callback=None, timeout=300, error_sink=None, reaction_times=None):
             calls.append({
                 "start": segments[0]["start"],
                 "end": segments[-1]["end"],

--- a/tests/test_audio_analyzer.py
+++ b/tests/test_audio_analyzer.py
@@ -2,7 +2,9 @@
 
 import os
 import sys
+import tempfile
 import unittest
+from unittest import mock
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 BACKEND_ROOT = os.path.join(ROOT, "backend")
@@ -10,6 +12,7 @@ if BACKEND_ROOT not in sys.path:
     sys.path.insert(0, BACKEND_ROOT)
 
 from services import audio_analyzer as aa
+from services import audio_extract
 
 
 class ComputeEnergyScoresTests(unittest.TestCase):
@@ -86,8 +89,6 @@ class ComputeEnergyScoresTests(unittest.TestCase):
 
 class ExtractAudioEnergyCommandTests(unittest.TestCase):
     def _run(self, wav_path=None):
-        from unittest import mock
-
         with mock.patch.object(aa, "proc_run", return_value=mock.Mock(returncode=0, stdout="", stderr="")) as mocked, \
              mock.patch.object(aa, "_fallback_energy", return_value=[]):
             aa.extract_audio_energy("/video.mp4", wav_path=wav_path)
@@ -100,8 +101,6 @@ class ExtractAudioEnergyCommandTests(unittest.TestCase):
         self.assertIn("astats=metadata=1:reset=1", af)
 
     def test_uses_shared_wav_when_provided(self):
-        import tempfile
-
         fd, wav = tempfile.mkstemp(suffix=".wav")
         os.close(fd)
         try:
@@ -114,6 +113,26 @@ class ExtractAudioEnergyCommandTests(unittest.TestCase):
     def test_missing_wav_falls_back_to_video(self):
         cmd = self._run(wav_path="/no/such.wav")
         self.assertIn("/video.mp4", cmd)
+
+
+class ExtractWavCleanupTests(unittest.TestCase):
+    def test_failed_extraction_removes_internally_created_wav(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wav_path = os.path.join(tmpdir, "failed.wav")
+            fd = os.open(wav_path, os.O_CREAT | os.O_RDWR)
+            with mock.patch.object(
+                audio_extract.tempfile,
+                "mkstemp",
+                return_value=(fd, wav_path),
+            ), mock.patch.object(
+                audio_extract,
+                "proc_run",
+                return_value=mock.Mock(returncode=1, stderr="ffmpeg failed"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "ffmpeg failed"):
+                    audio_extract.extract_wav_16k_mono("/video.mp4")
+
+            self.assertFalse(os.path.exists(wav_path))
 
 
 if __name__ == "__main__":

--- a/tests/test_audio_analyzer.py
+++ b/tests/test_audio_analyzer.py
@@ -83,5 +83,38 @@ class ComputeEnergyScoresTests(unittest.TestCase):
         self.assertEqual(len(scores), 1)
 
 
+
+class ExtractAudioEnergyCommandTests(unittest.TestCase):
+    def _run(self, wav_path=None):
+        from unittest import mock
+
+        with mock.patch.object(aa, "proc_run", return_value=mock.Mock(returncode=0, stdout="", stderr="")) as mocked, \
+             mock.patch.object(aa, "_fallback_energy", return_value=[]):
+            aa.extract_audio_energy("/video.mp4", wav_path=wav_path)
+        return mocked.call_args.args[0]
+
+    def test_window_is_pinned_with_asetnsamples(self):
+        cmd = self._run()
+        af = cmd[cmd.index("-af") + 1]
+        self.assertIn("asetnsamples=n=16000", af)
+        self.assertIn("astats=metadata=1:reset=1", af)
+
+    def test_uses_shared_wav_when_provided(self):
+        import tempfile
+
+        fd, wav = tempfile.mkstemp(suffix=".wav")
+        os.close(fd)
+        try:
+            cmd = self._run(wav_path=wav)
+            self.assertIn(wav, cmd)
+            self.assertNotIn("/video.mp4", cmd)
+        finally:
+            os.unlink(wav)
+
+    def test_missing_wav_falls_back_to_video(self):
+        cmd = self._run(wav_path="/no/such.wav")
+        self.assertIn("/video.mp4", cmd)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_audio_events.py
+++ b/tests/test_audio_events.py
@@ -76,5 +76,48 @@ class ProfileTests(unittest.TestCase):
         self.assertEqual(max(w, key=w.get), "transcript_semantic")
 
 
+
+class WaveformFromSharedWavTests(unittest.TestCase):
+    def test_reads_pre_extracted_wav_directly(self):
+        import struct
+        import tempfile
+        import wave as wave_mod
+
+        fd, wav_path = tempfile.mkstemp(suffix=".wav")
+        os.close(fd)
+        try:
+            with wave_mod.open(wav_path, "wb") as w:
+                w.setnchannels(1)
+                w.setsampwidth(2)
+                w.setframerate(16000)
+                w.writeframes(struct.pack("<4h", 0, 16384, -16384, 0))
+
+            waveform = ae._read_waveform_16k_mono("/nonexistent.mp4", wav_path=wav_path)
+            self.assertIsNotNone(waveform)
+            self.assertEqual(len(waveform), 4)
+            self.assertAlmostEqual(float(waveform[1]), 0.5, places=3)
+        finally:
+            os.unlink(wav_path)
+
+    def test_missing_wav_falls_back_to_extraction_path(self):
+        from unittest import mock
+
+        with mock.patch.object(ae, "proc_run", return_value=mock.Mock(returncode=1, stderr="")):
+            waveform = ae._read_waveform_16k_mono("/nonexistent.mp4", wav_path="/no/such/file.wav")
+        self.assertIsNone(waveform)
+
+    def test_corrupt_wav_from_ffmpeg_returns_none(self):
+        from unittest import mock
+
+        def fake_run(cmd, **kwargs):
+            # ffmpeg "succeeds" but leaves a WAV that wave.open cannot parse.
+            with open(cmd[cmd.index("wav") + 1], "wb") as f:
+                f.write(b"not a wav")
+            return mock.Mock(returncode=0, stderr="")
+
+        with mock.patch.object(ae, "proc_run", side_effect=fake_run):
+            self.assertIsNone(ae._read_waveform_16k_mono("/nonexistent.mp4"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_audio_events.py
+++ b/tests/test_audio_events.py
@@ -56,6 +56,26 @@ class ComputeEventScoresTests(unittest.TestCase):
         self.assertEqual(scores[0], 0.0)
 
 
+class DominantReactionTests(unittest.TestCase):
+    def test_names_the_loudest_channel_in_range(self):
+        events = [_event(3, laughter=0.2, cheering=0.8)]
+        self.assertEqual(ae.dominant_reaction(events, 0, 10), "cheering")
+
+    def test_ignores_frames_outside_the_range(self):
+        events = [_event(30, laughter=0.9)]
+        self.assertIsNone(ae.dominant_reaction(events, 0, 10))
+
+    def test_speech_only_range_has_no_reaction(self):
+        events = [_event(3, speech=1.0)]
+        self.assertIsNone(ae.dominant_reaction(events, 0, 10))
+
+
+class ReactionTimesTests(unittest.TestCase):
+    def test_only_frames_above_threshold(self):
+        events = [_event(1, laughter=0.05), _event(2, cheering=0.4)]
+        self.assertEqual(ae.reaction_times(events), [2])
+
+
 class ProfileTests(unittest.TestCase):
     def test_default_is_podcast_and_llm_sourced(self):
         p = profiles.get_profile(None)

--- a/tests/test_batch_render.py
+++ b/tests/test_batch_render.py
@@ -1,0 +1,111 @@
+"""Tests for backend.main batch clip rendering — worker pool sizing, result
+ordering, and clip_complete events for both outcomes."""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BACKEND_ROOT = os.path.join(ROOT, "backend")
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+import main as backend_main
+
+
+def _clean_env():
+    return {k: v for k, v in os.environ.items() if k != "PODCLI_RENDER_CONCURRENCY"}
+
+
+class RenderConcurrencyTests(unittest.TestCase):
+    def test_env_override_wins(self):
+        with mock.patch.dict(os.environ, {"PODCLI_RENDER_CONCURRENCY": "4"}):
+            self.assertEqual(backend_main._render_concurrency(), 4)
+
+    def test_env_override_floors_at_one(self):
+        with mock.patch.dict(os.environ, {"PODCLI_RENDER_CONCURRENCY": "0"}):
+            self.assertEqual(backend_main._render_concurrency(), 1)
+
+    def test_invalid_env_falls_back_to_cpu_rule(self):
+        with mock.patch.dict(os.environ, {"PODCLI_RENDER_CONCURRENCY": "junk"}), \
+             mock.patch.object(backend_main.os, "cpu_count", return_value=16):
+            self.assertEqual(backend_main._render_concurrency(), 2)
+
+    def test_two_workers_on_big_machines(self):
+        with mock.patch.dict(os.environ, _clean_env(), clear=True), \
+             mock.patch.object(backend_main.os, "cpu_count", return_value=8):
+            self.assertEqual(backend_main._render_concurrency(), 2)
+
+    def test_one_worker_on_small_machines(self):
+        with mock.patch.dict(os.environ, _clean_env(), clear=True), \
+             mock.patch.object(backend_main.os, "cpu_count", return_value=4):
+            self.assertEqual(backend_main._render_concurrency(), 1)
+
+
+class HandleBatchClipsTests(unittest.TestCase):
+    def _run_batch(self, concurrency, fail_index=None, n=4):
+        clips = [
+            {"start_second": float(i * 100), "end_second": float(i * 100 + 30), "title": f"clip_{i}"}
+            for i in range(n)
+        ]
+        params = {"video_path": "/video.mp4", "clips": clips}
+
+        def fake_generate_clip(**kwargs):
+            title = kwargs["title"]
+            idx = int(title.rsplit("_", 1)[1])
+            if fail_index is not None and idx == fail_index:
+                raise RuntimeError("render exploded")
+            return {
+                "output_path": f"/out/{title}.mp4",
+                "duration": 30.0,
+                "file_size_mb": 1.0,
+                "title": title,
+            }
+
+        progress_events = []
+        results_holder = {}
+
+        def capture_result(task_id, status, data=None, error=None):
+            results_holder["status"] = status
+            results_holder["data"] = data
+
+        with mock.patch.dict(os.environ, {"PODCLI_RENDER_CONCURRENCY": str(concurrency)}), \
+             mock.patch("services.clip_generator.generate_clip", side_effect=fake_generate_clip), \
+             mock.patch.object(backend_main, "emit_progress",
+                               side_effect=lambda *a, **kw: progress_events.append((a, kw))), \
+             mock.patch.object(backend_main, "emit_result", side_effect=capture_result):
+            backend_main.handle_batch_clips("task-1", params)
+
+        return results_holder, progress_events
+
+    def test_results_preserve_clip_order(self):
+        holder, _ = self._run_batch(concurrency=2)
+        rows = holder["data"]["results"]
+        self.assertEqual([r["clip_index"] for r in rows], [0, 1, 2, 3])
+        self.assertEqual(holder["data"]["successful_clips"], 4)
+
+    def test_sequential_path_matches(self):
+        holder, _ = self._run_batch(concurrency=1)
+        rows = holder["data"]["results"]
+        self.assertEqual([r["clip_index"] for r in rows], [0, 1, 2, 3])
+
+    def test_failed_clip_recorded_in_place(self):
+        holder, _ = self._run_batch(concurrency=2, fail_index=2)
+        rows = holder["data"]["results"]
+        self.assertEqual(rows[2]["status"], "error")
+        self.assertIn("render exploded", rows[2]["error"])
+        self.assertEqual(rows[2]["start_second"], 200.0)
+        self.assertEqual(holder["data"]["successful_clips"], 3)
+
+    def test_clip_complete_emitted_for_success_and_failure(self):
+        _, events = self._run_batch(concurrency=2, fail_index=1)
+        complete = [kw["clip_result"] for a, kw in events if a[1] == "clip_complete"]
+        self.assertEqual(len(complete), 4)
+        by_index = {r["clip_index"]: r for r in complete}
+        self.assertEqual(by_index[1]["status"], "error")
+        self.assertEqual(by_index[0]["status"], "success")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_caption_renderer.py
+++ b/tests/test_caption_renderer.py
@@ -1,0 +1,102 @@
+"""Tests for backend.services.caption_renderer chunking and event volume."""
+
+import os
+import sys
+import unittest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BACKEND_ROOT = os.path.join(ROOT, "backend")
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+from services import caption_renderer as cr
+from config.caption_styles import get_style
+
+
+def _word(text, start, end, speaker=None):
+    return {"word": text, "start": start, "end": end, "speaker": speaker}
+
+
+def _flowing_words(texts, start=0.0, dur=0.3, speaker=None):
+    words = []
+    t = start
+    for text in texts:
+        words.append(_word(text, t, t + dur, speaker))
+        t += dur
+    return words
+
+
+class ChunkWordsTests(unittest.TestCase):
+    def test_splits_on_word_count(self):
+        words = _flowing_words(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"])
+        chunks = cr._chunk_words(words, 4)
+        self.assertEqual([len(c) for c in chunks], [4, 4, 2])
+
+    def test_breaks_after_terminal_punctuation(self):
+        words = _flowing_words(["That", "was", "wild.", "Then", "we", "left"])
+        chunks = cr._chunk_words(words, 6)
+        self.assertEqual([len(c) for c in chunks], [3, 3])
+        self.assertEqual(chunks[0][-1]["word"], "wild.")
+
+    def test_breaks_on_question_and_exclamation(self):
+        words = _flowing_words(["Really?", "Yes!", "Okay"])
+        chunks = cr._chunk_words(words, 6)
+        self.assertEqual([len(c) for c in chunks], [1, 1, 1])
+
+    def test_breaks_on_long_gap(self):
+        words = [
+            _word("before", 0.0, 0.3),
+            _word("pause", 0.3, 0.6),
+            _word("after", 1.6, 1.9),  # 1.0s gap
+        ]
+        chunks = cr._chunk_words(words, 6)
+        self.assertEqual([len(c) for c in chunks], [2, 1])
+
+    def test_short_gap_does_not_break(self):
+        words = [
+            _word("quick", 0.0, 0.3),
+            _word("pause", 0.9, 1.2),  # 0.6s gap
+        ]
+        chunks = cr._chunk_words(words, 6)
+        self.assertEqual([len(c) for c in chunks], [2])
+
+    def test_breaks_on_speaker_change(self):
+        words = (
+            _flowing_words(["so", "anyway"], start=0.0, speaker="SPEAKER_00")
+            + _flowing_words(["totally", "agree"], start=0.6, speaker="SPEAKER_01")
+        )
+        chunks = cr._chunk_words(words, 6)
+        self.assertEqual([len(c) for c in chunks], [2, 2])
+        self.assertEqual(chunks[1][0]["word"], "totally")
+
+    def test_missing_speaker_labels_do_not_break(self):
+        words = _flowing_words(["one", "two", "three"])
+        self.assertEqual(len(cr._chunk_words(words, 6)), 1)
+
+    def test_empty_words(self):
+        self.assertEqual(cr._chunk_words([], 4), [])
+
+
+class BrandedEventVolumeTests(unittest.TestCase):
+    def test_events_are_linear_in_word_count(self):
+        style = get_style("branded")
+        chunk_size = style.get("words_per_chunk", 6)
+        words = _flowing_words(["word"] * chunk_size)
+        content = cr._render_branded(words, style, 0.0)
+        dialogue_count = content.count("Dialogue:")
+        # One text event per word for the chunk span + one pill per word.
+        self.assertEqual(dialogue_count, 2 * chunk_size)
+
+    def test_text_events_span_the_whole_chunk(self):
+        style = get_style("branded")
+        words = _flowing_words(["alpha", "beta", "gamma"])
+        content = cr._render_branded(words, style, 0.0)
+        layer1 = [l for l in content.splitlines() if l.startswith("Dialogue: 1,")]
+        starts = {l.split(",")[1] for l in layer1}
+        ends = {l.split(",")[2] for l in layer1}
+        self.assertEqual(len(starts), 1)
+        self.assertEqual(len(ends), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_claude_suggest_helpers.py
+++ b/tests/test_claude_suggest_helpers.py
@@ -188,5 +188,70 @@ class SliceSegmentsTests(unittest.TestCase):
         self.assertEqual(cs._slice_segments_for_range(segments, 0, 50), [])
 
 
+
+class ReactionAnchorPromptTests(unittest.TestCase):
+    def test_empty_or_none_returns_empty(self):
+        self.assertEqual(cs._format_reaction_anchors(None), "")
+        self.assertEqual(cs._format_reaction_anchors([]), "")
+
+    def test_anchors_are_sorted_deduped_and_formatted(self):
+        block = cs._format_reaction_anchors([120.34, 12.31, 12.34])
+        self.assertIn("AUDIENCE REACTION ANCHORS", block)
+        self.assertIn("12.3s", block)
+        self.assertIn("120.3s", block)
+        self.assertEqual(block.count("12.3s, 120.3s"), 1)  # deduped and ascending
+
+    def test_anchor_count_is_capped(self):
+        import re
+        block = cs._format_reaction_anchors([float(t) for t in range(200)])
+        self.assertEqual(len(re.findall(r"\d+\.\ds", block)), cs.MAX_REACTION_ANCHORS)
+
+
+class BlendSignalScoresTests(unittest.TestCase):
+    def _clips(self):
+        return [
+            {"start_second": 0.0, "end_second": 10.0, "score": 16, "reasons": ["hot_take"]},
+            {"start_second": 100.0, "end_second": 120.0, "score": 12, "reasons": []},
+        ]
+
+    def _events(self):
+        return [
+            {"time": 5.0, "laughter": 0.5, "cheering": 0.0, "screaming": 0.0, "speech": 0.2},
+        ]
+
+    def test_no_signals_is_a_noop(self):
+        clips = self._clips()
+        out = cs.blend_signal_scores(clips, energy_data=None, events_data=None)
+        self.assertEqual(out[0]["score"], 16)
+        self.assertNotIn("signal_boost", out[0])
+
+    def test_reaction_peak_boosts_only_covering_clip(self):
+        clips = cs.blend_signal_scores(self._clips(), events_data=self._events())
+        self.assertGreater(clips[0]["score"], 16)
+        self.assertEqual(clips[1]["score"], 12)
+        self.assertNotIn("signal_boost", clips[1])
+
+    def test_ai_score_stays_primary(self):
+        # Even a maxed-out reaction+energy signal adds at most 3 points.
+        clips = [{"start_second": 0.0, "end_second": 10.0, "score": 12}]
+        events = [{"time": 5.0, "laughter": 1.0, "cheering": 0.0, "screaming": 0.0, "speech": 0.0}]
+        energy = [{"time": float(t), "rms_db": -30.0} for t in range(0, 60)] + [{"time": 5.0, "rms_db": 0.0}]
+        out = cs.blend_signal_scores(clips, energy_data=energy, events_data=events)
+        self.assertLessEqual(out[0]["score"], 15.0)
+
+    def test_deterministic(self):
+        a = cs.blend_signal_scores(self._clips(), events_data=self._events())
+        b = cs.blend_signal_scores(self._clips(), events_data=self._events())
+        self.assertEqual(a, b)
+
+    def test_order_preserved(self):
+        clips = cs.blend_signal_scores(self._clips(), events_data=self._events())
+        self.assertEqual([c["start_second"] for c in clips], [0.0, 100.0])
+
+    def test_strong_laugh_tagged_in_reasons(self):
+        clips = cs.blend_signal_scores(self._clips(), events_data=self._events())
+        self.assertIn("laughter", clips[0]["reasons"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_claude_suggest_helpers.py
+++ b/tests/test_claude_suggest_helpers.py
@@ -252,6 +252,12 @@ class BlendSignalScoresTests(unittest.TestCase):
         clips = cs.blend_signal_scores(self._clips(), events_data=self._events())
         self.assertIn("laughter", clips[0]["reasons"])
 
+    def test_crowd_cheer_is_not_tagged_as_laughter(self):
+        events = [{"time": 5.0, "laughter": 0.0, "cheering": 0.5, "screaming": 0.0, "speech": 0.2}]
+        clips = cs.blend_signal_scores(self._clips(), events_data=events)
+        self.assertIn("cheering", clips[0]["reasons"])
+        self.assertNotIn("laughter", clips[0]["reasons"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_clip_generator.py
+++ b/tests/test_clip_generator.py
@@ -1,8 +1,11 @@
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
 
@@ -156,6 +159,109 @@ class ClipGeneratorTests(unittest.TestCase):
         self.assertEqual(smooth_mock.call_count, 2)
         self.assertEqual(detect_mock.call_count, 2)
         self.assertEqual(replace_mock.call_count, 2)
+
+
+
+class TransitionAutofixGatingTests(unittest.TestCase):
+    def test_multi_segment_cut_can_jump(self):
+        self.assertTrue(cg._reframe_can_jump(
+            reframe=True, crop_strategy="face",
+            keep_segments=[{"start": 0, "end": 5}, {"start": 8, "end": 12}],
+        ))
+
+    def test_non_reframe_format_cannot_jump(self):
+        self.assertFalse(cg._reframe_can_jump(reframe=False, crop_strategy="face"))
+
+    def test_center_crop_cannot_jump(self):
+        self.assertFalse(cg._reframe_can_jump(reframe=True, crop_strategy="center"))
+
+    def test_face_follow_can_jump_without_speaker_labels(self):
+        # whisper.cpp (the default engine) skips diarization, so the tracker
+        # still snaps between faces with every word unlabeled.
+        self.assertTrue(cg._reframe_can_jump(reframe=True, crop_strategy="face"))
+
+    def test_speaker_strategies_can_jump(self):
+        self.assertTrue(cg._reframe_can_jump(reframe=True, crop_strategy="speaker"))
+        self.assertTrue(cg._reframe_can_jump(reframe=True, crop_strategy="speaker-hardcut"))
+
+    def test_manual_crop_jumps_only_with_multiple_keyframes(self):
+        self.assertFalse(cg._reframe_can_jump(
+            reframe=True, crop_strategy="manual", crop_keyframes=[{"t": 0, "x_pct": 50}],
+        ))
+        self.assertTrue(cg._reframe_can_jump(
+            reframe=True, crop_strategy="manual",
+            crop_keyframes=[{"t": 0, "x_pct": 20}, {"t": 3, "x_pct": 80}],
+        ))
+
+    def test_default_engine_face_crop_runs_autofix(self):
+        env = {k: v for k, v in os.environ.items() if k != "PODCLI_TRANSITION_AUTOFIX_PASSES"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            passes = cg._transition_autofix_passes(
+                cg._reframe_can_jump(reframe=True, crop_strategy="face", crop_keyframes=None)
+            )
+        self.assertEqual(passes, 2)
+
+    def test_default_passes_gated_by_jump_potential(self):
+        env = {k: v for k, v in os.environ.items() if k != "PODCLI_TRANSITION_AUTOFIX_PASSES"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertEqual(cg._transition_autofix_passes(True), 2)
+            self.assertEqual(cg._transition_autofix_passes(False), 0)
+
+    def test_env_override_wins(self):
+        with mock.patch.dict(os.environ, {"PODCLI_TRANSITION_AUTOFIX_PASSES": "1"}):
+            self.assertEqual(cg._transition_autofix_passes(False), 1)
+            self.assertEqual(cg._transition_autofix_passes(True), 1)
+        with mock.patch.dict(os.environ, {"PODCLI_TRANSITION_AUTOFIX_PASSES": "0"}):
+            self.assertEqual(cg._transition_autofix_passes(True), 0)
+
+    def test_env_override_is_clamped_and_validated(self):
+        with mock.patch.dict(os.environ, {"PODCLI_TRANSITION_AUTOFIX_PASSES": "9"}):
+            self.assertEqual(cg._transition_autofix_passes(False), 2)
+        with mock.patch.dict(os.environ, {"PODCLI_TRANSITION_AUTOFIX_PASSES": "junk"}):
+            self.assertEqual(cg._transition_autofix_passes(True), 2)
+
+
+class OutputPathReservationTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="podcli-output-test-")
+        cg._reserved_output_paths.clear()
+        self.addCleanup(cg._reserved_output_paths.clear)
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+
+    def test_duplicate_title_gets_a_suffix(self):
+        first = cg._reserve_output_path(self.tmpdir, "same_title_short", ".mp4")
+        second = cg._reserve_output_path(self.tmpdir, "same_title_short", ".mp4")
+        third = cg._reserve_output_path(self.tmpdir, "same_title_short", ".mp4")
+        self.assertEqual(os.path.basename(first), "same_title_short.mp4")
+        self.assertEqual(os.path.basename(second), "same_title_short-2.mp4")
+        self.assertEqual(os.path.basename(third), "same_title_short-3.mp4")
+
+    def test_concurrent_renders_of_one_title_never_share_a_file(self):
+        barrier = threading.Barrier(8)
+
+        def render(i):
+            barrier.wait()
+            path = cg._reserve_output_path(self.tmpdir, "duplicate_short", ".mp4")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(f"clip-{i}")
+            return path
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            paths = list(pool.map(render, range(8)))
+
+        self.assertEqual(len(set(paths)), 8)
+        contents = []
+        for p in paths:
+            self.assertTrue(os.path.exists(p))
+            with open(p, encoding="utf-8") as f:
+                contents.append(f.read())
+        self.assertEqual(len(set(contents)), 8)
+
+    def test_sidecar_paths_inherit_the_unique_stem(self):
+        cg._reserve_output_path(self.tmpdir, "same_title_short", ".mp4")
+        second = cg._reserve_output_path(self.tmpdir, "same_title_short", ".mp4")
+        base, _ = os.path.splitext(second)
+        self.assertTrue(base.endswith("same_title_short-2"))
 
 
 if __name__ == "__main__":

--- a/tests/test_saliency.py
+++ b/tests/test_saliency.py
@@ -159,5 +159,54 @@ class PooledTests(unittest.TestCase):
         self.assertEqual(len(pooled), 3)
 
 
+
+class PrecomputedProfilesTests(unittest.TestCase):
+    def test_precomputed_energy_and_events_skip_extraction(self):
+        energy = [
+            {"time": float(t), "rms_db": -5.0 if 28 <= t <= 32 else -30.0}
+            for t in range(120)
+        ]
+        events = [{"time": 30.0, "laughter": 0.5, "cheering": 0.0, "screaming": 0.0, "speech": 0.0}]
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("source audio must not be re-extracted")
+
+        orig_energy, orig_events = sal.extract_audio_energy, sal.extract_audio_events
+        sal.extract_audio_energy, sal.extract_audio_events = _boom, _boom
+        try:
+            clips = sal.detect_highlights(
+                "/nonexistent.mp4",
+                profile_name="party",
+                energy_data=energy,
+                events_data=events,
+                min_dur=8.0,
+                max_dur=30.0,
+            )
+        finally:
+            sal.extract_audio_energy, sal.extract_audio_events = orig_energy, orig_events
+
+        self.assertTrue(clips)
+        self.assertTrue(any("reaction" in c["reasons"] for c in clips))
+
+    def test_empty_events_list_counts_as_precomputed(self):
+        energy = [{"time": float(t), "rms_db": -30.0} for t in range(60)]
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("events must not be re-extracted")
+
+        orig_events = sal.extract_audio_events
+        sal.extract_audio_events = _boom
+        try:
+            clips = sal.detect_highlights(
+                "/nonexistent.mp4",
+                profile_name="party",
+                energy_data=energy,
+                events_data=[],
+            )
+        finally:
+            sal.extract_audio_events = orig_events
+        self.assertIsInstance(clips, list)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_speaker_assignment.py
+++ b/tests/test_speaker_assignment.py
@@ -1,0 +1,61 @@
+"""Tests for backend.services.speaker_detection word/segment assignment."""
+
+import os
+import sys
+import unittest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BACKEND_ROOT = os.path.join(ROOT, "backend")
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+from services.speaker_detection import assign_speakers_to_words
+
+
+class AssignSpeakersToWordsTests(unittest.TestCase):
+    def test_no_diarization_data_assigns_none(self):
+        words = [{"word": "hi", "start": 0.0, "end": 0.4}]
+        out = assign_speakers_to_words(words, [])
+        self.assertIsNone(out[0]["speaker"])
+
+    def test_word_inside_single_segment(self):
+        words = [{"word": "hi", "start": 1.0, "end": 1.4}]
+        segments = [{"speaker": "SPEAKER_00", "start": 0.0, "end": 5.0}]
+        out = assign_speakers_to_words(words, segments)
+        self.assertEqual(out[0]["speaker"], "SPEAKER_00")
+
+    def test_boundary_word_gets_max_overlap_speaker_not_first_match(self):
+        # Word straddles a turn boundary: A covers 0.1s, B covers 0.5s.
+        words = [{"word": "yeah", "start": 10.0, "end": 10.6}]
+        segments = [
+            {"speaker": "SPEAKER_00", "start": 9.0, "end": 10.1},
+            {"speaker": "SPEAKER_01", "start": 10.1, "end": 12.0},
+        ]
+        out = assign_speakers_to_words(words, segments)
+        self.assertEqual(out[0]["speaker"], "SPEAKER_01")
+
+    def test_split_segments_of_same_speaker_accumulate(self):
+        words = [{"word": "so", "start": 10.0, "end": 11.0}]
+        segments = [
+            {"speaker": "SPEAKER_00", "start": 10.0, "end": 10.3},
+            {"speaker": "SPEAKER_01", "start": 10.3, "end": 10.7},
+            {"speaker": "SPEAKER_00", "start": 10.7, "end": 11.0},
+        ]
+        out = assign_speakers_to_words(words, segments)
+        self.assertEqual(out[0]["speaker"], "SPEAKER_00")
+
+    def test_zero_length_word_falls_back_to_midpoint(self):
+        words = [{"word": "uh", "start": 10.5, "end": 10.5}]
+        segments = [{"speaker": "SPEAKER_01", "start": 10.0, "end": 11.0}]
+        out = assign_speakers_to_words(words, segments)
+        self.assertEqual(out[0]["speaker"], "SPEAKER_01")
+
+    def test_word_outside_all_segments_is_none(self):
+        words = [{"word": "hm", "start": 50.0, "end": 50.4}]
+        segments = [{"speaker": "SPEAKER_00", "start": 0.0, "end": 10.0}]
+        out = assign_speakers_to_words(words, segments)
+        self.assertIsNone(out[0]["speaker"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_suggest_handler.py
+++ b/tests/test_suggest_handler.py
@@ -11,8 +11,24 @@ if BACKEND_ROOT not in sys.path:
     sys.path.insert(0, BACKEND_ROOT)
 
 import main as backend_main
+from services import claude_suggest
 
 SEGMENTS = [{"start": 0.0, "end": 10.0, "text": "hello"}]
+ENERGY_DATA = [{"time": float(t), "rms_db": -30.0} for t in range(31)] + [
+    {"time": 25.0, "rms_db": 0.0}
+]
+EVENTS_DATA = [{
+    "time": 25.0,
+    "laughter": 1.0,
+    "cheering": 0.0,
+    "screaming": 0.0,
+    "speech": 0.0,
+}]
+CLIPS = [
+    {"title": "first", "start_second": 0, "end_second": 10, "score": 15},
+    {"title": "second", "start_second": 10, "end_second": 20, "score": 14},
+    {"title": "reaction", "start_second": 20, "end_second": 30, "score": 13},
+]
 
 
 class SuggestReactionTimesTests(unittest.TestCase):
@@ -27,8 +43,8 @@ class SuggestReactionTimesTests(unittest.TestCase):
         def fake_emit_result(task_id, status, data=None, error=None):
             emitted.update({"task_id": task_id, "status": status, "data": data, "error": error})
 
-        with mock.patch.object(backend_main, "suggest_initial_with_claude", fake_suggest), \
-             mock.patch.object(backend_main, "_find_ai_cli_candidates", return_value=["claude"]), \
+        with mock.patch.object(claude_suggest, "suggest_initial_with_claude", fake_suggest), \
+             mock.patch.object(claude_suggest, "_find_ai_cli_candidates", return_value=["claude"]), \
              mock.patch.object(backend_main, "emit_result", fake_emit_result), \
              mock.patch.object(backend_main, "emit_progress"):
             backend_main.handle_suggest_clips("task-1", params)
@@ -41,40 +57,21 @@ class SuggestReactionTimesTests(unittest.TestCase):
         })
         self.assertEqual(captured["reaction_times"], [12.5, 40.0])
 
-    def test_profiles_are_derived_and_used_to_reselect_candidates(self):
-        clips = [
-            {"title": "first", "start_second": 0, "end_second": 10, "score": 15},
-            {"title": "second", "start_second": 10, "end_second": 20, "score": 14},
-            {"title": "reaction", "start_second": 20, "end_second": 30, "score": 13},
-        ]
-        energy_data = [
-            {"time": float(t), "rms_db": -30.0}
-            for t in range(31)
-        ] + [{"time": 25.0, "rms_db": 0.0}]
-        events_data = [{
-            "time": 25.0,
-            "laughter": 1.0,
-            "cheering": 0.0,
-            "screaming": 0.0,
-            "speech": 0.0,
-        }]
-        with mock.patch.object(
-            backend_main,
-            "get_energy_profile",
-            return_value={"energy_data": energy_data},
-        ) as energy_profile, \
-             mock.patch.object(
-                 backend_main,
-                 "get_event_profile",
-                 return_value={"events_data": events_data, "reaction_times": [25.0]},
-             ) as event_profile, \
-             mock.patch.object(backend_main, "audio_events_available", return_value=True), \
+    def test_cached_signals_are_reused_without_decoding(self):
+        with mock.patch(
+            "services.signal_cache.load_signals",
+            return_value={"energy_data": ENERGY_DATA, "events_data": EVENTS_DATA},
+        ), \
+             mock.patch("services.audio_analyzer.extract_audio_energy") as extract_energy, \
+             mock.patch("services.audio_events.extract_audio_events") as extract_events, \
              mock.patch.object(backend_main.os.path, "exists", return_value=True):
             captured, emitted = self._run(
                 {"segments": SEGMENTS, "video_path": "/video.mp4", "top_n": 2},
-                clips=clips,
+                clips=[dict(c) for c in CLIPS],
             )
 
+        extract_energy.assert_not_called()
+        extract_events.assert_not_called()
         self.assertEqual(captured["reaction_times"], [25.0])
         self.assertEqual(captured["top_n"], 4)
         self.assertEqual(
@@ -82,8 +79,34 @@ class SuggestReactionTimesTests(unittest.TestCase):
             ["first", "reaction"],
         )
         self.assertGreater(emitted["data"]["clips"][1]["signal_boost"], 2)
-        energy_profile.assert_called_once_with("/video.mp4", SEGMENTS)
-        event_profile.assert_called_once_with("/video.mp4", SEGMENTS)
+
+    def test_uncached_signals_are_extracted_once_from_a_shared_wav(self):
+        with mock.patch("services.signal_cache.load_signals", return_value={}), \
+             mock.patch("services.signal_cache.save_signals") as save_signals, \
+             mock.patch(
+                 "services.audio_extract.extract_wav_16k_mono", return_value="/tmp/shared.wav"
+             ) as extract_wav, \
+             mock.patch(
+                 "services.audio_analyzer.extract_audio_energy", return_value=ENERGY_DATA
+             ) as extract_energy, \
+             mock.patch(
+                 "services.audio_events.extract_audio_events", return_value=EVENTS_DATA
+             ) as extract_events, \
+             mock.patch("services.audio_events.is_available", return_value=True), \
+             mock.patch.object(backend_main.os.path, "exists", return_value=True), \
+             mock.patch.object(backend_main.os, "unlink"):
+            captured, _ = self._run(
+                {"segments": SEGMENTS, "video_path": "/video.mp4", "top_n": 2},
+                clips=[dict(c) for c in CLIPS],
+            )
+
+        extract_wav.assert_called_once_with("/video.mp4")
+        extract_energy.assert_called_once_with("/video.mp4", wav_path="/tmp/shared.wav")
+        extract_events.assert_called_once_with("/video.mp4", wav_path="/tmp/shared.wav")
+        save_signals.assert_called_once_with(
+            "/video.mp4", energy_data=ENERGY_DATA, events_data=EVENTS_DATA
+        )
+        self.assertEqual(captured["reaction_times"], [25.0])
 
     def test_missing_video_and_anchors_pass_none(self):
         captured, _ = self._run({"segments": SEGMENTS})

--- a/tests/test_suggest_handler.py
+++ b/tests/test_suggest_handler.py
@@ -1,0 +1,56 @@
+"""Tests for backend.main's AI suggestion handler: reaction anchors reach the prompt."""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BACKEND_ROOT = os.path.join(ROOT, "backend")
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+import main as backend_main
+
+SEGMENTS = [{"start": 0.0, "end": 10.0, "text": "hello"}]
+
+
+class SuggestReactionTimesTests(unittest.TestCase):
+    def _run(self, params):
+        captured = {}
+
+        def fake_suggest(**kwargs):
+            captured.update(kwargs)
+            return [{"title": "clip", "start_second": 0, "end_second": 30}]
+
+        with mock.patch("services.claude_suggest.suggest_initial_with_claude", fake_suggest), \
+             mock.patch("services.claude_suggest._find_ai_cli_candidates", return_value=["claude"]), \
+             mock.patch.object(backend_main, "emit_result"), \
+             mock.patch.object(backend_main, "emit_progress"):
+            backend_main.handle_suggest_clips("task-1", params)
+        return captured
+
+    def test_reaction_times_are_forwarded(self):
+        captured = self._run({
+            "segments": SEGMENTS,
+            "reaction_times": [12.5, 40.0],
+        })
+        self.assertEqual(captured["reaction_times"], [12.5, 40.0])
+
+    def test_reaction_times_are_derived_from_video_path(self):
+        with mock.patch("services.audio_events.is_available", return_value=True), \
+             mock.patch("services.audio_events.get_event_profile",
+                        return_value={"reaction_times": [7.0]}) as profile, \
+             mock.patch.object(backend_main.os.path, "exists", return_value=True):
+            captured = self._run({"segments": SEGMENTS, "video_path": "/video.mp4"})
+
+        self.assertEqual(captured["reaction_times"], [7.0])
+        self.assertEqual(profile.call_args.args[0], "/video.mp4")
+
+    def test_missing_video_and_anchors_pass_none(self):
+        captured = self._run({"segments": SEGMENTS})
+        self.assertIsNone(captured["reaction_times"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_suggest_handler.py
+++ b/tests/test_suggest_handler.py
@@ -1,4 +1,4 @@
-"""Tests for backend.main's AI suggestion handler: reaction anchors reach the prompt."""
+"""Tests for backend.main's AI suggestion handler."""
 
 import os
 import sys
@@ -16,39 +16,77 @@ SEGMENTS = [{"start": 0.0, "end": 10.0, "text": "hello"}]
 
 
 class SuggestReactionTimesTests(unittest.TestCase):
-    def _run(self, params):
+    def _run(self, params, clips=None):
         captured = {}
+        emitted = {}
 
         def fake_suggest(**kwargs):
             captured.update(kwargs)
-            return [{"title": "clip", "start_second": 0, "end_second": 30}]
+            return clips or [{"title": "clip", "start_second": 0, "end_second": 30}]
 
-        with mock.patch("services.claude_suggest.suggest_initial_with_claude", fake_suggest), \
-             mock.patch("services.claude_suggest._find_ai_cli_candidates", return_value=["claude"]), \
-             mock.patch.object(backend_main, "emit_result"), \
+        def fake_emit_result(task_id, status, data=None, error=None):
+            emitted.update({"task_id": task_id, "status": status, "data": data, "error": error})
+
+        with mock.patch.object(backend_main, "suggest_initial_with_claude", fake_suggest), \
+             mock.patch.object(backend_main, "_find_ai_cli_candidates", return_value=["claude"]), \
+             mock.patch.object(backend_main, "emit_result", fake_emit_result), \
              mock.patch.object(backend_main, "emit_progress"):
             backend_main.handle_suggest_clips("task-1", params)
-        return captured
+        return captured, emitted
 
     def test_reaction_times_are_forwarded(self):
-        captured = self._run({
+        captured, _ = self._run({
             "segments": SEGMENTS,
             "reaction_times": [12.5, 40.0],
         })
         self.assertEqual(captured["reaction_times"], [12.5, 40.0])
 
-    def test_reaction_times_are_derived_from_video_path(self):
-        with mock.patch("services.audio_events.is_available", return_value=True), \
-             mock.patch("services.audio_events.get_event_profile",
-                        return_value={"reaction_times": [7.0]}) as profile, \
+    def test_profiles_are_derived_and_used_to_reselect_candidates(self):
+        clips = [
+            {"title": "first", "start_second": 0, "end_second": 10, "score": 15},
+            {"title": "second", "start_second": 10, "end_second": 20, "score": 14},
+            {"title": "reaction", "start_second": 20, "end_second": 30, "score": 13},
+        ]
+        energy_data = [
+            {"time": float(t), "rms_db": -30.0}
+            for t in range(31)
+        ] + [{"time": 25.0, "rms_db": 0.0}]
+        events_data = [{
+            "time": 25.0,
+            "laughter": 1.0,
+            "cheering": 0.0,
+            "screaming": 0.0,
+            "speech": 0.0,
+        }]
+        with mock.patch.object(
+            backend_main,
+            "get_energy_profile",
+            return_value={"energy_data": energy_data},
+        ) as energy_profile, \
+             mock.patch.object(
+                 backend_main,
+                 "get_event_profile",
+                 return_value={"events_data": events_data, "reaction_times": [25.0]},
+             ) as event_profile, \
+             mock.patch.object(backend_main, "audio_events_available", return_value=True), \
              mock.patch.object(backend_main.os.path, "exists", return_value=True):
-            captured = self._run({"segments": SEGMENTS, "video_path": "/video.mp4"})
+            captured, emitted = self._run(
+                {"segments": SEGMENTS, "video_path": "/video.mp4", "top_n": 2},
+                clips=clips,
+            )
 
-        self.assertEqual(captured["reaction_times"], [7.0])
-        self.assertEqual(profile.call_args.args[0], "/video.mp4")
+        self.assertEqual(captured["reaction_times"], [25.0])
+        self.assertEqual(captured["top_n"], 4)
+        self.assertEqual(
+            [clip["title"] for clip in emitted["data"]["clips"]],
+            ["first", "reaction"],
+        )
+        self.assertGreater(emitted["data"]["clips"][1]["signal_boost"], 2)
+        energy_profile.assert_called_once_with("/video.mp4", SEGMENTS)
+        event_profile.assert_called_once_with("/video.mp4", SEGMENTS)
 
     def test_missing_video_and_anchors_pass_none(self):
-        captured = self._run({"segments": SEGMENTS})
+        captured, _ = self._run({"segments": SEGMENTS})
         self.assertIsNone(captured["reaction_times"])
 
 

--- a/tests/test_video_cut.py
+++ b/tests/test_video_cut.py
@@ -1,11 +1,13 @@
 """Tests for backend.services.video_cut.
 
-Mocks proc_run so no actual ffmpeg process is spawned. Verifies the
-command shapes, the single-segment shortcut path, and cleanup of
-temporary concat artifacts.
+Command shapes, the single-segment shortcut path and concat cleanup are
+checked against a mocked proc_run. Cut accuracy is checked against real
+ffmpeg on a synthetic clip with a known GOP structure.
 """
 
 import os
+import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -94,7 +96,6 @@ class CutMultiSegmentTests(unittest.TestCase):
                 self.assertFalse(os.path.exists(os.path.join(tmpdir, f"_part_{i}.mp4")))
             self.assertFalse(os.path.exists(os.path.join(tmpdir, "_concat_parts.txt")))
         finally:
-            import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)
 
     def test_multi_segment_cleans_up_on_failure(self):
@@ -118,7 +119,6 @@ class CutMultiSegmentTests(unittest.TestCase):
             for i in range(2):
                 self.assertFalse(os.path.exists(os.path.join(tmpdir, f"_part_{i}.mp4")))
         finally:
-            import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 
@@ -127,6 +127,90 @@ class ReExportTests(unittest.TestCase):
         from services import video_processor as vp
         self.assertIs(vp.cut_segment, video_cut.cut_segment)
         self.assertIs(vp.cut_multi_segment, video_cut.cut_multi_segment)
+
+
+
+class NoStreamCopyTests(unittest.TestCase):
+    def test_cut_always_re_encodes(self):
+        with mock.patch.object(video_cut, "proc_run", return_value=_ok()) as mocked:
+            video_cut.cut_segment("/in.mp4", "/out.mp4", 3.98, 6.0)
+
+        self.assertEqual(mocked.call_count, 1)
+        joined = " ".join(mocked.call_args.args[0])
+        self.assertIn("libx264", joined)
+        self.assertNotIn("-c copy", joined)
+        self.assertNotIn("ffprobe", joined)
+
+
+@unittest.skipUnless(
+    shutil.which("ffmpeg") and shutil.which("ffprobe"), "ffmpeg/ffprobe not installed"
+)
+class CutContentAccuracyTests(unittest.TestCase):
+    """Cut off the keyframe grid of a known 2s GOP and check the content that
+    lands at t=0, not just the clip's duration."""
+
+    COLORS = ["red", "green", "blue", "yellow", "cyan", "magenta", "white", "gray"]
+    RGB = {
+        "red": (255, 0, 0), "green": (0, 128, 0), "blue": (0, 0, 255),
+        "yellow": (255, 255, 0), "cyan": (0, 255, 255), "magenta": (255, 0, 255),
+        "white": (255, 255, 255), "gray": (128, 128, 128),
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp(prefix="podcli-gop-test-")
+        cls.src = os.path.join(cls.tmpdir, "src.mp4")
+        cmd = ["ffmpeg", "-y", "-loglevel", "error"]
+        for color in cls.COLORS:
+            cmd += ["-f", "lavfi", "-i", f"color=c={color}:s=64x64:r=25:d=1"]
+        cmd += [
+            "-filter_complex", f"concat=n={len(cls.COLORS)}:v=1:a=0",
+            "-c:v", "libx264", "-pix_fmt", "yuv420p",
+            "-g", "50", "-keyint_min", "50", "-sc_threshold", "0",
+            cls.src,
+        ]
+        subprocess.run(cmd, check=True, capture_output=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    def _first_frame_rgb(self, path):
+        raw = subprocess.run(
+            ["ffmpeg", "-loglevel", "error", "-i", path, "-frames:v", "1",
+             "-f", "rawvideo", "-pix_fmt", "rgb24", "-"],
+            check=True, capture_output=True,
+        ).stdout
+        px = list(raw)
+        n = len(px) // 3
+        return tuple(round(sum(px[c::3]) / n) for c in range(3))
+
+    def _assert_frame_is(self, path, color):
+        got = self._first_frame_rgb(path)
+        want = self.RGB[color]
+        for got_c, want_c in zip(got, want):
+            self.assertLessEqual(
+                abs(got_c - want_c), 24,
+                f"first frame {got} is not {color} {want}",
+            )
+
+    def test_cut_just_before_a_keyframe_starts_at_the_requested_second(self):
+        # Keyframes land on 0/2/4/6. A cut at 3.9 must open on second 3
+        # (yellow), never on the keyframe-2 content (blue) that a stream copy
+        # would seek back to.
+        out = os.path.join(self.tmpdir, "cut_off_grid.mp4")
+        video_cut.cut_segment(self.src, out, 3.9, 6.0)
+        self._assert_frame_is(out, "yellow")
+
+    def test_cut_mid_gop_starts_at_the_requested_second(self):
+        out = os.path.join(self.tmpdir, "cut_mid_gop.mp4")
+        video_cut.cut_segment(self.src, out, 5.5, 7.0)
+        self._assert_frame_is(out, "magenta")
+
+    def test_cut_on_a_keyframe_starts_at_the_requested_second(self):
+        out = os.path.join(self.tmpdir, "cut_on_kf.mp4")
+        video_cut.cut_segment(self.src, out, 4.0, 5.0)
+        self._assert_frame_is(out, "cyan")
 
 
 if __name__ == "__main__":

--- a/tests/test_video_processor_helpers.py
+++ b/tests/test_video_processor_helpers.py
@@ -137,5 +137,46 @@ class AssignFaceTracksTests(unittest.TestCase):
         self.assertEqual(frame0_ids, frame1_ids)
 
 
+
+class FaceSampleIndicesTests(unittest.TestCase):
+    def _reference_indices(self, total_frames, fps):
+        """The stepping the old cap.set() sampling loop used."""
+        sample_step = max(1, int(fps / 10))
+        dense_end = int(fps * 0.5)
+        semi_dense_end = int(fps * 1.0)
+        semi_dense_step = max(1, sample_step // 2)
+        indices = []
+        idx = 0
+        while idx < total_frames:
+            indices.append(idx)
+            if idx < dense_end:
+                idx += 1
+            elif idx < semi_dense_end:
+                idx += semi_dense_step
+            else:
+                idx += sample_step
+        return indices
+
+    def test_matches_seek_loop_progression_at_30fps(self):
+        self.assertEqual(vp._face_sample_indices(300, 30.0), self._reference_indices(300, 30.0))
+
+    def test_matches_seek_loop_progression_at_60fps(self):
+        self.assertEqual(vp._face_sample_indices(600, 60.0), self._reference_indices(600, 60.0))
+
+    def test_dense_start_then_sparse(self):
+        indices = vp._face_sample_indices(900, 30.0)
+        self.assertEqual(indices[:15], list(range(15)))
+        steps = {b - a for a, b in zip(indices, indices[1:]) if a >= 30}
+        self.assertEqual(steps, {3})
+
+    def test_strictly_increasing_and_bounded(self):
+        indices = vp._face_sample_indices(100, 24.0)
+        self.assertEqual(indices, sorted(set(indices)))
+        self.assertLess(indices[-1], 100)
+
+    def test_empty_video(self):
+        self.assertEqual(vp._face_sample_indices(0, 30.0), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Reaction and energy curves were computed on every episode and then thrown
away: only the fallback heuristic read them, so the strongest signal for a
funny moment never reached the selector that actually picks clips.

- Laughter peaks anchor the prompt, and selected clips are re-ranked against
  reaction and energy
- Faces are sampled with sequential grab and retrieve instead of a seek per
  frame, which was the dominant per clip cost
- One shared 16kHz wav feeds whisper.cpp, energy, YAMNet, and diarization
  instead of decoding the source up to five times
- Batches render on a bounded pool with unique output paths, so two clips
  sharing a title cannot race on the same file
- The transition pass runs unless a jump is provably impossible
- Stream-copy cutting is gone: it could emit a whole GOP of the wrong
  content with every caption offset, and the duration check still passed

Part of the product audit. Stacked on `audit-2-provisioning`, so review only this PR's diff and merge in order.