### PR TITLE
Honor clean_fillers on agent exports and make the port configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ PODCLI_QUALITY=high
 # Transition QA/autofix passes (0=off, 1-2 allowed; renderer hard-caps at 2)
 PODCLI_TRANSITION_AUTOFIX_PASSES=2
 
-PORT=3847                          # Web UI port
+PODCLI_PORT=3847                   # Web studio port (PORT also works)
 
 # Logging verbosity: debug, info, warn, error
 PODCLI_LOG_LEVEL=info

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -68,6 +68,7 @@ def _reveal_in_os(path: str) -> None:
 
 
 from config.paths import paths
+from config.server import DEFAULT_PORT, resolve_web_server_port, web_server_url
 from presets import MIN_CLIP_DURATION, MAX_CLIP_DURATION, TARGET_CLIP_DURATION_MIN, TARGET_CLIP_DURATION_MAX
 
 
@@ -2994,7 +2995,7 @@ def cmd_clips(args):
         print(f"\n  {green}✓{reset} Reopened {accent}{str(clip.get('id'))[:8]}{reset}  {bold}{clip.get('title')}{reset}")
         if not transcript:
             print(f"      {gray}Transcript not loaded — re-transcribe in the studio to edit captions.{reset}")
-        print(f"      {gray}Open the studio:{reset} {accent}http://localhost:3847/clip/{clip.get('id')}{reset}\n")
+        print(f"      {gray}Open the studio:{reset} {accent}{web_server_url()}/clip/{clip.get('id')}{reset}\n")
         return
 
 
@@ -3599,7 +3600,7 @@ def main():
                         help="Save handle/platforms/outro-title/accent/bg as the default brand and exit")
 
     # ── ui (Studio web dashboard) ──
-    sub.add_parser("ui", aliases=["webui"], help="Open the Studio web UI (http://localhost:3847)")
+    sub.add_parser("ui", aliases=["webui"], help=f"Open the Studio web UI (http://localhost:{DEFAULT_PORT})")
 
     # ── presets ──
     pre = sub.add_parser("presets", help="Manage presets")
@@ -3896,7 +3897,7 @@ def main():
 
 
 def launch_webui():
-    """Launch the Studio web UI server (http://localhost:3847)."""
+    """Launch the Studio web UI server (PODCLI_PORT, PORT, else 3847)."""
     import subprocess as sp
     import shutil as _shutil
 
@@ -3907,7 +3908,7 @@ def launch_webui():
     reset = "\033[0m"
 
     backend_dir = os.path.dirname(os.path.abspath(__file__))
-    port = os.environ.get("PORT", "3847")
+    port = resolve_web_server_port()
     node = os.environ.get("PODCLI_NODE") or _shutil.which("node")
     studio = os.environ.get("PODCLI_STUDIO") or os.path.join(backend_dir, "..", "studio")
     server = os.path.join(studio, "web-server.mjs")
