### PR TITLE
Hold captions through pauses and wait for fonts before rendering

### DIFF
--- a/backend/services/clip_generator.py
+++ b/backend/services/clip_generator.py
@@ -520,11 +520,17 @@ def _render_with_remotion(
     # Prepare words JSON (adjust timestamps by offset)
     adjusted_words = []
     for w in words:
-        adjusted_words.append({
+        adjusted = {
             "word": w.get("word", ""),
             "start": round(w["start"] - time_offset, 3),
             "end": round(w["end"] - time_offset, 3),
-        })
+        }
+        # The chunker starts a new caption card on a speaker change. Dropping the
+        # field here left that rule dead in the render while the studio preview,
+        # which keeps it, chunked the same words differently.
+        if w.get("speaker") is not None:
+            adjusted["speaker"] = w["speaker"]
+        adjusted_words.append(adjusted)
 
     # Extract face Y positions so captions can avoid overlapping faces
     # Probe video dimensions

--- a/remotion/bundle-cache.mjs
+++ b/remotion/bundle-cache.mjs
@@ -18,6 +18,7 @@ export const CACHE_DIR = path.join(CACHE_ROOT, "remotion-bundle");
 const HASH_FILE = path.join(CACHE_DIR, ".hash");
 const LOCK_DIR = `${CACHE_DIR}.lock`;
 const LOCK_STALE_MS = 5 * 60 * 1000;
+const LOCK_HEARTBEAT_MS = Math.floor(LOCK_STALE_MS / 3);
 const ENTRY_POINT = path.join(__dirname, "src", "index.ts");
 
 /**
@@ -57,28 +58,76 @@ function cacheIsValid(want) {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+function removeStaleLock() {
+  try {
+    const entries = fs.readdirSync(LOCK_DIR, { withFileTypes: true });
+    if (entries.length === 0) {
+      if (Date.now() - fs.statSync(LOCK_DIR).mtimeMs > LOCK_STALE_MS) {
+        fs.rmdirSync(LOCK_DIR);
+        return true;
+      }
+      return false;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      const tokenPath = path.join(LOCK_DIR, entry.name);
+      if (Date.now() - fs.statSync(tokenPath).mtimeMs > LOCK_STALE_MS) {
+        fs.rmSync(tokenPath, { force: true });
+      }
+    }
+    fs.rmdirSync(LOCK_DIR);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function acquireLock() {
+  const token = `${process.pid}-${crypto.randomUUID()}`;
   for (;;) {
     try {
       fs.mkdirSync(LOCK_DIR);
-      return;
+      const tokenPath = path.join(LOCK_DIR, token);
+      try {
+        fs.writeFileSync(tokenPath, token, { flag: "wx" });
+      } catch (err) {
+        try {
+          fs.rmdirSync(LOCK_DIR);
+        } catch {}
+        throw err;
+      }
+      const lock = { token, tokenPath, heartbeat: undefined };
+      lock.heartbeat = setInterval(() => {
+        try {
+          const now = new Date();
+          fs.utimesSync(tokenPath, now, now);
+        } catch {
+          clearInterval(lock.heartbeat);
+        }
+      }, LOCK_HEARTBEAT_MS);
+      lock.heartbeat.unref();
+      return lock;
     } catch (err) {
       if (err.code !== "EEXIST") throw err;
     }
-    try {
-      if (Date.now() - fs.statSync(LOCK_DIR).mtimeMs > LOCK_STALE_MS) {
-        fs.rmdirSync(LOCK_DIR);
-        continue;
-      }
-    } catch {}
+    if (removeStaleLock()) continue;
     await sleep(500);
   }
 }
 
-function releaseLock() {
+function releaseLock(lock) {
+  clearInterval(lock.heartbeat);
+  try {
+    fs.rmSync(lock.tokenPath, { force: true });
+  } catch {}
   try {
     fs.rmdirSync(LOCK_DIR);
   } catch {}
+}
+
+function ownsLock(lock) {
+  return fs.existsSync(lock.tokenPath);
 }
 
 export async function getCachedBundle({ onBundle } = {}) {
@@ -86,14 +135,14 @@ export async function getCachedBundle({ onBundle } = {}) {
   if (cacheIsValid(want)) return CACHE_DIR;
 
   fs.mkdirSync(CACHE_ROOT, { recursive: true });
-  await acquireLock();
+  const lock = await acquireLock();
   try {
     if (cacheIsValid(want)) return CACHE_DIR;
 
     onBundle?.();
     // Bundle into a scratch dir and swap it in whole, so a crash mid-bundle
     // never leaves CACHE_DIR half-written.
-    const staging = `${CACHE_DIR}.tmp-${process.pid}`;
+    const staging = `${CACHE_DIR}.tmp-${lock.token}`;
     fs.rmSync(staging, { recursive: true, force: true });
     try {
       await bundle({
@@ -101,6 +150,9 @@ export async function getCachedBundle({ onBundle } = {}) {
         outDir: staging,
         webpackOverride,
       });
+      if (!ownsLock(lock)) {
+        throw new Error("Bundle cache lock ownership lost");
+      }
       fs.writeFileSync(path.join(staging, ".hash"), want);
       fs.rmSync(CACHE_DIR, { recursive: true, force: true });
       fs.renameSync(staging, CACHE_DIR);
@@ -109,6 +161,6 @@ export async function getCachedBundle({ onBundle } = {}) {
     }
     return CACHE_DIR;
   } finally {
-    releaseLock();
+    releaseLock(lock);
   }
 }

--- a/remotion/bundle-cache.mjs
+++ b/remotion/bundle-cache.mjs
@@ -2,8 +2,11 @@ import { bundle } from "@remotion/bundler";
 import path from "path";
 import fs from "fs";
 import crypto from "crypto";
+import { createRequire } from "module";
 import { fileURLToPath } from "url";
 import { webpackOverride } from "./webpack-override.mjs";
+
+const require = createRequire(import.meta.url);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(__dirname, "..");
@@ -13,12 +16,15 @@ const CACHE_ROOT = process.env.PODCLI_CACHE_DIR
 
 export const CACHE_DIR = path.join(CACHE_ROOT, "remotion-bundle");
 const HASH_FILE = path.join(CACHE_DIR, ".hash");
+const LOCK_DIR = `${CACHE_DIR}.lock`;
+const LOCK_STALE_MS = 5 * 60 * 1000;
 const ENTRY_POINT = path.join(__dirname, "src", "index.ts");
 
 /**
- * A bundle is a product of the compositions and the webpack config, so both
- * feed the cache key. Keying on either alone silently serves a bundle built
- * from inputs that no longer exist.
+ * A bundle is a product of the compositions, the webpack config, and the
+ * remotion/bundler versions that produced it, so all of them feed the cache
+ * key. Keying on a subset silently serves a bundle built from inputs that no
+ * longer exist.
  */
 function currentHash() {
   const hash = crypto.createHash("md5");
@@ -33,22 +39,76 @@ function currentHash() {
 
   walk(path.join(__dirname, "src"));
   hash.update(fs.readFileSync(path.join(__dirname, "webpack-override.mjs")));
+  hash.update(`remotion@${require("remotion/package.json").version}`);
+  hash.update(`@remotion/bundler@${require("@remotion/bundler/package.json").version}`);
   return hash.digest("hex");
+}
+
+function cacheIsValid(want) {
+  try {
+    return (
+      fs.existsSync(path.join(CACHE_DIR, "index.html")) &&
+      fs.readFileSync(HASH_FILE, "utf-8").trim() === want
+    );
+  } catch {
+    return false;
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function acquireLock() {
+  for (;;) {
+    try {
+      fs.mkdirSync(LOCK_DIR);
+      return;
+    } catch (err) {
+      if (err.code !== "EEXIST") throw err;
+    }
+    try {
+      if (Date.now() - fs.statSync(LOCK_DIR).mtimeMs > LOCK_STALE_MS) {
+        fs.rmdirSync(LOCK_DIR);
+        continue;
+      }
+    } catch {}
+    await sleep(500);
+  }
+}
+
+function releaseLock() {
+  try {
+    fs.rmdirSync(LOCK_DIR);
+  } catch {}
 }
 
 export async function getCachedBundle({ onBundle } = {}) {
   const want = currentHash();
-  if (fs.existsSync(HASH_FILE) && fs.existsSync(path.join(CACHE_DIR, "index.html"))) {
-    if (fs.readFileSync(HASH_FILE, "utf-8").trim() === want) return CACHE_DIR;
-  }
+  if (cacheIsValid(want)) return CACHE_DIR;
 
-  onBundle?.();
-  fs.mkdirSync(CACHE_DIR, { recursive: true });
-  const location = await bundle({
-    entryPoint: ENTRY_POINT,
-    outDir: CACHE_DIR,
-    webpackOverride,
-  });
-  fs.writeFileSync(HASH_FILE, want);
-  return location;
+  fs.mkdirSync(CACHE_ROOT, { recursive: true });
+  await acquireLock();
+  try {
+    if (cacheIsValid(want)) return CACHE_DIR;
+
+    onBundle?.();
+    // Bundle into a scratch dir and swap it in whole, so a crash mid-bundle
+    // never leaves CACHE_DIR half-written.
+    const staging = `${CACHE_DIR}.tmp-${process.pid}`;
+    fs.rmSync(staging, { recursive: true, force: true });
+    try {
+      await bundle({
+        entryPoint: ENTRY_POINT,
+        outDir: staging,
+        webpackOverride,
+      });
+      fs.writeFileSync(path.join(staging, ".hash"), want);
+      fs.rmSync(CACHE_DIR, { recursive: true, force: true });
+      fs.renameSync(staging, CACHE_DIR);
+    } finally {
+      fs.rmSync(staging, { recursive: true, force: true });
+    }
+    return CACHE_DIR;
+  } finally {
+    releaseLock();
+  }
 }

--- a/remotion/bundle-cache.test.mjs
+++ b/remotion/bundle-cache.test.mjs
@@ -1,0 +1,70 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { bundle } from "@remotion/bundler";
+
+vi.mock("@remotion/bundler", () => ({ bundle: vi.fn() }));
+
+const savedCacheDir = process.env.PODCLI_CACHE_DIR;
+const temporaryDirectories = [];
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.mocked(bundle).mockReset();
+  vi.resetModules();
+  if (savedCacheDir === undefined) delete process.env.PODCLI_CACHE_DIR;
+  else process.env.PODCLI_CACHE_DIR = savedCacheDir;
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("bundle cache lock", () => {
+  it("does not let a displaced owner release its successor's lock", async () => {
+    const cacheRoot = fs.mkdtempSync(path.join(os.tmpdir(), "podcli-bundle-cache-"));
+    temporaryDirectories.push(cacheRoot);
+    process.env.PODCLI_CACHE_DIR = cacheRoot;
+
+    const pendingBundles = [];
+    vi.mocked(bundle).mockImplementation(async ({ outDir }) => {
+      const completion = deferred();
+      pendingBundles.push(completion);
+      await completion.promise;
+      fs.mkdirSync(outDir, { recursive: true });
+      fs.writeFileSync(path.join(outDir, "index.html"), "");
+      return outDir;
+    });
+
+    const { CACHE_DIR, getCachedBundle } = await import("./bundle-cache.mjs");
+    const lockDir = `${CACHE_DIR}.lock`;
+    const first = getCachedBundle();
+    await vi.waitFor(() => expect(pendingBundles).toHaveLength(1));
+
+    const staleTime = new Date(Date.now() - 10 * 60 * 1000);
+    for (const entry of fs.readdirSync(lockDir)) {
+      fs.utimesSync(path.join(lockDir, entry), staleTime, staleTime);
+    }
+    fs.utimesSync(lockDir, staleTime, staleTime);
+
+    const second = getCachedBundle();
+    await vi.waitFor(() => expect(pendingBundles).toHaveLength(2));
+    const replacementTokens = fs.readdirSync(lockDir);
+    expect(replacementTokens).toHaveLength(1);
+
+    pendingBundles[0].resolve();
+    await expect(first).rejects.toThrow("Bundle cache lock ownership lost");
+    expect(fs.readdirSync(lockDir)).toEqual(replacementTokens);
+
+    pendingBundles[1].resolve();
+    await second;
+    expect(fs.existsSync(lockDir)).toBe(false);
+  });
+});

--- a/remotion/render.mjs
+++ b/remotion/render.mjs
@@ -100,10 +100,18 @@ async function main() {
   await new Promise((resolve) => assetServer.listen(0, "127.0.0.1", resolve));
   const assetPort = assetServer.address().port;
 
-  // Ensure the asset server is closed on any exit path
+  // Ensure the asset server is closed and the overlay temp file removed on any exit path
+  let captionOverlay;
   const closeAssetServer = () => { try { assetServer.close(); } catch {} };
-  process.on("SIGINT", () => { closeAssetServer(); process.exit(1); });
-  process.on("SIGTERM", () => { closeAssetServer(); process.exit(1); });
+  const cleanupOnSignal = () => {
+    closeAssetServer();
+    if (captionOverlay && !opts["keep-overlay"]) {
+      try { fs.unlinkSync(captionOverlay); } catch {}
+    }
+    process.exit(1);
+  };
+  process.on("SIGINT", cleanupOnSignal);
+  process.on("SIGTERM", cleanupOnSignal);
 
   const videoSrc = `http://127.0.0.1:${assetPort}/clip.mp4`;
   const logoSrc = opts.logo ? `http://127.0.0.1:${assetPort}/logo.png` : undefined;
@@ -159,7 +167,6 @@ async function main() {
 
     const cpus = os.cpus().length;
     const concurrency = Math.max(2, Math.min(cpus, 8));
-    let captionOverlay;
     if (opts["keep-overlay"]) {
       const outBase = opts.output.replace(/\.[^.]+$/, "");
       captionOverlay = `${outBase}_captions.mov`;

--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -1,11 +1,29 @@
 import "@fontsource/dm-sans/400.css";
 import "@fontsource/dm-sans/700.css";
 import React from "react";
-import { Composition, getInputProps } from "remotion";
+import { Composition, continueRender, delayRender, getInputProps } from "remotion";
 import { CaptionedClip } from "./CaptionedClip";
 import { Bookend } from "./Bookend";
 import { STYLES } from "./types";
 import type { Word } from "./types";
+
+// @fontsource only injects @font-face CSS and the browser fetches lazily, so
+// early frames can rasterize with fallback glyphs. Force the load and block
+// rendering on it. fonts.load() is used because fonts.ready resolves
+// immediately while no rendered text references the family yet.
+const fontsReady = delayRender("Waiting for DM Sans");
+Promise.all([
+  document.fonts.load("400 16px 'DM Sans'"),
+  document.fonts.load("700 16px 'DM Sans'"),
+])
+  .then(() => document.fonts.ready)
+  .then(() => continueRender(fontsReady))
+  .catch((err) => {
+    // An unfetchable or unparseable woff2 must degrade to the fallback font. An
+    // uncleared delayRender fails every frame instead, killing the whole render.
+    console.warn("DM Sans failed to load, falling back:", err);
+    continueRender(fontsReady);
+  });
 
 const inputProps = getInputProps() as {
   videoSrc?: string;

--- a/remotion/src/chunks.test.ts
+++ b/remotion/src/chunks.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { buildChunks, activeChunkAt } from "./chunks";
+import type { Word } from "./types";
+
+function words(...spec: [string, number, number][]): Word[] {
+  return spec.map(([word, start, end]) => ({ word, start, end }));
+}
+
+describe("buildChunks", () => {
+  it("holds a chunk through a short pause so captions don't flicker", () => {
+    const chunks = buildChunks(
+      words(["one", 0, 0.4], ["two.", 0.4, 0.8], ["three", 1.0, 1.4]),
+      { perChunk: 4 }
+    );
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].end).toBe(0.8);
+    expect(chunks[0].displayEnd).toBe(chunks[1].start);
+    expect(activeChunkAt(chunks, 0.9)).toBe(chunks[0]);
+  });
+
+  it("caps the hold at 0.4s across a long silence", () => {
+    const chunks = buildChunks(
+      words(["one", 0, 0.4], ["two", 0.4, 0.8], ["three", 15.0, 15.4]),
+      { perChunk: 4 }
+    );
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0].displayEnd).toBeCloseTo(1.2, 6);
+    expect(activeChunkAt(chunks, 5)).toBeUndefined();
+  });
+
+  it("never displays past the next chunk's start", () => {
+    const chunks = buildChunks(
+      words(["one", 0, 0.9], ["two.", 0.9, 1.5], ["three", 1.5, 2.0]),
+      { perChunk: 4 }
+    );
+
+    expect(chunks[0].displayEnd).toBe(chunks[1].start);
+  });
+
+  it("gives the last chunk a hold, clamped to the composition duration", () => {
+    const spec: [string, number, number][] = [["one", 0, 0.4], ["two", 0.4, 0.8]];
+
+    expect(buildChunks(words(...spec), { perChunk: 4 }).at(-1)!.displayEnd).toBeCloseTo(2.0, 6);
+    expect(
+      buildChunks(words(...spec), { perChunk: 4, clipEnd: 1.0 }).at(-1)!.displayEnd
+    ).toBeCloseTo(1.0, 6);
+    expect(
+      buildChunks(words(...spec), { perChunk: 4, clipEnd: 10 }).at(-1)!.displayEnd
+    ).toBeCloseTo(2.0, 6);
+  });
+
+  it("breaks on terminal punctuation, speaker change and long gaps", () => {
+    const chunks = buildChunks(
+      [
+        { word: "hi.", start: 0, end: 0.3, speaker: "A" },
+        { word: "so", start: 0.3, end: 0.6, speaker: "A" },
+        { word: "yes", start: 0.6, end: 0.9, speaker: "B" },
+        { word: "later", start: 3.0, end: 3.4, speaker: "B" },
+      ],
+      { perChunk: 8 }
+    );
+
+    expect(chunks.map((c) => c.words.map((w) => w.word).join(" "))).toEqual([
+      "hi.",
+      "so",
+      "yes",
+      "later",
+    ]);
+  });
+});

--- a/remotion/src/chunks.ts
+++ b/remotion/src/chunks.ts
@@ -1,0 +1,100 @@
+import type { Word } from "./types";
+
+export interface Chunk {
+  words: Word[];
+  start: number;
+  end: number;
+  displayEnd: number;
+}
+
+export interface ChunkOptions {
+  perChunk: number;
+  maxChars?: number;
+  absorbTail?: number;
+  splitTail?: boolean;
+  /** Composition duration in seconds; caps the hold on the last chunk. */
+  clipEnd?: number;
+}
+
+const BREAK_GAP_SECONDS = 0.8;
+// Mirrors CAPTION_GAP_FILL_MAX in backend/services/caption_renderer.py: both
+// renderers must burn the same caption timings.
+const GAP_FILL_MAX_SECONDS = 0.4;
+const LAST_CHUNK_HOLD_SECONDS = 1.2;
+const TERMINAL_PUNCTUATION = /[.!?…]["')\]]?$/;
+
+function breaksAfter(prev: Word, next: Word): boolean {
+  return (
+    TERMINAL_PUNCTUATION.test(prev.word.trim()) ||
+    (prev.speaker != null && next.speaker != null && prev.speaker !== next.speaker) ||
+    next.start - prev.end > BREAK_GAP_SECONDS
+  );
+}
+
+function hasBreakBetween(words: Word[], from: number, to: number): boolean {
+  for (let i = from; i < to; i++) {
+    if (breaksAfter(words[i], words[i + 1])) return true;
+  }
+  return false;
+}
+
+export function buildChunks(words: Word[], opts: ChunkOptions): Chunk[] {
+  const chunks: Chunk[] = [];
+  let i = 0;
+
+  while (i < words.length) {
+    let end = i + 1;
+    let charCount = words[i].word.trim().length;
+
+    while (end < words.length && end - i < opts.perChunk) {
+      if (breaksAfter(words[end - 1], words[end])) break;
+      if (opts.maxChars != null) {
+        const nextChars = charCount + 1 + words[end].word.trim().length;
+        if (nextChars > opts.maxChars) break;
+        charCount = nextChars;
+      }
+      end += 1;
+    }
+
+    if (
+      opts.absorbTail != null &&
+      end < words.length &&
+      words.length - end <= opts.absorbTail &&
+      !hasBreakBetween(words, end - 1, words.length - 1)
+    ) {
+      end = words.length;
+    }
+    if (opts.splitTail && words.length - end === 1 && end - i > 2) {
+      end -= 1;
+    }
+
+    const slice = words.slice(i, end);
+    const speechEnd = slice[slice.length - 1].end;
+    chunks.push({
+      words: slice,
+      start: slice[0].start,
+      end: speechEnd,
+      displayEnd: speechEnd,
+    });
+    i = end;
+  }
+
+  // Captions vanishing during inter-chunk pauses reads as flicker, so a chunk
+  // holds until the next one starts. The hold is capped, or a chunk break on a
+  // long silence (a musical sting, dead air) freezes the last sentence on screen
+  // for the whole pause.
+  for (let k = 0; k < chunks.length; k++) {
+    const next = chunks[k + 1];
+    const hold = next
+      ? Math.min(next.start, chunks[k].end + GAP_FILL_MAX_SECONDS)
+      : chunks[k].end + LAST_CHUNK_HOLD_SECONDS;
+    const capped = opts.clipEnd != null ? Math.min(hold, opts.clipEnd) : hold;
+    chunks[k].displayEnd = Math.max(chunks[k].end, capped);
+  }
+
+  return chunks;
+}
+
+export function activeChunkAt(chunks: Chunk[], time: number): Chunk | undefined {
+  return chunks.find((c) => time >= c.start && time < c.displayEnd);
+}

--- a/remotion/src/components/BrandedCaptions.tsx
+++ b/remotion/src/components/BrandedCaptions.tsx
@@ -8,6 +8,7 @@ import {
 } from "remotion";
 import type { Word, CaptionStyle } from "../types";
 import { captionScale } from "../types";
+import { buildChunks, activeChunkAt } from "../chunks";
 
 interface Props {
   words: Word[];
@@ -16,61 +17,11 @@ interface Props {
   faceY?: number | null; // normalized 0-1 (0=top, 1=bottom)
 }
 
-interface Chunk {
-  words: Word[];
-  start: number;
-  end: number;
-}
-
 const MAX_CHARS_PER_CHUNK = 18;
-
-function buildChunks(words: Word[], perChunk: number): Chunk[] {
-  const chunks: Chunk[] = [];
-  let i = 0;
-
-  while (i < words.length) {
-    let end = i;
-    let charCount = 0;
-
-    while (end < words.length && end - i < perChunk) {
-      const nextWord = words[end].word.trim();
-      const nextChars = charCount === 0 ? nextWord.length : charCount + 1 + nextWord.length;
-
-      if (end > i && nextChars > MAX_CHARS_PER_CHUNK) {
-        break;
-      }
-
-      charCount = nextChars;
-      end += 1;
-    }
-
-    if (end === i) {
-      end = i + 1;
-    }
-
-    const remaining = words.length - end;
-    if (remaining === 1 && end - i > 2) {
-      end -= 1;
-    }
-
-    const slice = words.slice(i, end);
-    chunks.push({
-      words: slice,
-      start: slice[0].start,
-      end: slice[slice.length - 1].end,
-    });
-    i = end;
-  }
-
-  return chunks;
-}
 
 function splitIntoLines(words: Word[]): [Word[], Word[]] {
   if (words.length <= 2) {
     return [words, []];
-  }
-  if (words.length === 3) {
-    return [words.slice(0, 2), words.slice(2)];
   }
   return [words.slice(0, 2), words.slice(2)];
 }
@@ -137,7 +88,8 @@ const CaptionLine: React.FC<{
         color: style.color,
         textShadow: "0 0 40px rgba(0, 0, 0, 0.15), 0 0 80px rgba(0, 0, 0, 0.1), 0 0 150px rgba(0, 0, 0, 0.08)",
         lineHeight: 1.25,
-        whiteSpace: "nowrap",
+        maxWidth: "100%",
+        overflowWrap: "anywhere",
       }}
     >
       {words.map((word, i) => {
@@ -167,15 +119,18 @@ export const BrandedCaptions: React.FC<Props> = ({
   faceY,
 }) => {
   const frame = useCurrentFrame();
-  const { fps, height } = useVideoConfig();
+  const { fps, height, durationInFrames } = useVideoConfig();
   const s = captionScale(height);
   const currentTime = frame / fps;
   const scaledStyle = { ...style, fontSize: style.fontSize * s };
 
-  const chunks = buildChunks(words, style.wordsPerChunk);
-  const activeChunk = chunks.find(
-    (c) => currentTime >= c.start && currentTime < c.end
-  );
+  const chunks = buildChunks(words, {
+    perChunk: style.wordsPerChunk,
+    maxChars: MAX_CHARS_PER_CHUNK,
+    splitTail: true,
+    clipEnd: durationInFrames / fps,
+  });
+  const activeChunk = activeChunkAt(chunks, currentTime);
 
   // Dynamic margin: if face is in the lower portion, push captions further down
   // faceY is normalized 0-1 (0=top, 1=bottom)

--- a/remotion/src/components/HormoziCaptions.tsx
+++ b/remotion/src/components/HormoziCaptions.tsx
@@ -7,45 +7,25 @@ import {
 } from "remotion";
 import type { Word, CaptionStyle } from "../types";
 import { captionScale } from "../types";
+import { buildChunks, activeChunkAt } from "../chunks";
 
 interface Props {
   words: Word[];
   style: CaptionStyle;
 }
 
-interface Chunk {
-  words: Word[];
-  start: number;
-  end: number;
-}
-
-function buildChunks(words: Word[], perChunk: number): Chunk[] {
-  const chunks: Chunk[] = [];
-  let i = 0;
-  while (i < words.length) {
-    let end = Math.min(i + perChunk, words.length);
-    if (words.length - end === 1) end = words.length;
-    const slice = words.slice(i, end);
-    chunks.push({
-      words: slice,
-      start: slice[0].start,
-      end: slice[slice.length - 1].end,
-    });
-    i = end;
-  }
-  return chunks;
-}
-
 export const HormoziCaptions: React.FC<Props> = ({ words, style }) => {
   const frame = useCurrentFrame();
-  const { fps, height } = useVideoConfig();
+  const { fps, height, durationInFrames } = useVideoConfig();
   const s = captionScale(height);
   const currentTime = frame / fps;
 
-  const chunks = buildChunks(words, style.wordsPerChunk);
-  const activeChunk = chunks.find(
-    (c) => currentTime >= c.start && currentTime < c.end
-  );
+  const chunks = buildChunks(words, {
+    perChunk: style.wordsPerChunk,
+    absorbTail: 1,
+    clipEnd: durationInFrames / fps,
+  });
+  const activeChunk = activeChunkAt(chunks, currentTime);
 
   if (!activeChunk) return null;
 
@@ -82,6 +62,9 @@ export const HormoziCaptions: React.FC<Props> = ({ words, style }) => {
           backgroundColor: "rgba(0, 0, 0, 0.8)",
           borderRadius: 16 * s,
           padding: `${14 * s}px ${32 * s}px`,
+          maxWidth: `calc(100% - ${120 * s}px)`,
+          boxSizing: "border-box",
+          overflowWrap: "anywhere",
           textAlign: "center",
           fontFamily: style.fontFamily,
           fontSize: style.fontSize * s,

--- a/remotion/src/components/KaraokeCaptions.tsx
+++ b/remotion/src/components/KaraokeCaptions.tsx
@@ -2,33 +2,11 @@ import React from "react";
 import { useCurrentFrame, useVideoConfig } from "remotion";
 import type { Word, CaptionStyle } from "../types";
 import { captionScale } from "../types";
+import { buildChunks, activeChunkAt } from "../chunks";
 
 interface Props {
   words: Word[];
   style: CaptionStyle;
-}
-
-interface Chunk {
-  words: Word[];
-  start: number;
-  end: number;
-}
-
-function buildChunks(words: Word[], perChunk: number): Chunk[] {
-  const chunks: Chunk[] = [];
-  let i = 0;
-  while (i < words.length) {
-    let end = Math.min(i + perChunk, words.length);
-    if (words.length - end === 1) end = words.length;
-    const slice = words.slice(i, end);
-    chunks.push({
-      words: slice,
-      start: slice[0].start,
-      end: slice[slice.length - 1].end,
-    });
-    i = end;
-  }
-  return chunks;
 }
 
 function splitIntoLines(words: Word[]): [Word[], Word[]] {
@@ -88,14 +66,16 @@ const KaraokeLine: React.FC<{
 
 export const KaraokeCaptions: React.FC<Props> = ({ words, style }) => {
   const frame = useCurrentFrame();
-  const { fps, height } = useVideoConfig();
+  const { fps, height, durationInFrames } = useVideoConfig();
   const s = captionScale(height);
   const currentTime = frame / fps;
 
-  const chunks = buildChunks(words, style.wordsPerChunk);
-  const activeChunk = chunks.find(
-    (c) => currentTime >= c.start && currentTime < c.end
-  );
+  const chunks = buildChunks(words, {
+    perChunk: style.wordsPerChunk,
+    absorbTail: 1,
+    clipEnd: durationInFrames / fps,
+  });
+  const activeChunk = activeChunkAt(chunks, currentTime);
 
   if (!activeChunk) return null;
 

--- a/remotion/src/components/SubtleCaptions.tsx
+++ b/remotion/src/components/SubtleCaptions.tsx
@@ -2,33 +2,11 @@ import React from "react";
 import { useCurrentFrame, useVideoConfig, interpolate } from "remotion";
 import type { Word, CaptionStyle } from "../types";
 import { captionScale } from "../types";
+import { buildChunks, activeChunkAt } from "../chunks";
 
 interface Props {
   words: Word[];
   style: CaptionStyle;
-}
-
-interface Chunk {
-  words: Word[];
-  start: number;
-  end: number;
-}
-
-function buildChunks(words: Word[], perChunk: number): Chunk[] {
-  const chunks: Chunk[] = [];
-  let i = 0;
-  while (i < words.length) {
-    let end = Math.min(i + perChunk, words.length);
-    if (words.length - end <= 2) end = words.length;
-    const slice = words.slice(i, end);
-    chunks.push({
-      words: slice,
-      start: slice[0].start,
-      end: slice[slice.length - 1].end,
-    });
-    i = end;
-  }
-  return chunks;
 }
 
 function splitIntoLines(words: Word[]): [Word[], Word[]] {
@@ -39,14 +17,16 @@ function splitIntoLines(words: Word[]): [Word[], Word[]] {
 
 export const SubtleCaptions: React.FC<Props> = ({ words, style }) => {
   const frame = useCurrentFrame();
-  const { fps, height } = useVideoConfig();
+  const { fps, height, durationInFrames } = useVideoConfig();
   const s = captionScale(height);
   const currentTime = frame / fps;
 
-  const chunks = buildChunks(words, style.wordsPerChunk);
-  const activeChunk = chunks.find(
-    (c) => currentTime >= c.start && currentTime < c.end
-  );
+  const chunks = buildChunks(words, {
+    perChunk: style.wordsPerChunk,
+    absorbTail: 2,
+    clipEnd: durationInFrames / fps,
+  });
+  const activeChunk = activeChunkAt(chunks, currentTime);
 
   if (!activeChunk) return null;
 

--- a/remotion/src/types.ts
+++ b/remotion/src/types.ts
@@ -14,7 +14,6 @@ export interface CaptionStyle {
   activeColor: string;
   uppercase: boolean;
   wordsPerChunk: number;
-  position: "bottom" | "center" | "lower-third";
   marginBottom: number;
 }
 
@@ -46,7 +45,6 @@ export const STYLES: Record<string, CaptionStyle> = {
     activeColor: "#FFFF00",
     uppercase: true,
     wordsPerChunk: 3,
-    position: "bottom",
     marginBottom: 400,
   },
   karaoke: {
@@ -57,7 +55,6 @@ export const STYLES: Record<string, CaptionStyle> = {
     activeColor: "#FFFFFF",
     uppercase: false,
     wordsPerChunk: 5,
-    position: "bottom",
     marginBottom: 400,
   },
   subtle: {
@@ -68,7 +65,6 @@ export const STYLES: Record<string, CaptionStyle> = {
     activeColor: "#FFFFFF",
     uppercase: false,
     wordsPerChunk: 6,
-    position: "bottom",
     marginBottom: 200,
   },
   branded: {
@@ -79,7 +75,6 @@ export const STYLES: Record<string, CaptionStyle> = {
     activeColor: "#FFFFFF",
     uppercase: false,
     wordsPerChunk: 3,
-    position: "lower-third",
     marginBottom: 420,
   },
 };


### PR DESCRIPTION
The active chunk ended at its last word, so captions blinked out during
every natural pause and popped back for the next line.

- A chunk stays up until the next one starts, capped at 0.4s into a silence
  so a long pause clears, matching the burn-in renderer
- Chunk building lives in one module and breaks on punctuation, speaker
  change, and long gaps
- Rendering waits for the font, and a font that fails to load degrades to a
  fallback instead of failing every frame
- The bundle cache keys on the Remotion version and takes a lock, so a cold
  start under concurrency cannot serve a half-written bundle

Part of the product audit. Stacked on `audit-3-render`, so review only this PR's diff and merge in order.