@@ -3918,6 +3919,8 @@ def launch_webui():
         # same Python backend + ffmpeg via the env below.
         env = {
             **os.environ,
+            # Pin both: an inherited PODCLI_PORT outranks PORT in the studio's resolver.
+            "PODCLI_PORT": str(port),
             "PORT": str(port),
             "PODCLI_BACKEND": backend_dir,
             "PYTHON_PATH": sys.executable,
@@ -4523,8 +4526,7 @@ def _interactive_config():
         if action == "webui":
             import webbrowser
 
-            port = os.environ.get("PORT", "3847")
-            url = f"http://localhost:{port}/config"
+            url = f"{web_server_url()}/config"
             print(f"\n  {gray}Config UI:{reset} {url}")
             print(f"  {dim}Serve the UI first if needed: npm run build && npm run ui:prod{reset}\n")
             webbrowser.open(url)

--- a/backend/config/server.py
+++ b/backend/config/server.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+from typing import Mapping
+
+DEFAULT_PORT = 3847
+
+
+def resolve_web_server_port(env: Mapping[str, str] | None = None) -> int:
+    """Mirror of resolveWebServerPort in src/config/server.ts. The Python launcher
+    and the Node studio must agree on the port or the CLI prints a dead URL."""
+    env = os.environ if env is None else env
+    raw = env.get("PODCLI_PORT") or env.get("PORT")
+    try:
+        port = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return DEFAULT_PORT
+    return port if 0 < port <= 65535 else DEFAULT_PORT
+
+
+def web_server_url(env: Mapping[str, str] | None = None) -> str:
+    return f"http://localhost:{resolve_web_server_port(env)}"

--- a/backend/templates/knowledge/00-master-instructions.md
+++ b/backend/templates/knowledge/00-master-instructions.md
@@ -1,0 +1,31 @@
+# Master instructions
+
+How the AI should operate when producing content for this show. Fill in every `[bracket]`, then delete this line.
+
+## Operating rules
+
+1. Read `01-brand-identity.md` and `02-voice-and-tone.md` before writing anything.
+2. Check `03-episodes-database.md` before suggesting moments so published clips are not repeated.
+3. Apply the quality gate below to every title, description, and thumbnail line.
+4. Log what worked and what did not in `13-learnings.md` after each episode retro.
+
+## Quality gate
+
+Before outputting any content, verify:
+
+- Would the target viewer click this?
+- Does it earn attention in the first 5 seconds?
+- Does the content deliver what the hook promises?
+- Does the clip stand alone without episode context?
+- Zero banned words from `02-voice-and-tone.md`.
+- Does it sound like a person talking, not a press release?
+
+## Auto-detection
+
+- Transcript text or file provided: process it into scored moments.
+- Asked for titles, descriptions, or thumbnails: use the matching guide file.
+- Asked to "process episode": run the full pipeline.
+
+## Show-specific overrides
+
+[Anything this show does differently from the defaults above, or "none yet".]

--- a/backend/templates/knowledge/01-brand-identity.md
+++ b/backend/templates/knowledge/01-brand-identity.md
@@ -1,0 +1,28 @@
+# Brand identity
+
+## Show
+
+- Name: [Show name]
+- One-line positioning: [Who it is for and what they get, in one sentence]
+- Format: [Interview / co-hosted conversation / solo commentary], [typical length], [publishing cadence]
+- Language: [Primary language, plus any mixing]
+
+## Hosts
+
+| Host | Role | Voice in one line |
+|------|------|-------------------|
+| [Name] | [Host / co-host] | [e.g. asks blunt questions, plays devil's advocate] |
+
+## Audience
+
+- Who watches: [age range, occupation, what they care about]
+- Why they watch: [the job the show does for them: learn X, feel Y, keep up with Z]
+- Where they watch: [YouTube long-form / Shorts / TikTok / Instagram / podcast apps]
+
+## Promise
+
+Every episode should leave the viewer with: [the consistent takeaway that makes someone subscribe].
+
+## What this show is not
+
+[2-3 things the show deliberately avoids, e.g. news recaps, guest promo hours.]

--- a/backend/templates/knowledge/02-voice-and-tone.md
+++ b/backend/templates/knowledge/02-voice-and-tone.md
@@ -1,0 +1,30 @@
+# Voice and tone
+
+## Voice fingerprint
+
+Describe how this show talks in 3-5 adjectives with a line of explanation each:
+
+- [e.g. Direct: says the thing plainly, no wind-up]
+- [e.g. Curious: questions over hot takes]
+- [adjective]: [what it means in practice]
+
+## The coffee test
+
+Every line of copy should sound like something a host would actually say to a friend over coffee. If it reads like marketing, rewrite it.
+
+Passes: "[example sentence in the show's real voice]"
+Fails: "[example of the corporate/hype version of the same sentence]"
+
+## Banned words and phrases
+
+Words that must never appear in titles, descriptions, or thumbnails:
+
+- [e.g. insane, mind-blowing, game-changer]
+- [e.g. you won't believe]
+- [add the cliches your niche is drowning in]
+
+## Punctuation and style
+
+- [e.g. sentence case titles, no all-caps words]
+- [e.g. numerals over spelled-out numbers]
+- [e.g. emoji policy: none / max one per description]

--- a/backend/templates/knowledge/03-episodes-database.md
+++ b/backend/templates/knowledge/03-episodes-database.md
@@ -1,0 +1,20 @@
+# Episodes database
+
+Tracks every episode and every short produced from it, so new suggestions never duplicate published clips. Add a section per episode, newest first.
+
+## Template
+
+### EP[number]: [episode title]
+
+- Guest: [name, or "none"]
+- Recorded: [date] | Published: [date]
+- Link: [URL]
+- Core topics: [3-5 topics]
+
+Shorts produced:
+
+| # | Moment (timestamps) | Title | Platform | Status |
+|---|---------------------|-------|----------|--------|
+| 1 | [00:14:20-00:15:05] | [published title] | [YouTube Shorts] | [published / scheduled / dropped] |
+
+Moments considered but not used: [timestamps + one-line reason, so they can be reconsidered or skipped later].

--- a/backend/templates/knowledge/04-shorts-creation-guide.md
+++ b/backend/templates/knowledge/04-shorts-creation-guide.md
@@ -1,0 +1,33 @@
+# Shorts creation guide
+
+What makes a moment worth clipping for this show.
+
+## Moment selection criteria
+
+Score candidate moments against these, best first:
+
+1. [e.g. A strong claim someone could disagree with]
+2. [e.g. A specific story with a turn: setup, tension, payoff]
+3. [e.g. A number or fact the viewer did not know]
+4. [e.g. Genuine laughter or an emotional beat]
+5. [e.g. Practical advice the viewer can apply today]
+
+## Hard rules
+
+- Standalone: no episode context required to follow the clip.
+- Length: [e.g. 25-55 seconds, hard cap 90].
+- The hook must land inside the first [3] seconds.
+- Skip: [e.g. inside jokes, sponsor reads, name-drops without payoff].
+
+## Clip shapes that work for this show
+
+| Shape | Description | Example moment |
+|-------|-------------|----------------|
+| [Hot take] | [guest says the quiet part out loud] | [ep + timestamp once you have one] |
+| [Story] | [complete micro-story with a punchline] | [example] |
+
+## Editing preferences
+
+- Caption style: [branded / hormozi / karaoke / subtle]
+- Format: [9:16 / 16:9 / 1:1]
+- [Anything else: logo, intro/outro, music policy]

--- a/backend/templates/knowledge/05-title-formulas.md
+++ b/backend/templates/knowledge/05-title-formulas.md
@@ -1,0 +1,29 @@
+# Title formulas
+
+## Rules
+
+- Under [70] characters. Main keyword in the first 3 words.
+- Sentence case unless the platform convention differs.
+- Zero banned words from `02-voice-and-tone.md`.
+- The title must be true: the clip has to deliver it.
+
+## Shapes
+
+| Shape | Pattern | Example for this show |
+|-------|---------|-----------------------|
+| Claim | [Strong statement the clip defends] | [fill after first episodes] |
+| Question | [The question the clip answers] | [example] |
+| Number | [Specific stat or count as the hook] | [example] |
+| Contrast | [Expectation vs what actually happened] | [example] |
+| Quote | [The most striking line, verbatim] | [example] |
+
+## Show-specific patterns
+
+Patterns that have worked (move proven ones here from `13-learnings.md`):
+
+- [pattern + example]
+
+## Never
+
+- [e.g. clickbait that the clip does not pay off]
+- [e.g. titles that need the guest's name to make sense, unless the guest is the draw]

--- a/backend/templates/knowledge/06-descriptions-template.md
+++ b/backend/templates/knowledge/06-descriptions-template.md
@@ -1,0 +1,34 @@
+# Descriptions template
+
+## Shorts description formula
+
+1. First line: [restate or extend the hook, since only the first line shows before "more"]
+2. [One line of context or the payoff]
+3. Call to action: [e.g. "Full episode: [link]"]
+4. Hashtags: [3-5, most specific first]
+
+Example skeleton:
+
+```
+[Hook line]
+[Context or payoff line]
+Full episode: [link]
+#[niche] #[topic] #[show-name]
+```
+
+## Long-form description formula
+
+1. [2-3 sentence summary in the show's voice]
+2. Timestamps: [chapter list]
+3. Guest links: [socials, project]
+4. Standard footer: see `12-quick-reference.md`
+
+## Hashtag pools
+
+- Always: [#show-name, #core-niche]
+- Rotate by topic: [#topic-a, #topic-b, #topic-c]
+
+## SEO keywords
+
+Primary: [3-5 phrases people actually search]
+Secondary: [long-tail variants]

--- a/backend/templates/knowledge/07-thumbnail-guide.md
+++ b/backend/templates/knowledge/07-thumbnail-guide.md
@@ -1,0 +1,30 @@
+# Thumbnail guide
+
+## Brand kit
+
+- Colors: [primary hex], [accent hex], [text hex]
+- Font: [name, weight]
+- Logo placement: [corner / none]
+
+## Layouts
+
+### 16:9 (long-form)
+
+- [e.g. Host or guest face right third, text left two thirds]
+- Text: max [4] words per line, max [2] lines
+- [Expression guidance: real reaction frames over posed shots]
+
+### 9:16 (shorts)
+
+- [e.g. Text top quarter, face center, captions burn into lower third]
+- Text: max [3] words per line
+
+## Text rules
+
+- Never repeat the title verbatim: the thumbnail adds a second angle.
+- Zero banned words from `02-voice-and-tone.md`.
+- [Case and punctuation preference]
+
+## Reference thumbnails
+
+[Links or file paths to 3-5 thumbnails whose style this show imitates, with one line on why each works.]

--- a/backend/templates/knowledge/08-topics-themes.md
+++ b/backend/templates/knowledge/08-topics-themes.md
@@ -1,0 +1,24 @@
+# Topics and themes
+
+## Core topics
+
+The 3-6 subjects this show keeps returning to:
+
+| Topic | Why the audience cares | Example angle |
+|-------|------------------------|---------------|
+| [topic] | [the itch it scratches] | [a concrete episode or clip angle] |
+
+## Audience mapping
+
+| Audience segment | Topics they engage with | Content that reaches them |
+|------------------|-------------------------|---------------------------|
+| [segment] | [topics] | [shorts / long-form / both] |
+
+## Evergreen vs timely
+
+- Evergreen: [topics that work any week]
+- Timely: [topic types worth covering fast, and how fast]
+
+## Off-limits
+
+[Topics the show deliberately does not touch, and why.]

--- a/backend/templates/knowledge/09-content-workflow.md
+++ b/backend/templates/knowledge/09-content-workflow.md
@@ -1,0 +1,26 @@
+# Content workflow
+
+The end-to-end path from recording to published clips for this show.
+
+## Phases
+
+1. Plan: [who preps guest questions and when; use /plan-episode]
+2. Record: [setup notes: camera count, mic, where files land]
+3. Process: run /produce-shorts (or /process-transcript for moments only)
+4. Review: [who approves titles and clips before publishing]
+5. Publish: [platforms, days, times; use /publish-checklist]
+6. Retro: run /retro-episode after [7] days of data
+
+## Cadence
+
+- Episodes: [e.g. one per week, recorded Tuesdays]
+- Shorts per episode: [target count]
+- Publishing schedule: [e.g. shorts daily at 17:00 local]
+
+## Responsibilities
+
+| Step | Owner |
+|------|-------|
+| [editing] | [name / AI] |
+| [approval] | [name] |
+| [publishing] | [name / scheduled] |

--- a/backend/templates/knowledge/10-internal-processing.md
+++ b/backend/templates/knowledge/10-internal-processing.md
@@ -1,0 +1,26 @@
+# Internal processing
+
+Auto-execution rules for the AI when running pipelines for this show. These defaults apply when the user does not specify otherwise.
+
+## Defaults
+
+- Moments per episode: extract [8-15], surface the top [5]
+- Clip length: [25-55] seconds
+- Caption style: [branded]
+- Format: [9:16]
+- Titles per clip: [8] options, best first
+
+## Decisions the AI may make alone
+
+- [e.g. dropping a moment that fails the standalone test]
+- [e.g. trimming clip boundaries by up to 3 seconds for a cleaner cut]
+
+## Decisions that need a human
+
+- [e.g. publishing anything]
+- [e.g. clips involving sensitive topics: list them]
+- [e.g. changing a guest's meaning through editing]
+
+## When unsure
+
+[Default behavior: e.g. present both options with a recommendation instead of guessing.]

--- a/backend/templates/knowledge/11-inspiration-channels.md
+++ b/backend/templates/knowledge/11-inspiration-channels.md
@@ -1,0 +1,18 @@
+# Inspiration channels
+
+Channels and creators whose clips work, as reference material. Study structure, not content: hooks, pacing, caption style, thumbnail language.
+
+## Reference channels
+
+| Channel | Niche | What to steal (structurally) |
+|---------|-------|------------------------------|
+| [name + link] | [niche] | [e.g. cold-open question hooks, 40s average length] |
+
+## Hook patterns observed
+
+- [e.g. starts mid-sentence at the emotional peak, context comes second]
+- [pattern + which channel does it well]
+
+## What not to copy
+
+- [e.g. their all-caps thumbnail style clashes with our brand]

--- a/backend/templates/knowledge/12-quick-reference.md
+++ b/backend/templates/knowledge/12-quick-reference.md
@@ -1,0 +1,27 @@
+# Quick reference
+
+Copy-paste resources used across episodes. Keep this current: everything here gets pasted verbatim.
+
+## Links
+
+- Show: [main channel URL]
+- All platforms: [YouTube / Spotify / Apple / TikTok / Instagram]
+- Website or newsletter: [URL]
+
+## Standard description footer
+
+```
+[Subscribe line]
+[Platform links block]
+[Contact or sponsor line]
+```
+
+## Boilerplate
+
+- Guest intro line: "[template with [guest] placeholder]"
+- Sponsor disclosure: "[exact required wording]"
+
+## Hashtag sets
+
+- Default: [#a #b #c]
+- [Topic]: [#x #y #z]

--- a/backend/templates/knowledge/13-learnings.md
+++ b/backend/templates/knowledge/13-learnings.md
@@ -1,0 +1,19 @@
+# Learnings
+
+Cross-episode performance patterns. /retro-episode appends here; move proven patterns into the guide files (titles into `05`, moments into `04`) once they repeat.
+
+## Confirmed patterns
+
+| Date | Pattern | Evidence |
+|------|---------|----------|
+| [date] | [what worked] | [clip + metric] |
+
+## Disproven assumptions
+
+| Date | What we believed | What the data showed |
+|------|------------------|----------------------|
+
+## Open experiments
+
+| Started | Hypothesis | How we will know |
+|---------|------------|------------------|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Copy `.env.example` to `.env`, or export these in your shell. `setup.sh` copies 
 | `PODCLI_QUALITY` | `high` | Render quality profile |
 | `PODCLI_NO_UPDATE` | unset | Set to `1` to skip the update check. Same as `podcli config set update.auto off` |
 | `PODCLI_LOG_LEVEL` | `info` | Logging verbosity |
-| `PODCLI_PORT` | `3847` | Web studio port. `PORT` also works |
+| `PODCLI_PORT` | `3847` | Web studio port. `PORT` also works. Set it in the MCP client's env too, or the MCP tools render without live studio progress |
 | `HF_TOKEN` | unset | Hugging Face token, required for speaker diarization |
 | `PODCLI_ENV_FILE` | `./.env` | Path to an alternate `.env` |
 | `PODCLI_BACKEND` | resolved | Override the Python backend directory |

--- a/src/config/server.test.ts
+++ b/src/config/server.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { resolveWebServerPort } from "./server.js";
+
+describe("resolveWebServerPort", () => {
+  it("defaults to 3847", () => {
+    expect(resolveWebServerPort({})).toBe(3847);
+  });
+
+  it("reads PODCLI_PORT first", () => {
+    expect(resolveWebServerPort({ PODCLI_PORT: "4000", PORT: "5000" })).toBe(4000);
+  });
+
+  it("falls back to PORT", () => {
+    expect(resolveWebServerPort({ PORT: "5000" })).toBe(5000);
+  });
+
+  it("rejects garbage and out-of-range values", () => {
+    expect(resolveWebServerPort({ PORT: "banana" })).toBe(3847);
+    expect(resolveWebServerPort({ PORT: "0" })).toBe(3847);
+    expect(resolveWebServerPort({ PORT: "70000" })).toBe(3847);
+    expect(resolveWebServerPort({ PORT: "-1" })).toBe(3847);
+  });
+});

--- a/src/config/server.ts
+++ b/src/config/server.ts
@@ -1,0 +1,8 @@
+export function resolveWebServerPort(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.PODCLI_PORT || env.PORT;
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535 ? parsed : 3847;
+}
+
+export const webServerPort = resolveWebServerPort();
+export const webServerUrl = `http://localhost:${webServerPort}`;

--- a/src/handlers/batch-clips.handler.ts
+++ b/src/handlers/batch-clips.handler.ts
@@ -3,6 +3,8 @@ import { PythonExecutor } from "../services/python-executor.js";
 import { FileManager } from "../services/file-manager.js";
 import { ClipsHistory } from "../services/clips-history.js";
 import { paths } from "../config/paths.js";
+import { webServerUrl } from "../config/server.js";
+import { validateClipRange } from "../utils/clip-validation.js";
 import { childLogger } from "../utils/logger.js";
 import type {
   BatchClipsInput,
@@ -34,6 +36,8 @@ export const batchClipsToolDef = {
     "EASIEST: pass export_selected=true to export all selected clips in one go.\n" +
     "Alternative: pass clip_numbers=[1, 3, 5] for specific ones.\n" +
     "Everything (video, timestamps, settings) auto-loads from session state.\n\n" +
+    "Pass exactly one of clips, clip_numbers, or export_selected. If several are given, " +
+    "an explicit clips array wins, then export_selected, then clip_numbers.\n\n" +
     "Each clip gets: 9:16 vertical crop, burned-in captions, normalized audio, H.264 MP4.",
   inputSchema: {
     type: "object" as const,
@@ -149,13 +153,16 @@ export async function handleBatchClips(input: BatchClipsInput): Promise<string> 
   let clips: BatchClipSpec[];
   const deselected = state?.deselectedIndices ?? [];
 
+  const batchFormat = input.format || settings.format || "vertical";
+  const cleanFillers = input.clean_fillers ?? settings.cleanFillers ?? true;
+
   const buildClipFromSuggestion = (s: SuggestedClip, num: number): BatchClipSpec => ({
     start_second: s.start_second,
     end_second: s.end_second,
     title: s.title || `clip_${num}`,
     caption_style: s.suggested_caption_style || settings.captionStyle || "hormozi",
     crop_strategy: settings.cropStrategy || "speaker",
-    format: input.format || settings.format || "vertical",
+    format: batchFormat,
     allow_ass_fallback: input.allow_ass_fallback === true,
     keep_caption_overlay: input.keep_caption_overlay === true,
     logo_path: settings.logoPath || null,
@@ -205,19 +212,31 @@ export async function handleBatchClips(input: BatchClipsInput): Promise<string> 
     clips = clips.map((c) => ({ ...c, keep_caption_overlay: c.keep_caption_overlay ?? true }));
   }
 
+  for (let i = 0; i < clips.length; i++) {
+    const rangeError = validateClipRange(
+      clips[i].start_second,
+      clips[i].end_second,
+      clips[i].format || batchFormat,
+    );
+    if (rangeError) {
+      return JSON.stringify({ error: `Clip ${i + 1}: ${rangeError}` });
+    }
+  }
+
   // Async path — route through Web UI so caller can poll job_status for
   // live progress during a multi-minute render. Falls back to sync if the
   // UI isn't running.
   if (input.async_mode) {
     try {
-      const res = await fetch("http://localhost:3847/api/batch-clips", {
+      const res = await fetch(`${webServerUrl}/api/batch-clips`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           video_path: videoPath,
           clips,
+          format: batchFormat,
           transcript_words: transcriptWords,
-          clean_fillers: input.clean_fillers !== false,
+          clean_fillers: cleanFillers,
           logo_path: settings.logoPath || null,
           outro_path: settings.outroPath || null,
           intro_path: settings.introPath || null,
@@ -246,8 +265,9 @@ export async function handleBatchClips(input: BatchClipsInput): Promise<string> 
   const result = await executor.execute<BatchClipsResult>("batch_clips", {
     video_path: videoPath,
     clips,
+    format: batchFormat,
     transcript_words: transcriptWords,
-    clean_fillers: input.clean_fillers !== false,
+    clean_fillers: cleanFillers,
     allow_ass_fallback: input.allow_ass_fallback === true,
     keep_caption_overlay: input.keep_caption_overlay === true,
     output_dir: paths.output,
@@ -266,7 +286,7 @@ export async function handleBatchClips(input: BatchClipsInput): Promise<string> 
     transcriptWords: transcriptWords,
     defaultCaptionStyle: settings.captionStyle || "hormozi",
     defaultCropStrategy: settings.cropStrategy || "speaker",
-    defaultFormat: input.format || settings.format || "vertical",
+    defaultFormat: batchFormat,
   });
   await history.persistBatchRecipes(data.results, recorded, {
     transcriptWords: transcriptWords,
@@ -274,7 +294,7 @@ export async function handleBatchClips(input: BatchClipsInput): Promise<string> 
     logoPath: settings.logoPath || null,
     outroPath: settings.outroPath || null,
     introPath: settings.introPath || null,
-    cleanFillers: input.clean_fillers !== false,
+    cleanFillers,
   });
 
   return JSON.stringify({

--- a/src/handlers/create-clip.handler.ts
+++ b/src/handlers/create-clip.handler.ts
@@ -5,6 +5,7 @@ import { paths } from "../config/paths.js";
 import type { ClipResult, CreateClipInput, SuggestedClip, UIState } from "../models/index.js";
 import { childLogger } from "../utils/logger.js";
 import { sliceTranscript } from "../utils/transcript.js";
+import { validateClipRange } from "../utils/clip-validation.js";
 
 const log = childLogger("create-clip");
 const executor = new PythonExecutor();
@@ -176,6 +177,10 @@ export async function handleCreateClip(input: CreateClipInput): Promise<string> 
       error: "start_second and end_second are required (use clip_number to reference a suggestion)",
     });
   }
+  const rangeError = validateClipRange(startSecond, endSecond, format);
+  if (rangeError) {
+    return JSON.stringify({ error: rangeError });
+  }
 
   const result = await executor.execute<ClipResult>("create_clip", {
     video_path: videoPath,
@@ -187,7 +192,7 @@ export async function handleCreateClip(input: CreateClipInput): Promise<string> 
     transcript_words: transcriptWords,
     title,
     output_dir: paths.output,
-    clean_fillers: input.clean_fillers !== false,
+    clean_fillers: input.clean_fillers ?? settings.cleanFillers ?? true,
     allow_ass_fallback: input.allow_ass_fallback === true,
     keep_caption_overlay: input.keep_caption_overlay === true,
     logo_path: logoPath,

--- a/src/handlers/suggest-clips.handler.ts
+++ b/src/handlers/suggest-clips.handler.ts
@@ -6,6 +6,7 @@
  */
 
 import { randomUUID } from "crypto";
+import { validateSuggestionRange } from "../utils/clip-validation.js";
 
 export const suggestClipsToolDef = {
   name: "suggest_clips",
@@ -101,6 +102,14 @@ export interface SuggestClipsInput {
 
 export async function handleSuggestClips(input: SuggestClipsInput): Promise<string> {
   const suggestions = input.suggestions;
+
+  for (let i = 0; i < suggestions.length; i++) {
+    const s = suggestions[i];
+    const rangeError = validateSuggestionRange(s.start_second, s.end_second);
+    if (rangeError) {
+      throw new Error(`Suggestion ${i + 1} ("${s.title}"): ${rangeError}`);
+    }
+  }
 
   // Validate and enrich suggestions
   const enriched = suggestions.map((s, i) => {

--- a/src/handlers/transcribe.handler.ts
+++ b/src/handlers/transcribe.handler.ts
@@ -1,6 +1,7 @@
 import { basename } from "path";
 import { PythonExecutor } from "../services/python-executor.js";
 import { TranscriptCache } from "../services/transcript-cache.js";
+import { webServerUrl } from "../config/server.js";
 import type { TranscriptResult } from "../models/index.js";
 
 const executor = new PythonExecutor();
@@ -19,7 +20,8 @@ export const transcribeToolDef = {
   name: "transcribe_podcast",
   description:
     "STEP 1 — Transcribe a podcast video/audio file. This is typically the first tool you call.\n\n" +
-    "What it does: Uses Whisper AI for word-level timestamps + pyannote for speaker detection (who said what).\n" +
+    "What it does: Uses Whisper AI for word-level timestamps. Speaker detection (who said what) is off by " +
+    "default; pass enable_diarization=true to add speaker labels where torch/pyannote is available (whisper-py engine).\n" +
     "Returns: Lightweight metadata only — duration, language, word/segment counts, speaker summary, and " +
     "packed_ready flag. The actual transcript body is NOT returned here (it would be 500KB+ for a typical " +
     "episode). Read the content via get_ui_state(include_transcript: true) which returns a compact " +
@@ -54,8 +56,9 @@ export const transcribeToolDef = {
       enable_diarization: {
         type: "boolean",
         description:
-          "Enable speaker detection (who is speaking). Requires pyannote.audio. Default: true",
-        default: true,
+          "Set true for speaker labels (who is speaking). Works where torch/pyannote.audio is available " +
+          "(whisper-py engine); slower. Default: false",
+        default: false,
       },
       num_speakers: {
         type: "number",
@@ -73,7 +76,7 @@ export async function handleTranscribe(input: TranscribeInput): Promise<string> 
   const modelSize = input.model_size ?? "base";
   const engine = input.engine;
   const language = input.language;
-  const enableDiarization = input.enable_diarization !== false; // default true
+  const enableDiarization = input.enable_diarization === true;
   const numSpeakers = input.num_speakers;
 
   // Check cache first
@@ -150,7 +153,7 @@ export const transcribeStartToolDef = {
     "Use this instead of transcribe_podcast for long files so you can narrate progress " +
     "to the user while it runs (a 60-min episode takes 15–25 min).\n\n" +
     "Flow: call transcribe_start(file_path) → emit status text to user → " +
-    "call transcribe_status(job_id, wait_seconds: 30) in a loop until done → " +
+    "call job_status(job_id, wait_seconds: 30) in a loop until done → " +
     "then read the packed transcript via get_ui_state(include_transcript: true).\n\n" +
     "Requires the Web UI to be running (npm run ui). Returns { job_id, cached, status, estimate_minutes }.",
   inputSchema: {
@@ -167,7 +170,7 @@ export const transcribeStartToolDef = {
         type: "string",
         enum: ["whisper-py", "whispercpp", "assemblyai"],
       },
-      enable_diarization: { type: "boolean", default: true },
+      enable_diarization: { type: "boolean", default: false },
       num_speakers: { type: "number" },
     },
     required: ["file_path"],
@@ -176,7 +179,7 @@ export const transcribeStartToolDef = {
 
 export async function handleTranscribeStart(input: TranscribeInput): Promise<string> {
   try {
-    const res = await fetch("http://localhost:3847/api/transcribe", {
+    const res = await fetch(`${webServerUrl}/api/transcribe`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -184,7 +187,7 @@ export async function handleTranscribeStart(input: TranscribeInput): Promise<str
         model_size: input.model_size ?? "base",
         engine: input.engine,
         language: input.language,
-        enable_diarization: input.enable_diarization !== false,
+        enable_diarization: input.enable_diarization === true,
         num_speakers: input.num_speakers,
       }),
     });
@@ -259,7 +262,7 @@ export async function handleJobStatus(input: {
 
   try {
     while (true) {
-      const res = await fetch(`http://localhost:3847/api/job/${input.job_id}`);
+      const res = await fetch(`${webServerUrl}/api/job/${input.job_id}`);
       if (res.status === 404) {
         return JSON.stringify({ error: `Job ${input.job_id} not found` });
       }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -123,6 +123,7 @@ export interface UIState {
     logoPath?: string;
     outroPath?: string;
     introPath?: string;
+    cleanFillers?: boolean;
   };
   phase?: string;
   lastUpdated?: number;
@@ -187,6 +188,9 @@ export interface BatchClipsResult {
     output_path?: string;
     start_second?: number;
     end_second?: number;
+    /** Bounds of the clip as submitted; the renderer may trim start_second. */
+    source_start_second?: number;
+    source_end_second?: number;
     caption_style?: string;
     crop_strategy?: string;
     format?: Format;

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,20 @@ const log = childLogger("server");
  */
 const transcriptCache = new TranscriptCache();
 
+/**
+ * Only a studio that isn't listening may be retried inline. A render that
+ * started and then failed, timed out, or went missing must surface — retrying it
+ * would render the same clips twice.
+ */
+function studioUnreachable(err: unknown, label: string): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (!msg.includes("ECONNREFUSED") && !msg.includes("fetch failed")) return false;
+  log.warn(
+    `Studio not reachable at ${webServerUrl}. Running ${label} inline without live progress. If the studio listens on another port, set PODCLI_PORT for this MCP server too.`,
+  );
+  return true;
+}
+
 async function uiPing(body: Record<string, unknown>): Promise<void> {
   try {
     await fetch(`${webServerUrl}/api/ui-state`, {
@@ -679,14 +693,7 @@ export function createServer(): McpServer {
             }
           }
         } catch (webErr: unknown) {
-          const webMsg =
-            webErr instanceof Error ? webErr.message : String(webErr);
-          if (
-            !webMsg.includes("ECONNREFUSED") &&
-            !webMsg.includes("fetch failed")
-          ) {
-            // Unexpected error — still try direct fallback
-          }
+          if (!studioUnreachable(webErr, "create_clip")) throw webErr;
         }
 
         if (!usedWebServer) {
@@ -948,14 +955,7 @@ export function createServer(): McpServer {
             }
           }
         } catch (webErr: unknown) {
-          const webMsg =
-            webErr instanceof Error ? webErr.message : String(webErr);
-          if (
-            !webMsg.includes("ECONNREFUSED") &&
-            !webMsg.includes("fetch failed")
-          ) {
-            // Unexpected error — still try fallback
-          }
+          if (!studioUnreachable(webErr, "batch_create_clips")) throw webErr;
         }
 
         if (!usedWebServer) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,10 +29,11 @@ import { AssetManager, inferType } from "./services/asset-manager.js";
 import { ClipsHistory } from "./services/clips-history.js";
 import { TranscriptCache } from "./services/transcript-cache.js";
 import { paths } from "./config/paths.js";
+import { webServerUrl } from "./config/server.js";
 import { childLogger } from "./utils/logger.js";
 import { mcpError } from "./utils/errors.js";
 import { podcliVersion } from "./version.js";
-import type { BatchClipsResult, Format, UIState, WordTimestamp } from "./models/index.js";
+import type { Format, SuggestedClip, UIState, WordTimestamp } from "./models/index.js";
 
 const log = childLogger("server");
 
@@ -44,7 +45,7 @@ const transcriptCache = new TranscriptCache();
 
 async function uiPing(body: Record<string, unknown>): Promise<void> {
   try {
-    await fetch("http://localhost:3847/api/ui-state", {
+    await fetch(`${webServerUrl}/api/ui-state`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -75,6 +76,19 @@ async function withKnowledge(result: string): Promise<string> {
 /** Append a workflow next-step hint to a tool result. */
 function withNextStep(result: string, nextStep: string): string {
   return `${result}\n\n---\n[Next Step] ${nextStep}`;
+}
+
+// Fallback transcript views (no packed markdown available) can be 500KB+ for a
+// long episode; cap what goes into a tool response.
+const TRANSCRIPT_FALLBACK_CAP = 50_000;
+
+function capTranscriptText(text: string): string {
+  if (text.length <= TRANSCRIPT_FALLBACK_CAP) return text;
+  return (
+    text.slice(0, TRANSCRIPT_FALLBACK_CAP) +
+    `\n\n[Transcript truncated: showing the first ${TRANSCRIPT_FALLBACK_CAP} of ${text.length} characters. ` +
+    "Use parse_transcript or transcribe_podcast to generate the packed view for full coverage.]"
+  );
 }
 
 /**
@@ -138,7 +152,7 @@ interface ImportTranscriptResult extends ApiError {
 
 async function readUIState(): Promise<ServerUIState | null> {
   try {
-    const res = await fetch("http://localhost:3847/api/ui-state");
+    const res = await fetch(`${webServerUrl}/api/ui-state`);
     if (!res.ok) return null;
     return (await res.json()) as ServerUIState;
   } catch (err) {
@@ -249,8 +263,10 @@ export function createServer(): McpServer {
       enable_diarization: z
         .boolean()
         .optional()
-        .default(true)
-        .describe("Enable speaker detection (who is speaking). Default: true"),
+        .default(false)
+        .describe(
+          "Set true for speaker labels (who is speaking). Works where torch is available (whisper-py engine); slower. Default: false",
+        ),
       num_speakers: z
         .number()
         .optional()
@@ -321,7 +337,7 @@ export function createServer(): McpServer {
         .default("base"),
       language: z.string().optional(),
       engine: z.enum(["whisper-py", "whispercpp", "assemblyai"]).optional(),
-      enable_diarization: z.boolean().optional().default(true),
+      enable_diarization: z.boolean().optional().default(false),
       num_speakers: z.number().optional(),
     },
     async (input) => {
@@ -481,6 +497,12 @@ export function createServer(): McpServer {
         .describe(
           "Allow ASS caption fallback if Remotion rendering fails (default: false)",
         ),
+      clean_fillers: z
+        .boolean()
+        .optional()
+        .describe(
+          "Remove filler words (um, uh, hmm) from captions and compress long silences. Defaults to the studio's clean filler words setting (on unless the user turned it off).",
+        ),
       transcript_words: z
         .array(
           z.object({
@@ -595,7 +617,7 @@ export function createServer(): McpServer {
         let usedWebServer = false;
         let finalResult = "";
         try {
-          const webRes = await fetch("http://localhost:3847/api/mcp/export", {
+          const webRes = await fetch(`${webServerUrl}/api/mcp/export`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
@@ -616,6 +638,9 @@ export function createServer(): McpServer {
               transcript_words: params.transcript_words,
               logo_path: params.logo_path || null,
               outro_path: params.outro_path || null,
+              ...(params.clean_fillers !== undefined && {
+                clean_fillers: params.clean_fillers,
+              }),
               keep_caption_overlay: params.keep_caption_overlay === true,
             }),
           });
@@ -625,12 +650,16 @@ export function createServer(): McpServer {
 
             // Poll the job until completion (1 hour max)
             const deadline = Date.now() + 3600_000;
+            let lostJob = false;
             while (Date.now() < deadline) {
               await new Promise((r) => setTimeout(r, 2000));
               const pollRes = await fetch(
-                `http://localhost:3847/api/job/${jobId}`,
+                `${webServerUrl}/api/job/${jobId}`,
               );
-              if (!pollRes.ok) break;
+              if (!pollRes.ok) {
+                lostJob = true;
+                break;
+              }
               const job = (await pollRes.json()) as WebJob;
               if (job.status === "done") {
                 usedWebServer = true;
@@ -642,7 +671,11 @@ export function createServer(): McpServer {
               }
             }
             if (!usedWebServer) {
-              throw new Error("Clip creation timed out after 1 hour");
+              throw new Error(
+                lostJob
+                  ? `Lost track of render job ${jobId}: the web server stopped reporting it (it may have restarted). Check list_outputs for results.`
+                  : "Clip creation timed out after 1 hour",
+              );
             }
           }
         } catch (webErr: unknown) {
@@ -686,7 +719,7 @@ export function createServer(): McpServer {
             logoPath: (params.logo_path as string) || recipeSettings.logoPath || null,
             outroPath: (params.outro_path as string) || recipeSettings.outroPath || null,
             introPath: recipeSettings.introPath || null,
-            cleanFillers: true,
+            cleanFillers: params.clean_fillers ?? recipeSettings.cleanFillers ?? true,
             keepSegments: keepSegments ?? undefined,
           });
 
@@ -745,6 +778,12 @@ export function createServer(): McpServer {
         .optional()
         .describe(
           "Keep ProRes 4444 alpha caption overlays for DaVinci Resolve export (batch-level default; per-clip overrides).",
+        ),
+      clean_fillers: z
+        .boolean()
+        .optional()
+        .describe(
+          "Remove filler words (um, uh, hmm) from captions and compress long silences. Defaults to the studio's clean filler words setting (on unless the user turned it off).",
         ),
       transcript_words: z
         .array(
@@ -843,13 +882,17 @@ export function createServer(): McpServer {
         let usedWebServer = false;
         let finalResult: string = "";
         try {
-          const webRes = await fetch("http://localhost:3847/api/mcp/export", {
+          const webRes = await fetch(`${webServerUrl}/api/mcp/export`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
               video_path: resolvedVideoPath,
               clips: resolvedClips,
               transcript_words: resolvedTranscriptWords,
+              ...(params.clean_fillers !== undefined && {
+                clean_fillers: params.clean_fillers,
+              }),
+              keep_caption_overlay: params.keep_caption_overlay === true,
             }),
           });
           if (webRes.ok) {
@@ -876,12 +919,16 @@ export function createServer(): McpServer {
 
             // Sync path — poll internally until completion (1 hour max)
             const deadline = Date.now() + 3600_000;
+            let lostJob = false;
             while (Date.now() < deadline) {
               await new Promise((r) => setTimeout(r, 2000));
               const pollRes = await fetch(
-                `http://localhost:3847/api/job/${jobId}`,
+                `${webServerUrl}/api/job/${jobId}`,
               );
-              if (!pollRes.ok) break;
+              if (!pollRes.ok) {
+                lostJob = true;
+                break;
+              }
               const job = (await pollRes.json()) as WebJob;
               if (job.status === "done") {
                 usedWebServer = true;
@@ -893,7 +940,11 @@ export function createServer(): McpServer {
               }
             }
             if (!usedWebServer) {
-              throw new Error("Batch clip creation timed out after 1 hour");
+              throw new Error(
+                lostJob
+                  ? `Lost track of batch job ${jobId}: the web server stopped reporting it (it may have restarted). Check list_outputs for partial results.`
+                  : "Batch clip creation timed out after 1 hour",
+              );
             }
           }
         } catch (webErr: unknown) {
@@ -910,32 +961,12 @@ export function createServer(): McpServer {
         if (!usedWebServer) {
           await uiPing({ phase: "exporting" });
 
-          const batchParams = {
+          // handleBatchClips records history + recipes itself.
+          finalResult = await handleBatchClips({
             ...params,
             video_path: resolvedVideoPath || params.video_path,
             clips: resolvedClips || params.clips,
             transcript_words: resolvedTranscriptWords || params.transcript_words,
-          };
-          finalResult = await handleBatchClips(batchParams);
-          const parsed = JSON.parse(finalResult) as BatchClipsResult;
-          const uiState = await readUIState().catch(() => null);
-          const settings = uiState?.settings ?? {};
-
-          const recorded = await history.recordBatchResults(parsed.results, {
-            sourceVideo: (batchParams.video_path as string) || "",
-            transcriptWords: batchParams.transcript_words as WordTimestamp[] | undefined,
-          });
-          await history.persistBatchRecipes(parsed.results, recorded, {
-            transcriptWords: batchParams.transcript_words as WordTimestamp[] | undefined,
-            clipSpecs: (batchParams.clips || []) as Array<{
-              start_second: number;
-              end_second: number;
-              keep_segments?: Array<{ start: number; end: number }>;
-            }>,
-            logoPath: settings.logoPath || null,
-            outroPath: settings.outroPath || null,
-            introPath: settings.introPath || null,
-            cleanFillers: true,
           });
 
           await uiPing({ phase: "done" });
@@ -1345,7 +1376,7 @@ export function createServer(): McpServer {
     },
     async ({ include_transcript }) => {
       try {
-        const res = await fetch("http://localhost:3847/api/ui-state");
+        const res = await fetch(`${webServerUrl}/api/ui-state`);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const state = (await res.json()) as ServerUIState;
 
@@ -1409,22 +1440,24 @@ export function createServer(): McpServer {
           } else if (state.transcript) {
             const segments = state.transcript.segments || [];
             if (segments.length) {
-              lines.push("");
-              lines.push("=== TRANSCRIPT ===");
+              const segLines: string[] = [];
               for (const seg of segments) {
                 const speaker = seg.speaker || "?";
                 const start = Math.floor(seg.start || 0);
                 const end = Math.floor(seg.end || 0);
                 const text = seg.text || "";
-                lines.push(`[${start}s-${end}s] ${speaker}: ${text}`);
+                segLines.push(`[${start}s-${end}s] ${speaker}: ${text}`);
               }
+              lines.push("");
+              lines.push("=== TRANSCRIPT ===");
+              lines.push(capTranscriptText(segLines.join("\n")));
             }
           } else if (state.rawTranscriptText) {
             lines.push("");
             lines.push(
               "=== RAW TRANSCRIPT (not yet parsed — use this to analyze and suggest clips) ===",
             );
-            lines.push(state.rawTranscriptText);
+            lines.push(capTranscriptText(state.rawTranscriptText));
           }
         }
 
@@ -1501,70 +1534,7 @@ export function createServer(): McpServer {
     },
     async ({ clip_number, clip_id, index, action, updates }) => {
       try {
-        // 1. Read current UI state
-        const res = await fetch("http://localhost:3847/api/ui-state");
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const state = (await res.json()) as ServerUIState;
-        const suggestions = state.suggestions ?? [];
-
-        if (!suggestions.length) {
-          return {
-            content: [
-              { type: "text" as const, text: "No suggestions in UI state." },
-            ],
-          };
-        }
-
-        // 2. Find target clip (clip_number is 1-based)
-        let targetIdx = -1;
-        if (clip_number !== undefined) {
-          targetIdx = clip_number - 1;
-        } else if (clip_id) {
-          targetIdx = suggestions.findIndex((s) => s.clip_id === clip_id);
-        } else if (index !== undefined) {
-          targetIdx = index;
-        }
-
-        if (targetIdx < 0 || targetIdx >= suggestions.length) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Clip not found. Use get_ui_state to see available clips.`,
-              },
-            ],
-          };
-        }
-
-        // --- DELETE ---
-        if (action === "delete") {
-          const removed = suggestions[targetIdx];
-          suggestions.splice(targetIdx, 1);
-          // Adjust deselectedIndices: remove the deleted index, shift higher ones down
-          const deselected: number[] = state.deselectedIndices || [];
-          const adjusted = deselected
-            .filter((i: number) => i !== targetIdx)
-            .map((i: number) => (i > targetIdx ? i - 1 : i));
-
-          await fetch("http://localhost:3847/api/ui-state", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ suggestions, deselectedIndices: adjusted }),
-          });
-
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Deleted clip #${targetIdx + 1}: "${removed.title}". ${suggestions.length} clips remaining.`,
-              },
-            ],
-          };
-        }
-
-        // --- UPDATE ---
-        const upd = updates || {};
-        if (Object.keys(upd).length === 0) {
+        if (action !== "delete" && Object.keys(updates || {}).length === 0) {
           return {
             content: [
               {
@@ -1574,38 +1544,54 @@ export function createServer(): McpServer {
             ],
           };
         }
-        const clip = suggestions[targetIdx];
-        if (upd.title !== undefined) clip.title = upd.title;
-        if (upd.start_second !== undefined)
-          clip.start_second = upd.start_second;
-        if (upd.end_second !== undefined) clip.end_second = upd.end_second;
-        if (upd.reasoning !== undefined) clip.reasoning = upd.reasoning;
-        if (upd.preview_text !== undefined)
-          clip.preview_text = upd.preview_text;
-        if (upd.suggested_caption_style !== undefined)
-          clip.suggested_caption_style = upd.suggested_caption_style;
 
-        // Recalculate derived fields
-        clip.duration =
-          Math.round((clip.end_second - clip.start_second) * 10) / 10;
-        const fmtTime = (s: number) =>
-          `${Math.floor(s / 60)}:${Math.floor(s % 60)
-            .toString()
-            .padStart(2, "0")}`;
-        clip.timestamp_display = `${fmtTime(clip.start_second)} → ${fmtTime(clip.end_second)}`;
+        // Mutate server-side so concurrent edits aren't lost to a wholesale
+        // state replace (clip_number is 1-based).
+        const body: Record<string, unknown> = { action, updates };
+        if (clip_number !== undefined) body.index = clip_number - 1;
+        else if (clip_id) body.clip_id = clip_id;
+        else if (index !== undefined) body.index = index;
 
-        suggestions[targetIdx] = clip;
-        await fetch("http://localhost:3847/api/ui-state", {
+        const res = await fetch(`${webServerUrl}/api/suggestions/modify`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ suggestions }),
+          body: JSON.stringify(body),
         });
+        const data = (await res.json()) as ApiError & {
+          index: number;
+          clip: SuggestedClip;
+          total: number;
+        };
+        if (!res.ok || data.error) {
+          if (res.status === 404) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: "Clip not found. Use get_ui_state to see available clips.",
+                },
+              ],
+            };
+          }
+          throw new Error(data.error || `HTTP ${res.status}`);
+        }
+
+        if (action === "delete") {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Deleted clip #${data.index + 1}: "${data.clip.title}". ${data.total} clips remaining.`,
+              },
+            ],
+          };
+        }
 
         return {
           content: [
             {
               type: "text" as const,
-              text: `Updated clip #${targetIdx + 1}: "${clip.title}" (${clip.start_second}s–${clip.end_second}s, ${clip.duration}s)`,
+              text: `Updated clip #${data.index + 1}: "${data.clip.title}" (${data.clip.start_second}s–${data.clip.end_second}s, ${data.clip.duration}s)`,
             },
           ],
         };
@@ -1652,54 +1638,43 @@ export function createServer(): McpServer {
     },
     async ({ clip_number, clip_id, index, selected }) => {
       try {
-        const res = await fetch("http://localhost:3847/api/ui-state");
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const state = (await res.json()) as ServerUIState;
-        const suggestions = state.suggestions ?? [];
-        const deselected: number[] = state.deselectedIndices ?? [];
+        // Mutate server-side so concurrent edits aren't lost to a wholesale
+        // state replace (clip_number is 1-based).
+        const body: Record<string, unknown> = { action: "toggle", selected };
+        if (clip_number !== undefined) body.index = clip_number - 1;
+        else if (clip_id) body.clip_id = clip_id;
+        else if (index !== undefined) body.index = index;
 
-        // Find target index (clip_number is 1-based)
-        let targetIdx = -1;
-        if (clip_number !== undefined) {
-          targetIdx = clip_number - 1;
-        } else if (clip_id) {
-          targetIdx = suggestions.findIndex((s) => s.clip_id === clip_id);
-        } else if (index !== undefined) {
-          targetIdx = index;
-        }
-
-        if (targetIdx < 0 || targetIdx >= suggestions.length) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: "Clip not found. Use get_ui_state to see available clips.",
-              },
-            ],
-          };
-        }
-
-        let updated: number[];
-        if (selected) {
-          updated = deselected.filter((i: number) => i !== targetIdx);
-        } else {
-          updated = deselected.includes(targetIdx)
-            ? deselected
-            : [...deselected, targetIdx];
-        }
-
-        await fetch("http://localhost:3847/api/ui-state", {
+        const res = await fetch(`${webServerUrl}/api/suggestions/modify`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ deselectedIndices: updated }),
+          body: JSON.stringify(body),
         });
+        const data = (await res.json()) as ApiError & {
+          index: number;
+          clip: SuggestedClip;
+          total: number;
+          selectedCount: number;
+        };
+        if (!res.ok || data.error) {
+          if (res.status === 404) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: "Clip not found. Use get_ui_state to see available clips.",
+                },
+              ],
+            };
+          }
+          throw new Error(data.error || `HTTP ${res.status}`);
+        }
 
-        const clip = suggestions[targetIdx];
         return {
           content: [
             {
               type: "text" as const,
-              text: `Clip #${targetIdx + 1} "${clip.title}" is now ${selected ? "selected" : "deselected"}. (${suggestions.length - updated.length}/${suggestions.length} selected)`,
+              text: `Clip #${data.index + 1} "${data.clip.title}" is now ${selected ? "selected" : "deselected"}. (${data.selectedCount}/${data.total} selected)`,
             },
           ],
         };
@@ -1780,7 +1755,7 @@ export function createServer(): McpServer {
           };
         }
 
-        await fetch("http://localhost:3847/api/ui-state", {
+        await fetch(`${webServerUrl}/api/ui-state`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ settings }),
@@ -1824,7 +1799,7 @@ export function createServer(): McpServer {
     {},
     async () => {
       try {
-        const res = await fetch("http://localhost:3847/api/outputs");
+        const res = await fetch(`${webServerUrl}/api/outputs`);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const clips = (await res.json()) as OutputClip[];
 
@@ -1909,7 +1884,7 @@ export function createServer(): McpServer {
           };
         }
 
-        const res = await fetch("http://localhost:3847/api/presets", {
+        const res = await fetch(`${webServerUrl}/api/presets`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ action, name, config }),
@@ -1951,7 +1926,7 @@ export function createServer(): McpServer {
           if (data.config.outro_path)
             settings.outroPath = data.config.outro_path;
           if (Object.keys(settings).length) {
-            await fetch("http://localhost:3847/api/ui-state", {
+            await fetch(`${webServerUrl}/api/ui-state`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ settings }),
@@ -2021,7 +1996,7 @@ export function createServer(): McpServer {
         if ((action === "export" || action === "import") && !filePath) {
           return mcpError(`'path' is required for action '${action}'.`);
         }
-        const base = "http://localhost:3847/api/thumbnail-config";
+        const base = `${webServerUrl}/api/thumbnail-config`;
         if (action === "show") {
           const res = await fetch(base);
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -2082,7 +2057,7 @@ export function createServer(): McpServer {
 
         // If no video_path, read from UI state
         if (!vPath || !segs) {
-          const stateRes = await fetch("http://localhost:3847/api/ui-state");
+          const stateRes = await fetch(`${webServerUrl}/api/ui-state`);
           if (stateRes.ok) {
             const state = (await stateRes.json()) as ServerUIState;
             if (!vPath) vPath = state.videoPath || state.filePath;
@@ -2118,7 +2093,7 @@ export function createServer(): McpServer {
           };
         }
 
-        const res = await fetch("http://localhost:3847/api/analyze-energy", {
+        const res = await fetch(`${webServerUrl}/api/analyze-energy`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ video_path: vPath, segments: segs }),
@@ -2222,7 +2197,7 @@ export function createServer(): McpServer {
     },
     async (params) => {
       try {
-        const res = await fetch("http://localhost:3847/api/reel", {
+        const res = await fetch(`${webServerUrl}/api/reel`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(params),
@@ -2273,7 +2248,7 @@ export function createServer(): McpServer {
     async ({ file_path }) => {
       try {
         // Validate via select-file endpoint
-        const selectRes = await fetch("http://localhost:3847/api/select-file", {
+        const selectRes = await fetch(`${webServerUrl}/api/select-file`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ file_path }),
@@ -2293,7 +2268,7 @@ export function createServer(): McpServer {
         const fileInfo = (await selectRes.json()) as FileInfo;
 
         // Push to UI state
-        await fetch("http://localhost:3847/api/ui-state", {
+        await fetch(`${webServerUrl}/api/ui-state`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ videoPath: file_path, filePath: file_path }),
@@ -2366,7 +2341,7 @@ export function createServer(): McpServer {
     },
     async ({ file_path, transcript }) => {
       try {
-        const res = await fetch("http://localhost:3847/api/import-transcript", {
+        const res = await fetch(`${webServerUrl}/api/import-transcript`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ file_path, transcript }),
@@ -2386,7 +2361,7 @@ export function createServer(): McpServer {
         const result = (await res.json()) as ImportTranscriptResult;
 
         // Push transcript to UI state
-        await fetch("http://localhost:3847/api/ui-state", {
+        await fetch(`${webServerUrl}/api/ui-state`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -2449,7 +2424,7 @@ export function createServer(): McpServer {
     },
     async ({ file_path, raw_text, total_duration, time_adjust }) => {
       try {
-        const res = await fetch("http://localhost:3847/api/parse-transcript", {
+        const res = await fetch(`${webServerUrl}/api/parse-transcript`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -2474,7 +2449,7 @@ export function createServer(): McpServer {
         const result = (await res.json()) as ImportTranscriptResult;
 
         // Push parsed transcript to UI state
-        await fetch("http://localhost:3847/api/ui-state", {
+        await fetch(`${webServerUrl}/api/ui-state`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -2575,7 +2550,7 @@ export function createServer(): McpServer {
               "- Use modify_clip to adjust timing before export",
               "- Use toggle_clip to select/deselect clips",
               "- Use update_settings to change the default caption style or crop strategy",
-              "- The user can review and adjust clips in the Web UI at http://localhost:3847",
+              `- The user can review and adjust clips in the Web UI at ${webServerUrl}`,
             ].join("\n"),
           },
         },

--- a/src/services/clips-history.ts
+++ b/src/services/clips-history.ts
@@ -1,8 +1,9 @@
-import { readFile, writeFile, mkdir, rm, rename } from "fs/promises";
+import { readFile, writeFile, mkdir, rm } from "fs/promises";
 import { existsSync } from "fs";
 import { basename, join } from "path";
 import { v4 as uuidv4 } from "uuid";
 import { paths } from "../config/paths.js";
+import { writeFileAtomic } from "../utils/atomic-file.js";
 import { sliceTranscript, sliceWords } from "../utils/transcript.js";
 import { isDemoMode, demoClips } from "../ui/demo-fixtures.js";
 import type { BatchClipsResult, ClipHistoryEntry, Format, WordTimestamp } from "../models/index.js";
@@ -60,16 +61,7 @@ export class ClipsHistory {
   private async save(entries: ClipHistoryEntry[]): Promise<void> {
     if (isDemoMode()) return; // demo fixtures are read-only; never persist to clips.json
     await this.ensureDir();
-    // Write to a temp file and atomically rename so a crash or a concurrent
-    // reader never sees a half-written clips.json.
-    const tmp = `${this.historyPath}.${process.pid}.${uuidv4().slice(0, 8)}.tmp`;
-    try {
-      await writeFile(tmp, JSON.stringify(entries, null, 2), "utf-8");
-      await rename(tmp, this.historyPath);
-    } catch (err) {
-      await rm(tmp, { force: true }).catch(() => {});
-      throw err;
-    }
+    await writeFileAtomic(this.historyPath, JSON.stringify(entries, null, 2));
   }
 
   // Run load → mutate → save as one critical section, queued behind any

--- a/src/services/knowledge-base.test.ts
+++ b/src/services/knowledge-base.test.ts
@@ -7,7 +7,7 @@ const tmp = mkdtempSync(join(tmpdir(), "podcli-kb-test-"));
 process.env.PODCLI_HOME = tmp;
 process.env.PODCLI_DATA = tmp;
 
-const { KnowledgeBase } = await import("./knowledge-base.js");
+const { KnowledgeBase, isFilledIn } = await import("./knowledge-base.js");
 
 describe("KnowledgeBase", () => {
   let kb: InstanceType<typeof KnowledgeBase>;
@@ -18,11 +18,49 @@ describe("KnowledgeBase", () => {
     kb = new KnowledgeBase();
   });
 
-  it("ensureDir creates the directory and seeds a README", async () => {
+  it("ensureDir creates an empty directory", async () => {
     rmSync(join(tmp, "knowledge"), { recursive: true, force: true });
     await kb.ensureDir();
-    expect(existsSync(join(tmp, "knowledge", "README.md"))).toBe(true);
-    expect(readFileSync(join(tmp, "knowledge", "README.md"), "utf-8")).toMatch(/Knowledge Base/);
+    expect(existsSync(join(tmp, "knowledge"))).toBe(true);
+    expect(await kb.listFiles()).toEqual([]);
+  });
+
+  it("initFromTemplates copies the numbered templates and keeps existing files", async () => {
+    const first = await kb.initFromTemplates();
+    expect(first.created).toContain("01-brand-identity.md");
+    expect(first.created).toContain("02-voice-and-tone.md");
+    expect(first.kept).toEqual([]);
+    expect(readFileSync(join(tmp, "knowledge", "01-brand-identity.md"), "utf-8")).toContain("[Show name]");
+
+    await kb.writeFile("01-brand-identity.md", "# Brand identity\nMine, edited");
+    const second = await kb.initFromTemplates();
+    expect(second.created).toEqual([]);
+    expect(second.kept).toEqual(first.created);
+    expect(readFileSync(join(tmp, "knowledge", "01-brand-identity.md"), "utf-8")).toContain("Mine, edited");
+  });
+
+  it("status reports which templates are present and which are filled in", async () => {
+    const empty = await kb.status();
+    expect(empty.templates.length).toBeGreaterThan(0);
+    expect(empty.present).toEqual([]);
+    expect(empty.missing).toEqual(empty.templates);
+
+    await kb.initFromTemplates();
+    const untouched = await kb.status();
+    expect(untouched.present).toEqual(untouched.templates);
+    expect(untouched.filled).toEqual([]);
+
+    await kb.writeFile("01-brand-identity.md", "# Brand identity\n\n- Name: Deep Dive\n- Audience: founders");
+    const edited = await kb.status();
+    expect(edited.filled).toEqual(["01-brand-identity.md"]);
+  });
+
+  it("isFilledIn treats a mostly-bracketed file as a template", () => {
+    const template = "# Voice\n\n- Tone: [tone]\n- Banned: [words]\n- Hook: [hook]\n- Close: [close]";
+    expect(isFilledIn(template, template)).toBe(false);
+    expect(isFilledIn("# Voice\n\n- Tone: [tone]\n- Banned: hype\n- Hook: [hook]\n- Close: [close]", template)).toBe(false);
+    expect(isFilledIn("# Voice\n\n- Tone: blunt\n- Banned: hype\n- Hook: cold open\n- Close: hard cut", template)).toBe(true);
+    expect(isFilledIn("", template)).toBe(false);
   });
 
   it("writeFile auto-appends .md extension if missing", async () => {
@@ -60,8 +98,7 @@ describe("KnowledgeBase", () => {
   });
 
   it("readAll concatenates all files except README", async () => {
-    // ensureDir seeds README
-    await kb.ensureDir();
+    await kb.writeFile("README.md", "# ignore me");
     await kb.writeFile("one.md", "first");
     await kb.writeFile("two.md", "second");
     const all = await kb.readAll();
@@ -72,7 +109,7 @@ describe("KnowledgeBase", () => {
     expect(all).not.toContain("README");
   });
 
-  it("readAll returns empty string when only README exists", async () => {
+  it("readAll returns empty string when the directory is empty", async () => {
     await kb.ensureDir();
     expect(await kb.readAll()).toBe("");
   });

--- a/src/services/knowledge-base.ts
+++ b/src/services/knowledge-base.ts
@@ -1,33 +1,91 @@
-import { readFile, writeFile, readdir, stat, unlink, mkdir } from "fs/promises";
+import { readFile, writeFile, readdir, stat, unlink, mkdir, copyFile } from "fs/promises";
 import { existsSync } from "fs";
 import { join } from "path";
 import { paths } from "../config/paths.js";
 import type { KnowledgeFile } from "../models/index.js";
 
-const DEFAULT_README = `# podcli Knowledge Base
+const templatesDir = join(paths.backendDir, "templates", "knowledge");
 
-Add \`.md\` files here to give the AI context when creating clips.
+// Template blanks look like [Show name]; a markdown link ([text](url)) is not one.
+const PLACEHOLDER = /\[[^\]\n]{1,80}\](?!\()/g;
 
-## Suggested files
+function placeholders(text: string): number {
+  return text.match(PLACEHOLDER)?.length ?? 0;
+}
 
-- \`podcast.md\` — Show name, description, format, episode structure
-- \`hosts.md\` — Host names, speaking styles, roles
-- \`style.md\` — Preferred caption style, logo, crop strategy, colors
-- \`audience.md\` — Target audience, platform preferences (TikTok vs Reels vs Shorts)
-- \`avoid.md\` — Topics, segments, or time ranges to skip
+export function isFilledIn(content: string, template: string): boolean {
+  const body = content.trim();
+  if (!body || body === template.trim()) return false;
+  return placeholders(body) <= placeholders(template) * 0.3;
+}
 
-The MCP server reads all files here before processing requests.
-`;
+export interface KnowledgeStatus {
+  templates: string[];
+  present: string[];
+  filled: string[];
+  missing: string[];
+}
 
 export class KnowledgeBase {
   private dir = paths.knowledge;
 
   async ensureDir() {
-    if (!existsSync(this.dir)) {
-      await mkdir(this.dir, { recursive: true });
-      // Write default README
-      await writeFile(join(this.dir, "README.md"), DEFAULT_README, "utf-8");
+    await mkdir(this.dir, { recursive: true });
+  }
+
+  private async loadTemplates(): Promise<Map<string, string>> {
+    const templates = new Map<string, string>();
+    let names: string[];
+    try {
+      names = (await readdir(templatesDir)).filter((f) => f.endsWith(".md")).sort();
+    } catch {
+      return templates;
     }
+    for (const name of names) {
+      templates.set(name, await readFile(join(templatesDir, name), "utf-8"));
+    }
+    return templates;
+  }
+
+  /** Copy the starter templates in, never overwriting a file the user already has. */
+  async initFromTemplates(): Promise<{ created: string[]; kept: string[] }> {
+    const templates = await this.loadTemplates();
+    if (templates.size === 0) {
+      throw new Error(`No knowledge templates found at ${templatesDir}`);
+    }
+    await this.ensureDir();
+
+    const created: string[] = [];
+    const kept: string[] = [];
+    for (const name of templates.keys()) {
+      const target = join(this.dir, name);
+      if (existsSync(target)) {
+        kept.push(name);
+        continue;
+      }
+      await copyFile(join(templatesDir, name), target);
+      created.push(name);
+    }
+    return { created, kept };
+  }
+
+  async status(): Promise<KnowledgeStatus> {
+    const templates = await this.loadTemplates();
+    const byName = new Map((await this.listFiles()).map((f) => [f.filename, f.content]));
+
+    const present: string[] = [];
+    const filled: string[] = [];
+    const missing: string[] = [];
+    for (const [name, template] of templates) {
+      const content = byName.get(name);
+      if (content === undefined) {
+        missing.push(name);
+        continue;
+      }
+      present.push(name);
+      if (isFilledIn(content, template)) filled.push(name);
+    }
+    return { templates: [...templates.keys()], present, filled, missing };
   }
 
   async listFiles(): Promise<KnowledgeFile[]> {

--- a/src/services/python-executor.test.ts
+++ b/src/services/python-executor.test.ts
@@ -41,45 +41,33 @@ describe("stderrTail", () => {
 });
 
 describe("terminateProcessTree", () => {
-  const isWindows = process.platform === "win32";
-
   const fakeProc = () => {
     const proc = new EventEmitter() as unknown as ChildProcess;
     Object.assign(proc, { pid: 4242, exitCode: null, signalCode: null, kill: vi.fn() });
     return proc;
   };
 
-  // Windows has no process groups: the tree is killed through proc.kill, while
-  // POSIX signals the negated pid. Assert whichever channel this platform uses.
-  const killSpy = (proc: ChildProcess) =>
-    isWindows ? proc.kill : vi.spyOn(process, "kill").mockReturnValue(true);
-
-  const expectSignal = (spy: unknown, signal: NodeJS.Signals) =>
-    isWindows ? expect(spy).toHaveBeenCalledWith(signal) : expect(spy).toHaveBeenCalledWith(-4242, signal);
-
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it("escalates to SIGKILL when the tree survives SIGTERM", () => {
+  it("escalates a POSIX process group to SIGKILL", () => {
     vi.useFakeTimers();
     const proc = fakeProc();
-    const kill = killSpy(proc);
-    terminateProcessTree(proc, 2000);
+    const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+    terminateProcessTree(proc, 2000, { platform: "linux" });
 
-    expectSignal(kill, "SIGTERM");
+    expect(kill).toHaveBeenCalledWith(-4242, "SIGTERM");
     vi.advanceTimersByTime(2000);
-    expectSignal(kill, "SIGKILL");
+    expect(kill).toHaveBeenCalledWith(-4242, "SIGKILL");
   });
 
-  // The pid can be handed to an unrelated process once the child is reaped, and
-  // on POSIX the kill targets the whole group, so a late SIGKILL would take it out.
-  it("cancels the escalation once the process exits", () => {
+  it("cancels POSIX escalation once the process exits", () => {
     vi.useFakeTimers();
     const proc = fakeProc();
-    const kill = killSpy(proc);
-    terminateProcessTree(proc, 2000);
+    const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+    terminateProcessTree(proc, 2000, { platform: "linux" });
 
     proc.emit("exit", null, "SIGTERM");
     vi.advanceTimersByTime(10_000);
@@ -87,14 +75,36 @@ describe("terminateProcessTree", () => {
     expect(kill).toHaveBeenCalledTimes(1);
   });
 
-  it("does not schedule a kill for an already-exited process", () => {
+  it("does not signal an already-exited POSIX process group", () => {
     vi.useFakeTimers();
     const proc = fakeProc();
     Object.assign(proc, { exitCode: 0 });
-    const kill = killSpy(proc);
-    terminateProcessTree(proc, 2000);
+    const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+    terminateProcessTree(proc, 2000, { platform: "linux" });
 
     vi.advanceTimersByTime(10_000);
-    expect(kill).toHaveBeenCalledTimes(1);
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it("terminates the full Windows process tree", () => {
+    vi.useFakeTimers();
+    const proc = fakeProc();
+    const taskkillProc = new EventEmitter();
+    const spawnProcess = vi.fn().mockReturnValue(taskkillProc);
+    const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+
+    terminateProcessTree(proc, 2000, {
+      platform: "win32",
+      spawnProcess: spawnProcess as never,
+    });
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      "taskkill",
+      ["/pid", "4242", "/T", "/F"],
+      { stdio: "ignore", windowsHide: true }
+    );
+    expect(proc.kill).not.toHaveBeenCalled();
+    expect(kill).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/src/services/python-executor.test.ts
+++ b/src/services/python-executor.test.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from "events";
+import type { ChildProcess } from "child_process";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { stderrTail, terminateProcessTree } from "./python-executor.js";
+
+describe("stderrTail", () => {
+  it("returns short stderr unchanged", () => {
+    expect(stderrTail("boom")).toBe("boom");
+  });
+
+  it("keeps the tail of long stderr", () => {
+    const noise = "x".repeat(10_000) + "END";
+    const tail = stderrTail(noise);
+    expect(tail.length).toBe(4000);
+    expect(tail.endsWith("END")).toBe(true);
+  });
+
+  it("prefers the last traceback block", () => {
+    const stderr = [
+      "progress line",
+      "Traceback (most recent call last):",
+      '  File "old.py", line 1',
+      "OldError: first failure",
+      "retrying...",
+      "Traceback (most recent call last):",
+      '  File "new.py", line 9',
+      "ValueError: actual failure",
+    ].join("\n");
+    const tail = stderrTail(stderr);
+    expect(tail.startsWith("Traceback (most recent call last):")).toBe(true);
+    expect(tail).toContain("ValueError: actual failure");
+    expect(tail).not.toContain("OldError");
+  });
+
+  it("truncates a huge traceback to the tail", () => {
+    const stderr = "Traceback (most recent call last):\n" + "y".repeat(9000) + "\nValueError: end";
+    const tail = stderrTail(stderr);
+    expect(tail.length).toBe(4000);
+    expect(tail.endsWith("ValueError: end")).toBe(true);
+  });
+});
+
+describe("terminateProcessTree", () => {
+  const isWindows = process.platform === "win32";
+
+  const fakeProc = () => {
+    const proc = new EventEmitter() as unknown as ChildProcess;
+    Object.assign(proc, { pid: 4242, exitCode: null, signalCode: null, kill: vi.fn() });
+    return proc;
+  };
+
+  // Windows has no process groups: the tree is killed through proc.kill, while
+  // POSIX signals the negated pid. Assert whichever channel this platform uses.
+  const killSpy = (proc: ChildProcess) =>
+    isWindows ? proc.kill : vi.spyOn(process, "kill").mockReturnValue(true);
+
+  const expectSignal = (spy: unknown, signal: NodeJS.Signals) =>
+    isWindows ? expect(spy).toHaveBeenCalledWith(signal) : expect(spy).toHaveBeenCalledWith(-4242, signal);
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("escalates to SIGKILL when the tree survives SIGTERM", () => {
+    vi.useFakeTimers();
+    const proc = fakeProc();
+    const kill = killSpy(proc);
+    terminateProcessTree(proc, 2000);
+
+    expectSignal(kill, "SIGTERM");
+    vi.advanceTimersByTime(2000);
+    expectSignal(kill, "SIGKILL");
+  });
+
+  // The pid can be handed to an unrelated process once the child is reaped, and
+  // on POSIX the kill targets the whole group, so a late SIGKILL would take it out.
+  it("cancels the escalation once the process exits", () => {
+    vi.useFakeTimers();
+    const proc = fakeProc();
+    const kill = killSpy(proc);
+    terminateProcessTree(proc, 2000);
+
+    proc.emit("exit", null, "SIGTERM");
+    vi.advanceTimersByTime(10_000);
+
+    expect(kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not schedule a kill for an already-exited process", () => {
+    vi.useFakeTimers();
+    const proc = fakeProc();
+    Object.assign(proc, { exitCode: 0 });
+    const kill = killSpy(proc);
+    terminateProcessTree(proc, 2000);
+
+    vi.advanceTimersByTime(10_000);
+    expect(kill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/python-executor.ts
+++ b/src/services/python-executor.ts
@@ -7,36 +7,67 @@ type ProgressCallback = (event: ProgressEvent) => void;
 
 const isWindows = process.platform === "win32";
 
-export function killProcessTree(proc: ChildProcess, signal: NodeJS.Signals): void {
-  if (proc.pid === undefined) return;
+type ProcessTreeOptions = {
+  platform?: NodeJS.Platform;
+  spawnProcess?: typeof spawn;
+};
+
+function hasExited(proc: ChildProcess): boolean {
+  return proc.exitCode !== null || proc.signalCode !== null;
+}
+
+export function killProcessTree(
+  proc: ChildProcess,
+  signal: NodeJS.Signals,
+  options: ProcessTreeOptions = {}
+): void {
+  if (proc.pid === undefined || hasExited(proc)) return;
+  const platform = options.platform ?? process.platform;
   try {
-    // Negative pid kills the whole group — the child is a detached group
-    // leader, so its ffmpeg/whisper children die with it.
-    if (isWindows) proc.kill(signal);
-    else process.kill(-proc.pid, signal);
-  } catch {
-    // Already exited.
-  }
+    if (platform === "win32") {
+      const taskkill = (options.spawnProcess ?? spawn)(
+        "taskkill",
+        ["/pid", String(proc.pid), "/T", "/F"],
+        { stdio: "ignore", windowsHide: true }
+      );
+      taskkill.once("error", () => undefined);
+    } else process.kill(-proc.pid, signal);
+  } catch {}
 }
 
 const KILL_GRACE_MS = 2000;
 
-// SIGTERM, then SIGKILL if the tree is still up. The escalation is cancelled on
-// exit: the OS can hand the pid to an unrelated process, and killProcessTree
-// signals the whole group (-pid), so a late SIGKILL would take that one out.
-export function terminateProcessTree(proc: ChildProcess, graceMs = KILL_GRACE_MS): void {
-  killProcessTree(proc, "SIGTERM");
-  if (proc.exitCode !== null || proc.signalCode !== null) return;
+export function terminateProcessTree(
+  proc: ChildProcess,
+  graceMs = KILL_GRACE_MS,
+  options: ProcessTreeOptions = {}
+): void {
+  if (hasExited(proc)) return;
+  const platform = options.platform ?? process.platform;
+  if (platform === "win32") {
+    killProcessTree(proc, "SIGKILL", options);
+    return;
+  }
 
   let exited = false;
-  const escalation = setTimeout(() => {
-    if (!exited) killProcessTree(proc, "SIGKILL");
+  let escalation: NodeJS.Timeout | undefined;
+  const onExit = (): void => {
+    exited = true;
+    if (escalation) clearTimeout(escalation);
+  };
+  proc.once("exit", onExit);
+  if (hasExited(proc)) {
+    proc.removeListener("exit", onExit);
+    return;
+  }
+
+  killProcessTree(proc, "SIGTERM", options);
+  if (exited || hasExited(proc)) return;
+
+  escalation = setTimeout(() => {
+    if (!exited && !hasExited(proc)) killProcessTree(proc, "SIGKILL", options);
   }, graceMs);
   escalation.unref();
-  proc.once("exit", () => {
-    exited = true;
-    clearTimeout(escalation);
-  });
 }
 
 // Prefer the last traceback block — that's where the actual failure is —

--- a/src/services/python-executor.ts
+++ b/src/services/python-executor.ts
@@ -7,7 +7,7 @@ type ProgressCallback = (event: ProgressEvent) => void;
 
 const isWindows = process.platform === "win32";
 
-function killProcessTree(proc: ChildProcess, signal: NodeJS.Signals): void {
+export function killProcessTree(proc: ChildProcess, signal: NodeJS.Signals): void {
   if (proc.pid === undefined) return;
   try {
     // Negative pid kills the whole group — the child is a detached group
@@ -17,6 +17,34 @@ function killProcessTree(proc: ChildProcess, signal: NodeJS.Signals): void {
   } catch {
     // Already exited.
   }
+}
+
+const KILL_GRACE_MS = 2000;
+
+// SIGTERM, then SIGKILL if the tree is still up. The escalation is cancelled on
+// exit: the OS can hand the pid to an unrelated process, and killProcessTree
+// signals the whole group (-pid), so a late SIGKILL would take that one out.
+export function terminateProcessTree(proc: ChildProcess, graceMs = KILL_GRACE_MS): void {
+  killProcessTree(proc, "SIGTERM");
+  if (proc.exitCode !== null || proc.signalCode !== null) return;
+
+  let exited = false;
+  const escalation = setTimeout(() => {
+    if (!exited) killProcessTree(proc, "SIGKILL");
+  }, graceMs);
+  escalation.unref();
+  proc.once("exit", () => {
+    exited = true;
+    clearTimeout(escalation);
+  });
+}
+
+// Prefer the last traceback block — that's where the actual failure is —
+// and keep a tail long enough to include it.
+export function stderrTail(stderr: string, maxChars = 4000): string {
+  const tb = stderr.lastIndexOf("Traceback (most recent call last):");
+  const tail = tb !== -1 ? stderr.slice(tb) : stderr;
+  return tail.slice(-maxChars);
 }
 
 function parseResultLine<T>(stdout: string): TaskResult<T> | null {
@@ -129,7 +157,7 @@ export class PythonExecutor {
             reject(
               new Error(
                 `No parseable output from Python task. Exit code: ${code}. ` +
-                  `Stdout: ${stdout.slice(-300)}. Stderr: ${stderr.slice(-300)}`
+                  `Stdout: ${stdout.slice(-300)}. Stderr: ${stderrTail(stderr)}`
               )
             );
             return;
@@ -150,8 +178,7 @@ export class PythonExecutor {
       } catch {}
 
       timer = setTimeout(() => {
-        killProcessTree(proc, "SIGTERM");
-        setTimeout(() => killProcessTree(proc, "SIGKILL"), 2000).unref();
+        terminateProcessTree(proc);
         finish(() => reject(new Error(`Task timed out after ${this.timeoutMs / 1000}s`)));
       }, this.timeoutMs);
     });

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -30,13 +30,17 @@ import { tmpdir } from "os";
 import { fileURLToPath } from "url";
 import { v4 as uuidv4 } from "uuid";
 
-import { PythonExecutor } from "../services/python-executor.js";
+import { PythonExecutor, terminateProcessTree } from "../services/python-executor.js";
 import { TranscriptCache } from "../services/transcript-cache.js";
 import { FileManager } from "../services/file-manager.js";
 import { AssetManager, inferType, safeName } from "../services/asset-manager.js";
 import { ClipsHistory } from "../services/clips-history.js";
 import { KnowledgeBase } from "../services/knowledge-base.js";
 import { paths, pythonEnv } from "../config/paths.js";
+import { webServerPort } from "../config/server.js";
+import { writeFileAtomicSync } from "../utils/atomic-file.js";
+import { maxClipSeconds, validateClipRange, validateSuggestionRange } from "../utils/clip-validation.js";
+import { advanceProgress, tagSubmittedClip, tagSubmittedClips } from "../utils/clip-results.js";
 import { DEMO_ASSETS_DIR } from "./demo-fixtures.js";
 import { registerConfigIntegrationRoutes } from "../handlers/integrations.routes.js";
 import { childLogger } from "../utils/logger.js";
@@ -63,7 +67,7 @@ const publicDir = existsSync(join(__dirname, "public", "index.html"))
   : resolve(__dirname, "..", "..", "dist", "ui", "public");
 
 const app = express();
-const PORT = parseInt(process.env.PORT || "3847");
+const PORT = webServerPort;
 const DEMO = process.env.PODCLI_DEMO === "1";
 
 // --- Services ---
@@ -94,9 +98,27 @@ interface JobState {
   result?: unknown;
   error?: string;
   createdAt: number;
+  finishedAt?: number;
+  clip_results?: unknown[];
 }
 
 const jobs = new Map<string, JobState>();
+
+// Sweep terminal jobs so the map doesn't grow forever. Completion isn't
+// stamped at the many done/error sites; the sweeper stamps it on first sight,
+// so a job survives at least one full retention window after finishing.
+const JOB_RETENTION_MS = 30 * 60_000;
+setInterval(() => {
+  const now = Date.now();
+  for (const [id, job] of jobs) {
+    if (job.status !== "done" && job.status !== "error") continue;
+    if (job.finishedAt === undefined) {
+      job.finishedAt = now;
+    } else if (now - job.finishedAt > JOB_RETENTION_MS) {
+      jobs.delete(id);
+    }
+  }
+}, 60_000).unref();
 
 /** Transcript data stored per file, plus optional face-tracking hints. */
 type ServerTranscript = TranscriptResult & { face_map?: unknown };
@@ -120,6 +142,8 @@ interface UIState {
     logoPath: string;
     outroPath: string;
     introPath: string;
+    cleanFillers: boolean;
+    onboardingDismissed: boolean;
   };
   phase: string;
   results: unknown[];
@@ -154,6 +178,8 @@ function loadPersistedState(): UIState {
           logoPath: saved.settings?.logoPath || "",
           outroPath: saved.settings?.outroPath || "",
           introPath: saved.settings?.introPath || "",
+          cleanFillers: saved.settings?.cleanFillers !== false,
+          onboardingDismissed: !!saved.settings?.onboardingDismissed,
         },
         // Never restore mid-export phases
         phase: ["exporting", "parsing", "suggesting"].includes(saved.phase)
@@ -186,6 +212,8 @@ function loadPersistedState(): UIState {
       logoPath: "",
       outroPath: "",
       introPath: "",
+      cleanFillers: true,
+      onboardingDismissed: false,
     },
     phase: "idle",
     results: [],
@@ -219,7 +247,7 @@ function rememberSource(realPath: string): void {
   if (!VIDEO_SOURCE_EXTS.has(extname(realPath).toLowerCase())) return;
   recentSources = [realPath, ...recentSources.filter((p) => p !== realPath)].slice(0, 40);
   try {
-    writeFileSync(sourcesFile, JSON.stringify(recentSources, null, 2), "utf-8");
+    writeFileAtomicSync(sourcesFile, JSON.stringify(recentSources, null, 2));
   } catch {}
 }
 
@@ -239,7 +267,7 @@ function persistState() {
   if (saveTimer) clearTimeout(saveTimer);
   saveTimer = setTimeout(() => {
     try {
-      writeFileSync(paths.uiState, JSON.stringify(uiState, null, 2));
+      writeFileAtomicSync(paths.uiState, JSON.stringify(uiState, null, 2));
     } catch (err) {
       log.warn("Failed to persist UI state to disk", { err: errMsg(err) });
     }
@@ -642,14 +670,18 @@ app.post("/api/download-video", async (req, res) => {
     "after_move:podcli-filepath:%(filepath)s",
     url,
   ];
-  const proc = spawn(paths.pythonPath, args, { env: pythonEnv() });
+  // Detached so a kill takes out yt-dlp's ffmpeg children with it.
+  const proc = spawn(paths.pythonPath, args, {
+    env: pythonEnv(),
+    detached: process.platform !== "win32",
+  });
 
   let stdout = "";
   let stderr = "";
   let outputFilePath = "";
   let settled = false;
   let responded = false;
-  const timer = setTimeout(() => proc.kill("SIGTERM"), 3600_000);
+  const timer = setTimeout(() => terminateProcessTree(proc), 3600_000);
   const finish = (action: () => void): void => {
     if (settled) return;
     settled = true;
@@ -732,7 +764,7 @@ app.post("/api/download-video", async (req, res) => {
     });
   });
   req.on("close", () => {
-    if (!responded && !settled) proc.kill("SIGTERM");
+    if (!responded && !settled) terminateProcessTree(proc);
   });
   responded = true;
   res.json({ job_id: jobId, status: "running" });
@@ -1191,6 +1223,7 @@ app.post("/api/batch-clips", async (req, res) => {
     transcript_words = [],
     clean_fillers = false,
     keep_caption_overlay = false,
+    format = "vertical",
   } = req.body;
 
   if (!video_path || !existsSync(video_path)) {
@@ -1228,7 +1261,7 @@ app.post("/api/batch-clips", async (req, res) => {
       res.status(400).json({ error: `Clip ${i + 1}: invalid format "${c.format}". Use: vertical, horizontal, square` });
       return;
     }
-    const maxDur = c.format === "horizontal" ? 300 : 180;
+    const maxDur = maxClipSeconds(c.format || format);
     if (dur > maxDur) {
       res.status(400).json({
         error: `Clip ${i + 1}: too long (${Math.round(dur)}s). Max ${maxDur}s.`,
@@ -1277,6 +1310,7 @@ app.post("/api/batch-clips", async (req, res) => {
       {
         video_path,
         clips: enrichedClips,
+        format,
         transcript_words,
         output_dir: paths.output,
         logo_path,
@@ -1287,21 +1321,30 @@ app.post("/api/batch-clips", async (req, res) => {
         face_map: uiState.transcript?.face_map,
       },
       (event) => {
-        job.progress = event.percent;
+        const progress = advanceProgress(job, event.percent);
         job.message = event.message;
         historyRecorder.recordProgress(event);
+        const clipResult = event.clip_result
+          ? tagSubmittedClip(event.clip_result, enrichedClips)
+          : undefined;
+        if (event.stage === "clip_complete" && clipResult) {
+          (job.clip_results ??= []).push(clipResult);
+        }
         broadcastSSE("job-update", {
           jobId,
-          progress: event.percent,
+          progress,
           message: event.message,
+          stage: event.stage,
+          clip_result: clipResult,
         });
       },
     )
     .then(async (result) => {
+      const data = tagSubmittedClips(result.data, enrichedClips);
       job.status = "done";
       job.progress = 100;
       job.message = "Batch complete!";
-      job.result = result.data;
+      job.result = data;
       // Record successful clips to history
       try {
         await historyRecorder.recordRemaining(result.data?.results);
@@ -1311,7 +1354,7 @@ app.post("/api/batch-clips", async (req, res) => {
         });
       }
       setExportState("done", null);
-      broadcastSSE("job-complete", { jobId, result: result.data });
+      broadcastSSE("job-complete", { jobId, result: data });
     })
     .catch((err) => {
       job.status = "error";
@@ -1366,6 +1409,7 @@ app.get("/api/job/:id/stream", (req, res) => {
         message: current.message,
         result: current.result,
         error: current.error,
+        clip_results: current.clip_results,
       })}\n\n`,
     );
 
@@ -1959,16 +2003,35 @@ app.get("/api/history", async (req, res) => {
 // share one history writer (preserves unknown fields like Phase 2 metrics).
 const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "").trim();
 
+const RUN_PY_TIMEOUT_MS = 15 * 60_000;
+
 function runPy(scriptAndArgs: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
+    // Detached so a timeout kill takes out the whole process group (ffmpeg etc.).
     const proc = spawn(paths.pythonPath, scriptAndArgs, {
       env: pythonEnv({ PODCLI_HOME: paths.home, PODCLI_DATA: paths.dataDir }),
+      detached: process.platform !== "win32",
     });
     let stdout = "", stderr = "";
+    let settled = false;
+    const finish = (result: { code: number; stdout: string; stderr: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      terminateProcessTree(proc);
+      finish({
+        code: 1,
+        stdout,
+        stderr: `${stderr}\nTimed out after ${RUN_PY_TIMEOUT_MS / 1000}s`.trim(),
+      });
+    }, RUN_PY_TIMEOUT_MS);
     proc.stdout.on("data", (d) => (stdout += d));
     proc.stderr.on("data", (d) => (stderr += d));
-    proc.on("close", (code) => resolve({ code: code ?? 1, stdout, stderr }));
-    proc.on("error", (e) => resolve({ code: 1, stdout, stderr: String(e) }));
+    proc.on("close", (code) => finish({ code: code ?? 1, stdout, stderr }));
+    proc.on("error", (e) => finish({ code: 1, stdout, stderr: String(e) }));
   });
 }
 
@@ -1989,7 +2052,7 @@ app.patch("/api/clips/:id", async (req, res) => {
   if (DEMO) { res.json({ ok: true }); return; } // fixtures are read-only
   const { title, caption_style, thumbnail_config } = req.body || {};
   const args = ["clips", "edit", req.params.id];
-  if (title != null) args.push("--title", String(title));
+  if (title != null) args.push(`--title=${title}`);
   if (caption_style != null) args.push("--caption-style", String(caption_style));
   if (thumbnail_config != null) args.push("--thumbnail-config", JSON.stringify(thumbnail_config));
   if (args.length === 3) {
@@ -2033,8 +2096,10 @@ app.post("/api/clips/:id/thumbnail", async (req, res) => {
   const tc = clip.thumbnail_config || {};
   // Standalone thumbnail generation — produces variation PNGs, never touches the clip video.
   const outDir = join(paths.output, "thumbnails", String(clip.id));
+  // Free-text values ride behind "--" (positionals) or as --flag=value so a
+  // title starting with "-" can't be parsed as an option.
   const args = [
-    "thumbnails", tc.text || clip.title,
+    "thumbnails",
     "--output", outDir,
     "--variations", "3",
     "--json",
@@ -2044,8 +2109,9 @@ app.post("/api/clips/:id/thumbnail", async (req, res) => {
   ];
   if (tc.image_path) args.push("--photo", String(tc.image_path));
   else if (typeof tc.timestamp === "number") args.push("--timestamp", String(tc.timestamp));
-  if (tc.line1) args.push("--line1", String(tc.line1));
-  if (tc.line2) args.push("--line2", String(tc.line2));
+  if (tc.line1) args.push(`--line1=${tc.line1}`);
+  if (tc.line2) args.push(`--line2=${tc.line2}`);
+  args.push("--", tc.text || clip.title);
   const r = await runCli(args);
   if (r.code !== 0) {
     res.status(400).json({ error: stripAnsi(r.stderr || r.stdout) || "thumbnail failed" });
@@ -2099,13 +2165,14 @@ app.get("/api/clips/:id/thumbnail/options", async (req, res) => {
   const clamp = (v: any, d: number) => Math.min(Math.max(parseInt(String(v)) || d, 1), 8);
   const outDir = join(paths.output, "thumbnails", String(clip.id), "frames");
   const r = await runCli([
-    "thumbnail-options", tc.text || clip.title,
+    "thumbnail-options",
     "--output", outDir,
     "--video", clip.source_video,
     "--start", String(clip.start_second),
     "--end", String(clip.end_second),
     "--texts", String(clamp(req.query.texts, 6)),
     "--frames", String(clamp(req.query.frames, 6)),
+    "--", tc.text || clip.title,
   ]);
   if (r.code !== 0) { res.status(400).json({ error: stripAnsi(r.stderr || r.stdout) || "options failed" }); return; }
   const jsonLine = r.stdout.trim().split("\n").reverse().find((l) => l.trim().startsWith("{"));
@@ -2132,10 +2199,11 @@ app.post("/api/clips/:id/thumbnail/render", async (req, res) => {
   const outDir = join(paths.output, "thumbnails", String(clip.id));
   await mkdir(outDir, { recursive: true });
   const out = join(outDir, `thumb_${uuidv4().slice(0, 8)}.png`);
-  const args = ["thumbnail-render", tc.text || clip.title, "--frame", resolvedFrame, "--output", out];
-  if (line1) args.push("--line1", String(line1));
-  if (line2) args.push("--line2", String(line2));
+  const args = ["thumbnail-render", "--frame", resolvedFrame, "--output", out];
+  if (line1) args.push(`--line1=${line1}`);
+  if (line2) args.push(`--line2=${line2}`);
   if (frame_info) args.push("--frame-info", JSON.stringify(frame_info));
+  args.push("--", tc.text || clip.title);
   const r = await runCli(args);
   if (r.code !== 0) { res.status(400).json({ error: stripAnsi(r.stderr || r.stdout) || "render failed" }); return; }
   const jsonLine = r.stdout.trim().split("\n").reverse().find((l) => l.trim().startsWith("{"));
@@ -2177,7 +2245,7 @@ app.post("/api/thumbnail-studio/options", async (req, res) => {
   if (!title || !String(title).trim()) { res.status(400).json({ error: "title is required" }); return; }
   const clamp = (v: any, d: number) => Math.min(Math.max(parseInt(String(v)) || d, 1), 8);
   const args = [
-    "thumbnail-options", String(title),
+    "thumbnail-options",
     "--output", join(thumbStudioDir, "frames"),
     "--texts", String(clamp(texts, 6)),
     "--frames", String(clamp(frames, 6)),
@@ -2192,6 +2260,7 @@ app.post("/api/thumbnail-studio/options", async (req, res) => {
     if (start != null && start !== "") args.push("--start", String(Math.max(0, Number(start) || 0)));
     if (end != null && end !== "") args.push("--end", String(Math.max(0, Number(end) || 0)));
   }
+  args.push("--", String(title));
   const r = await runCli(args);
   if (r.code !== 0) { res.status(400).json({ error: stripAnsi(r.stderr || r.stdout) || "options failed" }); return; }
   const jsonLine = r.stdout.trim().split("\n").reverse().find((l) => l.trim().startsWith("{"));
@@ -2212,10 +2281,11 @@ app.post("/api/thumbnail-studio/render", async (req, res) => {
   if (!resolvedFrame) { res.status(400).json({ error: "invalid frame" }); return; }
   await mkdir(thumbStudioDir, { recursive: true });
   const out = join(thumbStudioDir, `thumb_${uuidv4().slice(0, 8)}.png`);
-  const args = ["thumbnail-render", String(title), "--frame", resolvedFrame, "--output", out];
-  if (line1) args.push("--line1", String(line1));
-  if (line2) args.push("--line2", String(line2));
+  const args = ["thumbnail-render", "--frame", resolvedFrame, "--output", out];
+  if (line1) args.push(`--line1=${line1}`);
+  if (line2) args.push(`--line2=${line2}`);
   if (frame_info) args.push("--frame-info", JSON.stringify(frame_info));
+  args.push("--", String(title));
   const r = await runCli(args);
   if (r.code !== 0) { res.status(400).json({ error: stripAnsi(r.stderr || r.stdout) || "render failed" }); return; }
   const jsonLine = r.stdout.trim().split("\n").reverse().find((l) => l.trim().startsWith("{"));
@@ -2284,7 +2354,7 @@ app.put("/api/youtube/config", (req, res) => {
     if (client_id !== undefined) yt.client_id = client_id;
     if (client_secret) yt.client_secret = client_secret;
     all.youtube = yt;
-    writeFileSync(paths.integrations, JSON.stringify(all, null, 2) + "\n", "utf-8");
+    writeFileAtomicSync(paths.integrations, JSON.stringify(all, null, 2) + "\n");
     // Holds the OAuth client secret — keep it owner-only (chmod covers the
     // case where the file already existed with looser perms).
     try { chmodSync(paths.integrations, 0o600); } catch { /* best effort */ }
@@ -2518,7 +2588,7 @@ app.post("/api/clips/:id/davinci", async (req, res) => {
     return;
   }
   const cli = join(paths.backendDir, "services", "integrations", "davinci_resolve", "cli.py");
-  const r = await runPy([cli, "--source", clip.output_path, "--title", clip.title]);
+  const r = await runPy([cli, "--source", clip.output_path, `--title=${clip.title}`]);
   if (r.code !== 0) {
     res.status(400).json({ error: stripAnsi(r.stderr || r.stdout) || "export failed" });
     return;
@@ -2572,7 +2642,7 @@ app.get("/api/corrections", (_req, res) => {
 app.put("/api/corrections", express.json(), (req, res) => {
   try {
     const corrections = req.body || {};
-    writeFileSync(correctionsPath, JSON.stringify(corrections, null, 2));
+    writeFileAtomicSync(correctionsPath, JSON.stringify(corrections, null, 2));
     res.json({ ok: true, corrections });
   } catch (err: any) {
     res.status(500).json({ error: err.message });
@@ -2591,7 +2661,7 @@ app.post("/api/corrections/add", express.json(), (req, res) => {
       corrections = JSON.parse(readFileSync(correctionsPath, "utf-8"));
     }
     corrections[wrong] = correct;
-    writeFileSync(correctionsPath, JSON.stringify(corrections, null, 2));
+    writeFileAtomicSync(correctionsPath, JSON.stringify(corrections, null, 2));
     res.json({ ok: true, corrections });
   } catch (err: any) {
     res.status(500).json({ error: err.message });
@@ -2605,7 +2675,7 @@ app.delete("/api/corrections/:wrong", (req, res) => {
       corrections = JSON.parse(readFileSync(correctionsPath, "utf-8"));
     }
     delete corrections[req.params.wrong];
-    writeFileSync(correctionsPath, JSON.stringify(corrections, null, 2));
+    writeFileAtomicSync(correctionsPath, JSON.stringify(corrections, null, 2));
     res.json({ ok: true, corrections });
   } catch (err: any) {
     res.status(500).json({ error: err.message });
@@ -2624,6 +2694,15 @@ app.get("/api/knowledge", async (_req, res) => {
 
 app.get("/api/knowledge/dir", (_req, res) => {
   res.json({ path: paths.knowledge });
+});
+
+// Must stay ahead of the :filename routes, which would otherwise claim "init".
+app.post("/api/knowledge/init", async (_req, res) => {
+  try {
+    res.json(await knowledgeBase.initFromTemplates());
+  } catch (err: unknown) {
+    res.status(500).json({ error: errMsg(err) });
+  }
 });
 
 // Knowledge file upload (drag & drop .md files) — must be before :filename routes
@@ -2695,6 +2774,39 @@ app.delete("/api/knowledge/:filename", async (req, res) => {
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }
+});
+
+// --- Onboarding readiness ---
+app.get("/api/onboarding", async (_req, res) => {
+  const knowledge = await knowledgeBase
+    .status()
+    .catch(() => ({ templates: [], present: [], filled: [], missing: [] }));
+  const assets = await assetManager.list().catch(() => []);
+  const clips = await clipsHistory.load().catch(() => []);
+
+  let aiCli = false;
+  try {
+    const result = await executor.execute<{ available?: boolean }>("ai_cli_status", {});
+    aiCli = !!result.data?.available;
+  } catch {
+    // A failed probe reads the same as no CLI installed.
+  }
+
+  res.json({
+    knowledge: {
+      total: knowledge.templates.length,
+      present: knowledge.present.length,
+      filled: knowledge.filled,
+      missing: knowledge.missing,
+    },
+    assets: {
+      count: assets.length,
+      branding: assets.some((a) => a.type === "logo" || a.type === "outro"),
+    },
+    aiCli: { available: aiCli },
+    clips: { count: clips.length },
+    dismissed: !!uiState.settings.onboardingDismissed,
+  });
 });
 
 // --- Prompt Builder (shared by /api/generate-prompt and /api/mcp-hints) ---
@@ -2928,7 +3040,11 @@ app.post("/api/claude-suggest", async (req, res) => {
       ...uiState.suggestions.map((s) => ({ start_second: s.start_second, end_second: s.end_second, title: s.title })),
     ];
 
+    // The backend derives laughter/reaction anchors from the audio, so it needs
+    // the source video, not just the segments.
     const params: Record<string, unknown> = { segments: segs, top_n, existing_clips };
+    const suggestVideo = uiState.filePath || uiState.videoPath;
+    if (suggestVideo) params.video_path = suggestVideo;
     if (min_duration) params.min_duration = min_duration;
     if (max_duration) params.max_duration = max_duration;
     const result = await executor.execute<{ clips?: SuggestedClip[] }>(
@@ -3322,26 +3438,111 @@ app.post("/api/ui-state", (req, res) => {
       uiState.settings.outroPath = body.settings.outroPath;
     if (body.settings.introPath !== undefined)
       uiState.settings.introPath = body.settings.introPath;
+    if (body.settings.cleanFillers !== undefined)
+      uiState.settings.cleanFillers = body.settings.cleanFillers !== false;
+    if (body.settings.onboardingDismissed !== undefined)
+      uiState.settings.onboardingDismissed = !!body.settings.onboardingDismissed;
   }
   uiState.lastUpdated = Date.now();
   persistState();
 
-  // Broadcast to UI when changes come from MCP (not from UI itself)
+  // Broadcast to UI when changes come from MCP (not from UI itself).
+  // Send the stored (server-enriched) values, not the raw request body, so
+  // clients see keep_segments etc.; energyData rides along so unrelated syncs
+  // don't wipe computed energy client-side.
   if (source !== "ui") {
     broadcastSSE("state-sync", {
-      ...(body.videoPath !== undefined && { videoPath: body.videoPath }),
-      ...(body.filePath !== undefined && { filePath: body.filePath }),
-      ...(body.suggestions !== undefined && { suggestions: body.suggestions }),
+      ...(body.videoPath !== undefined && { videoPath: uiState.videoPath }),
+      ...(body.filePath !== undefined && { filePath: uiState.filePath }),
+      ...(body.suggestions !== undefined && { suggestions: uiState.suggestions }),
       ...(body.deselectedIndices !== undefined && {
-        deselectedIndices: body.deselectedIndices,
+        deselectedIndices: uiState.deselectedIndices,
       }),
-      ...(body.phase !== undefined && { phase: body.phase }),
-      ...(body.transcript !== undefined && { transcript: body.transcript }),
-      ...(body.settings && { settings: body.settings }),
+      ...(body.phase !== undefined && { phase: uiState.phase }),
+      ...(body.transcript !== undefined && { transcript: uiState.transcript }),
+      ...(body.settings && { settings: uiState.settings }),
+      energyData: uiState.energyData,
     });
   }
 
   res.json({ ok: true });
+});
+
+/**
+ * POST /api/suggestions/modify — mutate one suggestion in-place on the server.
+ * Replaces the read-modify-replace cycle MCP tools used, which lost concurrent
+ * edits between the GET and the wholesale POST.
+ * Body: { action: "update" | "delete" | "toggle", index? | clip_id?, updates?, selected? }
+ */
+app.post("/api/suggestions/modify", (req, res) => {
+  const { action = "update", clip_id, updates, selected } = req.body || {};
+  let index = typeof req.body?.index === "number" ? req.body.index : -1;
+  if (index === -1 && clip_id) {
+    index = uiState.suggestions.findIndex((s) => s.clip_id === clip_id);
+  }
+  if (index < 0 || index >= uiState.suggestions.length) {
+    res.status(404).json({ error: "Clip not found", total: uiState.suggestions.length });
+    return;
+  }
+
+  let clip: SuggestedClip;
+  if (action === "delete") {
+    [clip] = uiState.suggestions.splice(index, 1);
+    uiState.deselectedIndices = uiState.deselectedIndices
+      .filter((i) => i !== index)
+      .map((i) => (i > index ? i - 1 : i));
+  } else if (action === "toggle") {
+    if (typeof selected !== "boolean") {
+      res.status(400).json({ error: "selected must be a boolean for action 'toggle'" });
+      return;
+    }
+    if (selected) {
+      uiState.deselectedIndices = uiState.deselectedIndices.filter((i) => i !== index);
+    } else if (!uiState.deselectedIndices.includes(index)) {
+      uiState.deselectedIndices = [...uiState.deselectedIndices, index];
+    }
+    clip = uiState.suggestions[index];
+  } else if (action === "update") {
+    const upd = updates || {};
+    clip = uiState.suggestions[index];
+    const nextStart = typeof upd.start_second === "number" ? upd.start_second : clip.start_second;
+    const nextEnd = typeof upd.end_second === "number" ? upd.end_second : clip.end_second;
+    const rangeError = validateSuggestionRange(nextStart, nextEnd);
+    if (rangeError) {
+      res.status(400).json({ error: rangeError });
+      return;
+    }
+    if (typeof upd.title === "string") clip.title = upd.title;
+    clip.start_second = nextStart;
+    clip.end_second = nextEnd;
+    if (typeof upd.reasoning === "string") clip.reasoning = upd.reasoning;
+    if (typeof upd.preview_text === "string") clip.preview_text = upd.preview_text;
+    if (typeof upd.suggested_caption_style === "string") {
+      clip.suggested_caption_style = upd.suggested_caption_style;
+    }
+    clip.duration = Math.round((clip.end_second - clip.start_second) * 10) / 10;
+    const fmtTime = (s: number) =>
+      `${Math.floor(s / 60)}:${Math.floor(s % 60).toString().padStart(2, "0")}`;
+    clip.timestamp_display = `${fmtTime(clip.start_second)} → ${fmtTime(clip.end_second)}`;
+  } else {
+    res.status(400).json({ error: `Unknown action: ${action}` });
+    return;
+  }
+
+  uiState.lastUpdated = Date.now();
+  persistState();
+  broadcastSSE("state-sync", {
+    suggestions: uiState.suggestions,
+    deselectedIndices: uiState.deselectedIndices,
+    energyData: uiState.energyData,
+  });
+  res.json({
+    ok: true,
+    index,
+    clip,
+    total: uiState.suggestions.length,
+    selectedCount: uiState.suggestions.length - uiState.deselectedIndices.length,
+  });
 });
 
 /**
@@ -3371,6 +3572,13 @@ app.post("/api/mcp/export", async (req, res) => {
   const format =
     req.body.format || uiState.settings.format || "vertical";
   const allowAssFallback = req.body.allow_ass_fallback === true;
+  // An agent that says nothing about fillers gets the studio's toggle, so an
+  // export it triggers matches what the user set up there.
+  const cleanFillers =
+    req.body.clean_fillers !== undefined
+      ? req.body.clean_fillers !== false
+      : uiState.settings.cleanFillers !== false;
+  const keepCaptionOverlay = req.body.keep_caption_overlay === true;
 
   if (!videoPath || !existsSync(videoPath)) {
     res.status(400).json({ error: "Video file not found" });
@@ -3379,6 +3587,14 @@ app.post("/api/mcp/export", async (req, res) => {
   if (!clips.length) {
     res.status(400).json({ error: "No clips to export" });
     return;
+  }
+  for (let i = 0; i < clips.length; i++) {
+    const c = clips[i];
+    const rangeError = validateClipRange(c.start_second, c.end_second, c.format || format);
+    if (rangeError) {
+      res.status(400).json({ error: `Clip ${i + 1}: ${rangeError}` });
+      return;
+    }
   }
 
   await fileManager.ensureDirectories();
@@ -3424,7 +3640,7 @@ app.post("/api/mcp/export", async (req, res) => {
     logoPath,
     outroPath,
     introPath,
-    cleanFillers: req.body.clean_fillers === true,
+    cleanFillers,
   });
 
   // Broadcast to UI so it can track progress
@@ -3444,24 +3660,35 @@ app.post("/api/mcp/export", async (req, res) => {
         logo_path: logoPath,
         outro_path: outroPath,
         intro_path: introPath,
+        clean_fillers: cleanFillers,
+        keep_caption_overlay: keepCaptionOverlay,
         face_map: uiState.transcript?.face_map,
       },
       (event) => {
-        job.progress = event.percent;
+        const progress = advanceProgress(job, event.percent);
         job.message = event.message;
         historyRecorder.recordProgress(event);
+        const clipResult = event.clip_result
+          ? tagSubmittedClip(event.clip_result, styledClips)
+          : undefined;
+        if (event.stage === "clip_complete" && clipResult) {
+          (job.clip_results ??= []).push(clipResult);
+        }
         broadcastSSE("job-update", {
           jobId,
-          progress: event.percent,
+          progress,
           message: event.message,
+          stage: event.stage,
+          clip_result: clipResult,
         });
       },
     )
     .then(async (result) => {
+      const data = tagSubmittedClips(result.data, styledClips);
       job.status = "done";
       job.progress = 100;
       job.message = "Export complete!";
-      job.result = result.data;
+      job.result = data;
       // Record clips to history
       try {
         await historyRecorder.recordRemaining(result.data?.results);
@@ -3471,7 +3698,7 @@ app.post("/api/mcp/export", async (req, res) => {
         });
       }
       setExportState("done", null);
-      broadcastSSE("job-complete", { jobId, result: result.data });
+      broadcastSSE("job-complete", { jobId, result: data });
     })
     .catch((err) => {
       job.status = "error";
@@ -3513,8 +3740,10 @@ async function main() {
 
   // SPA fallback: client-side routes (/, /episode, /clip/:id) resolve to the
   // built index.html. Registered last so it never shadows /api or static assets.
+  // root: the install path can contain a dot segment (a global npm install under
+  // ~/.nvm, say), and sendFile's dotfile rule would 404 the whole app.
   app.get(/^(?!\/api\/).*/, (_req, res) => {
-    res.sendFile(join(publicDir, "index.html"));
+    res.sendFile("index.html", { root: publicDir });
   });
 
   // Bind to loopback by default — the studio serves local files (clips, assets,
@@ -3525,7 +3754,7 @@ async function main() {
   });
   server.on("error", (err: NodeJS.ErrnoException) => {
     if (err.code === "EADDRINUSE") {
-      log.error(`Port ${PORT} is already in use — is the studio already running? Set PORT to use another.`);
+      log.error(`Port ${PORT} is already in use — is the studio already running? Set PODCLI_PORT to use another.`);
     } else {
       log.error("Web server failed to start", { err: err.message });
     }

--- a/src/utils/atomic-file.test.ts
+++ b/src/utils/atomic-file.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, readFileSync, readdirSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { writeFileAtomic, writeFileAtomicSync } from "./atomic-file.js";
+
+const dir = mkdtempSync(join(tmpdir(), "podcli-atomic-"));
+
+describe("atomic-file", () => {
+  it("writes a new file synchronously", () => {
+    const p = join(dir, "sync.json");
+    writeFileAtomicSync(p, '{"a":1}');
+    expect(readFileSync(p, "utf-8")).toBe('{"a":1}');
+  });
+
+  it("replaces an existing file synchronously", () => {
+    const p = join(dir, "replace.json");
+    writeFileAtomicSync(p, "old");
+    writeFileAtomicSync(p, "new");
+    expect(readFileSync(p, "utf-8")).toBe("new");
+  });
+
+  it("writes asynchronously", async () => {
+    const p = join(dir, "async.json");
+    await writeFileAtomic(p, "async-data");
+    expect(readFileSync(p, "utf-8")).toBe("async-data");
+  });
+
+  it("leaves no temp files behind", async () => {
+    const p = join(dir, "clean.json");
+    writeFileAtomicSync(p, "1");
+    await writeFileAtomic(p, "2");
+    expect(readdirSync(dir).filter((f) => f.endsWith(".tmp"))).toEqual([]);
+  });
+
+  it("cleans up the temp file when the rename target is invalid", async () => {
+    const target = join(dir, "missing-dir", "x.json");
+    await expect(writeFileAtomic(target, "data")).rejects.toThrow();
+    expect(existsSync(target)).toBe(false);
+    expect(readdirSync(dir).filter((f) => f.endsWith(".tmp"))).toEqual([]);
+  });
+});

--- a/src/utils/atomic-file.ts
+++ b/src/utils/atomic-file.ts
@@ -1,0 +1,33 @@
+import { writeFileSync, renameSync, rmSync } from "fs";
+import { writeFile, rename, rm } from "fs/promises";
+import { randomUUID } from "crypto";
+
+// Write to a temp file and atomically rename so a crash or a concurrent
+// reader never sees a half-written file.
+function tmpPathFor(filePath: string): string {
+  return `${filePath}.${process.pid}.${randomUUID().slice(0, 8)}.tmp`;
+}
+
+export function writeFileAtomicSync(filePath: string, data: string): void {
+  const tmp = tmpPathFor(filePath);
+  try {
+    writeFileSync(tmp, data, "utf-8");
+    renameSync(tmp, filePath);
+  } catch (err) {
+    try {
+      rmSync(tmp, { force: true });
+    } catch {}
+    throw err;
+  }
+}
+
+export async function writeFileAtomic(filePath: string, data: string): Promise<void> {
+  const tmp = tmpPathFor(filePath);
+  try {
+    await writeFile(tmp, data, "utf-8");
+    await rename(tmp, filePath);
+  } catch (err) {
+    await rm(tmp, { force: true }).catch(() => {});
+    throw err;
+  }
+}

--- a/src/utils/clip-results.test.ts
+++ b/src/utils/clip-results.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { advanceProgress, tagSubmittedClip, tagSubmittedClips } from "./clip-results.js";
+import type { BatchClipsResult } from "../models/index.js";
+
+const specs = [
+  { start_second: 120, end_second: 165 },
+  { start_second: 640, end_second: 700 },
+];
+
+describe("tagSubmittedClip", () => {
+  it("stamps the bounds of the clip that was submitted at that index", () => {
+    const row = tagSubmittedClip(
+      { clip_index: 1, status: "success", output_path: "/out/b.mp4" },
+      specs,
+    );
+    expect(row.source_start_second).toBe(640);
+    expect(row.source_end_second).toBe(700);
+  });
+
+  // The renderer trims weak openings, so the row's own start_second is the
+  // rendered start, not the requested one.
+  it("keeps the submitted bounds even when the render moved start_second", () => {
+    const row = tagSubmittedClip(
+      { clip_index: 0, status: "success", start_second: 123.4, end_second: 165 },
+      specs,
+    );
+    expect(row.start_second).toBe(123.4);
+    expect(row.source_start_second).toBe(120);
+  });
+
+  it("leaves rows alone when there is no matching spec", () => {
+    expect(tagSubmittedClip({ status: "success" }, specs).source_start_second).toBeUndefined();
+    expect(tagSubmittedClip({ clip_index: 9, status: "success" }, specs).source_start_second).toBeUndefined();
+    expect(tagSubmittedClip({ clip_index: 0, status: "success" }).source_start_second).toBeUndefined();
+  });
+
+  it("stamps error rows too", () => {
+    const row = tagSubmittedClip(
+      { clip_index: 1, status: "error", error: "ffmpeg died" },
+      specs,
+    );
+    expect(row.source_start_second).toBe(640);
+  });
+});
+
+describe("tagSubmittedClips", () => {
+  it("stamps every row of the final result", () => {
+    const data: BatchClipsResult = {
+      total_clips: 2,
+      successful_clips: 1,
+      results: [
+        { clip_index: 0, status: "success", output_path: "/out/a.mp4" },
+        { clip_index: 1, status: "error", error: "boom" },
+      ],
+    };
+    const tagged = tagSubmittedClips(data, specs);
+    expect(tagged?.results.map((r) => r.source_start_second)).toEqual([120, 640]);
+  });
+
+  it("passes undefined data through", () => {
+    expect(tagSubmittedClips(undefined, specs)).toBeUndefined();
+  });
+});
+
+describe("advanceProgress", () => {
+  // Parallel workers each report their own share, so percentages arrive out of order.
+  it("never lets progress run backwards", () => {
+    const job = { progress: 0 };
+    expect(advanceProgress(job, 50)).toBe(50);
+    expect(advanceProgress(job, 12)).toBe(50);
+    expect(advanceProgress(job, 75)).toBe(75);
+    expect(job.progress).toBe(75);
+  });
+});

--- a/src/utils/clip-results.ts
+++ b/src/utils/clip-results.ts
@@ -1,0 +1,42 @@
+import type { BatchClipsResult } from "../models/index.js";
+
+type ClipResultRow = BatchClipsResult["results"][number];
+export type ClipBounds = { start_second: number; end_second: number };
+
+// Python numbers its result rows by position in the clips array it was handed,
+// which for an agent-driven export is not the studio's clip order. Stamp each row
+// with the bounds of the clip that was submitted for it so the client can match a
+// result to its own clip instead of trusting the index. The rendered start_second
+// can't stand in for that: the renderer trims weak openings and reports the
+// trimmed value.
+export function tagSubmittedClip(
+  row: ClipResultRow,
+  clipSpecs?: ClipBounds[],
+): ClipResultRow {
+  const spec =
+    typeof row.clip_index === "number" ? clipSpecs?.[row.clip_index] : undefined;
+  if (!spec) return row;
+  return {
+    ...row,
+    source_start_second: spec.start_second,
+    source_end_second: spec.end_second,
+  };
+}
+
+export function tagSubmittedClips(
+  data: BatchClipsResult | undefined,
+  clipSpecs?: ClipBounds[],
+): BatchClipsResult | undefined {
+  if (!data?.results) return data;
+  return {
+    ...data,
+    results: data.results.map((row) => tagSubmittedClip(row, clipSpecs)),
+  };
+}
+
+// Clips render in parallel, so each worker reports its own share of the batch and
+// the percentages arrive out of order. Only ever move the bar forward.
+export function advanceProgress(job: { progress: number }, percent: number): number {
+  if (typeof percent === "number" && percent > job.progress) job.progress = percent;
+  return job.progress;
+}

--- a/src/utils/clip-validation.test.ts
+++ b/src/utils/clip-validation.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { validateClipRange, validateSuggestionRange, maxClipSeconds } from "./clip-validation.js";
+
+describe("validateClipRange", () => {
+  it("accepts a normal vertical clip", () => {
+    expect(validateClipRange(10, 40)).toBeNull();
+  });
+
+  it("rejects non-numbers", () => {
+    expect(validateClipRange("10" as unknown, 40)).toMatch(/must be numbers/);
+    expect(validateClipRange(10, NaN)).toMatch(/must be numbers/);
+    expect(validateClipRange(undefined, undefined)).toMatch(/must be numbers/);
+  });
+
+  it("rejects negative start", () => {
+    expect(validateClipRange(-1, 20)).toMatch(/>= 0/);
+  });
+
+  it("rejects end <= start", () => {
+    expect(validateClipRange(30, 30)).toMatch(/greater than start_second/);
+    expect(validateClipRange(30, 10)).toMatch(/greater than start_second/);
+  });
+
+  it("caps vertical clips at 180s and horizontal at 300s", () => {
+    expect(validateClipRange(0, 180)).toBeNull();
+    expect(validateClipRange(0, 181)).toMatch(/Max 180 seconds/);
+    expect(validateClipRange(0, 300, "horizontal")).toBeNull();
+    expect(validateClipRange(0, 301, "horizontal")).toMatch(/Max 300 seconds/);
+  });
+
+  it("maxClipSeconds matches the range check", () => {
+    expect(maxClipSeconds()).toBe(180);
+    expect(maxClipSeconds("vertical")).toBe(180);
+    expect(maxClipSeconds("horizontal")).toBe(300);
+  });
+});
+
+describe("validateSuggestionRange", () => {
+  it("accepts ranges longer than render limits", () => {
+    expect(validateSuggestionRange(0, 400)).toBeNull();
+  });
+
+  it("rejects end <= start", () => {
+    expect(validateSuggestionRange(50, 50)).toMatch(/greater than start_second/);
+  });
+
+  it("rejects absurdly long ranges", () => {
+    expect(validateSuggestionRange(0, 601)).toMatch(/Max 600 seconds/);
+  });
+
+  it("rejects non-numbers", () => {
+    expect(validateSuggestionRange(null, 10)).toMatch(/must be numbers/);
+  });
+});

--- a/src/utils/clip-validation.ts
+++ b/src/utils/clip-validation.ts
@@ -1,0 +1,47 @@
+export function maxClipSeconds(format?: string): number {
+  return format === "horizontal" ? 300 : 180;
+}
+
+/** Returns an error message, or null when the range is renderable. */
+export function validateClipRange(
+  start: unknown,
+  end: unknown,
+  format?: string,
+): string | null {
+  if (
+    typeof start !== "number" ||
+    !Number.isFinite(start) ||
+    typeof end !== "number" ||
+    !Number.isFinite(end)
+  ) {
+    return "start_second and end_second must be numbers";
+  }
+  if (start < 0) return "start_second must be >= 0";
+  if (end <= start) return "end_second must be greater than start_second";
+  const maxDur = maxClipSeconds(format);
+  if (end - start > maxDur) {
+    return `Clip too long (${Math.round(end - start)}s). Max ${maxDur} seconds.`;
+  }
+  return null;
+}
+
+// Suggestions aren't bound to a format yet, so allow up to the longest
+// renderable duration plus trim headroom.
+const MAX_SUGGESTION_SECONDS = 600;
+
+export function validateSuggestionRange(start: unknown, end: unknown): string | null {
+  if (
+    typeof start !== "number" ||
+    !Number.isFinite(start) ||
+    typeof end !== "number" ||
+    !Number.isFinite(end)
+  ) {
+    return "start_second and end_second must be numbers";
+  }
+  if (start < 0) return "start_second must be >= 0";
+  if (end <= start) return "end_second must be greater than start_second";
+  if (end - start > MAX_SUGGESTION_SECONDS) {
+    return `Suggested range too long (${Math.round(end - start)}s). Max ${MAX_SUGGESTION_SECONDS} seconds.`;
+  }
+  return null;
+}

--- a/tests/test_server_port.py
+++ b/tests/test_server_port.py
@@ -1,0 +1,41 @@
+"""Studio port resolution — must stay identical to src/config/server.ts."""
+
+import os
+import re
+import sys
+import unittest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BACKEND_ROOT = os.path.join(ROOT, "backend")
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+from config.server import DEFAULT_PORT, resolve_web_server_port, web_server_url
+
+
+class WebServerPortTests(unittest.TestCase):
+    def test_defaults_to_3847(self):
+        self.assertEqual(DEFAULT_PORT, 3847)
+        self.assertEqual(resolve_web_server_port({}), 3847)
+
+    def test_reads_podcli_port_first(self):
+        self.assertEqual(resolve_web_server_port({"PODCLI_PORT": "4000", "PORT": "5000"}), 4000)
+
+    def test_falls_back_to_port(self):
+        self.assertEqual(resolve_web_server_port({"PORT": "5000"}), 5000)
+
+    def test_rejects_garbage_and_out_of_range(self):
+        for raw in ("banana", "", "0", "70000", "-1"):
+            self.assertEqual(resolve_web_server_port({"PORT": raw}), 3847, raw)
+
+    def test_url_uses_resolved_port(self):
+        self.assertEqual(web_server_url({"PODCLI_PORT": "4000"}), "http://localhost:4000")
+
+    def test_typescript_resolver_agrees(self):
+        ts = open(os.path.join(ROOT, "src", "config", "server.ts"), encoding="utf-8").read()
+        self.assertIn("env.PODCLI_PORT || env.PORT", ts)
+        self.assertTrue(re.search(r":\s*3847\s*;", ts))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every agent-driven render silently skipped filler and dead-air removal: the
export route dropped the flag, and the tool schema never even accepted the
one its own docs promised.

- clean_fillers and keep_caption_overlay flow through, falling back to the
  studio's own toggle rather than a hardcoded default
- PODCLI_PORT works end to end, replacing ~31 hardcoded call sites, so the
  advice in the port-conflict error is now true
- ui-state, corrections, and integrations write atomically, so a crash no
  longer resets a session to defaults
- Terminal jobs evict, subprocesses time out, and kill escalation cannot
  signal a recycled pid
- Clip results carry the submitted bounds, so out-of-order parallel results
  land on the right clips and progress cannot run backwards
- Horizontal batches validate against the horizontal cap

Part of the product audit. Stacked on `audit-4-captions`, so review only this PR's diff and merge in order.