### PR TITLE
Make clip review trustworthy and keyboard accessible

### DIFF
--- a/src/ui/client/ConfirmDialog.tsx
+++ b/src/ui/client/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { createPortal } from "react-dom";
+import { useDialog } from "./useDialog";
 
 export default function ConfirmDialog({
   open,
@@ -18,10 +19,19 @@ export default function ConfirmDialog({
   onConfirm: () => void;
   onCancel: () => void;
 }) {
+  const dialogRef = useDialog(open, onCancel);
   if (!open) return null;
   return createPortal(
     <div className="modal-overlay" onClick={onCancel}>
-      <div className="modal-body confirm-dialog" onClick={(e) => e.stopPropagation()}>
+      <div
+        ref={dialogRef}
+        className="modal-body confirm-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+      >
         <h3>{title}</h3>
         {message && <p>{message}</p>}
         <div className="confirm-actions">

--- a/src/ui/client/EpisodeWorkspace.jsx
+++ b/src/ui/client/EpisodeWorkspace.jsx
@@ -31,7 +31,7 @@ import MomentTrim from './MomentTrim';
 import { useDialog } from './useDialog';
 import { PageHeader } from './Page';
 import { buildPreviewChunks, activePreviewChunk, selectPreviewWords } from './captionChunks';
-import { findClipResult, resultBoundsKey } from './lib';
+import { findClipResult, resultBoundsKey, clipKey, buildEnergyMap, dropEnergy, clampClipIndex } from './lib';
 
 const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
 const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
@@ -290,7 +290,7 @@ const onKeyActivate = (fn) => (e) => {
       return <div style={{ whiteSpace: 'normal' }}>{inner}</div>;
     }
 
-    function LivePhonePreview({ videoUrl, videoRef, captionStyle, activeClip, transcriptWords, logoPath, previewSrc, showTikTokFrame, onToggleFrame, clipEnded, onReplay }) {
+    function LivePhonePreview({ videoUrl, videoRef, captionStyle, activeClip, transcriptWords, logoPath, showTikTokFrame, onToggleFrame, clipEnded, onReplay }) {
       const cfg = STYLE_CONFIGS[captionStyle] || STYLE_CONFIGS.branded;
       const [logoBroken, setLogoBroken] = useState(false);
       useEffect(() => { setLogoBroken(false); }, [logoPath]);
@@ -362,8 +362,7 @@ const onKeyActivate = (fn) => (e) => {
           <div className="phone-notch" />
           {videoUrl ? (
             <video key={videoUrl} ref={videoRef} src={videoUrl}
-              muted playsInline preload="auto"
-              className={previewSrc ? '' : ''} />
+              muted playsInline preload="auto" />
           ) : (
             <div className="phone-empty">
               <div style={{ opacity: 0.4, display: 'flex' }}><Play size={22} /></div>
@@ -617,7 +616,7 @@ const onKeyActivate = (fn) => (e) => {
       }, [exportMenuOpen]);
 
       // Energy analysis
-      const [energyData, setEnergyData] = useState({}); // clip_id → { peak, avg, level }
+      const [energyData, setEnergyData] = useState({}); // clipKey(clip) → { score, level }
       const [analyzingEnergy, setAnalyzingEnergy] = useState(false);
 
       // Auto-transcribe + cache
@@ -718,17 +717,22 @@ const onKeyActivate = (fn) => (e) => {
 
       const saveClipEdit = () => {
         if (editingClip === null || editForm.end <= editForm.start) return;
+        const edited = suggestions[editingClip];
+        const reTimed = edited && (edited.start_second !== editForm.start || edited.end_second !== editForm.end);
         setSuggestions(prev => {
           const next = [...prev];
           next[editingClip] = { ...next[editingClip], title: editForm.title, start_second: editForm.start, end_second: editForm.end, duration: Math.round(editForm.end - editForm.start), segments: undefined };
           return next;
         });
+        // The score was measured over the old range, so it no longer describes this clip.
+        if (reTimed) setEnergyData(prev => dropEnergy(prev, edited));
         setEditingClip(null);
       };
 
       const deleteClipEdit = () => {
         if (editingClip === null) return;
         if (!confirm(`Delete clip "${editForm.title}" from this batch?`)) return;
+        const removed = suggestions[editingClip];
         setSuggestions(prev => prev.filter((_, i) => i !== editingClip));
         setDeselected(prev => {
           const next = new Set();
@@ -738,27 +742,20 @@ const onKeyActivate = (fn) => (e) => {
           }
           return next;
         });
+        if (removed) setEnergyData(prev => dropEnergy(prev, removed));
         setEditingClip(null);
       };
 
       // Energy analysis
       const analyzeEnergy = async () => {
         setAnalyzingEnergy(true);
+        const analyzed = suggestions;
         try {
-          const segments = suggestions.map(c => ({ start: c.start_second, end: c.end_second }));
+          const segments = analyzed.map(c => ({ start: c.start_second, end: c.end_second }));
           const vp = file?.file_path || videoPath.trim();
           const d = await api('/analyze-energy', { method: 'POST', body: JSON.stringify({ video_path: vp, segments }) });
           // Backend returns { segment_scores: [0-10, ...], peak_times: [...] }
-          if (d.segment_scores && Array.isArray(d.segment_scores)) {
-            const map = {};
-            d.segment_scores.forEach((score, i) => {
-              if (suggestions[i]) {
-                const level = score >= 7 ? 'high' : score >= 4 ? 'medium' : 'low';
-                map[i] = { score: score, level };
-              }
-            });
-            setEnergyData(map);
-          }
+          if (Array.isArray(d.segment_scores)) setEnergyData(buildEnergyMap(d.segment_scores, analyzed));
         } catch {}
         finally { setAnalyzingEnergy(false); }
       };
@@ -896,16 +893,8 @@ const onKeyActivate = (fn) => (e) => {
 
         if (sseEvent.type === 'state-sync' || sseEvent.type === 'state') {
           const d = sseEvent.data;
-          if (d.suggestions) {
-            const sameClips = suggestions.length === d.suggestions.length &&
-              d.suggestions.every((c, i) => {
-                const p = suggestions[i];
-                return p && p.id === c.id && p.start_second === c.start_second && p.end_second === c.end_second;
-              });
-            setSuggestions(d.suggestions);
-            if (d.energyData !== undefined) setEnergyData(d.energyData || {});
-            else if (!sameClips) setEnergyData({});
-          }
+          if (d.suggestions) setSuggestions(d.suggestions);
+          if (d.energyData !== undefined) setEnergyData(d.energyData || {});
           if (d.deselectedIndices !== undefined) setDeselected(new Set(d.deselectedIndices));
           else if (d.suggestions && !d.deselectedIndices) setDeselected(new Set());
           if (d.phase) setPhase(d.phase);
@@ -949,9 +938,9 @@ const onKeyActivate = (fn) => (e) => {
             setBatchJobId(null);
           }
         }
-        // phase/transcript/suggestions are read above; the ts-guard makes re-runs
-        // on their change a no-op, so depending on them just keeps the reads fresh.
-      }, [sseEvent, phase, transcript, suggestions, applyClipResult]);
+        // phase/transcript are read above; the ts-guard makes re-runs on their
+        // change a no-op, so depending on them just keeps the reads fresh.
+      }, [sseEvent, phase, transcript, applyClipResult]);
 
       // Preview panel state
       const videoRef = useRef();
@@ -961,6 +950,12 @@ const onKeyActivate = (fn) => (e) => {
       const [clipEnded, setClipEnded] = useState(false);
 
       const activeClip = activeClipIdx !== null ? suggestions[activeClipIdx] : null;
+
+      // An agent can delete a clip out from under the cursor, leaving it on a row
+      // that no longer exists — space would then deselect an index nobody owns.
+      useEffect(() => {
+        setActiveClipIdx(prev => clampClipIndex(prev, suggestions.length));
+      }, [suggestions.length]);
 
       // Video source URL
       const videoUrl = previewSrc
@@ -1185,7 +1180,9 @@ const onKeyActivate = (fn) => (e) => {
       }, [retryStream?.status]);
 
       const toggleClip = (i) => setDeselected(prev => { const n = new Set(prev); n.has(i) ? n.delete(i) : n.add(i); return n; });
-      const selectedCount = suggestions.length - deselected.size;
+      const selectedClips = suggestions.filter((_, i) => !deselected.has(i));
+      const selectedCount = selectedClips.length;
+      const clipRowRefs = useRef([]);
 
       // Keyboard shortcuts: j/k move clip selection, space toggles include, e edits
       useEffect(() => {
@@ -1204,12 +1201,14 @@ const onKeyActivate = (fn) => (e) => {
           if (key === 'j' || key === 'k') {
             e.preventDefault();
             setPreviewSrc(null);
-            setActiveClipIdx(prev => {
-              const cur = prev === null ? -1 : prev;
-              return key === 'j'
-                ? Math.min(cur + 1, suggestions.length - 1)
-                : Math.max(cur - 1, 0);
-            });
+            const cur = activeClipIdx === null ? -1 : activeClipIdx;
+            const next = key === 'j'
+              ? Math.min(cur + 1, suggestions.length - 1)
+              : Math.max(cur - 1, 0);
+            setActiveClipIdx(next);
+            // Without this the focus ring, the highlight, and what Enter
+            // re-activates drift onto different rows.
+            clipRowRefs.current[next]?.focus();
           } else if (key === ' ') {
             if (phase !== 'review' || activeClipIdx === null) return;
             e.preventDefault();
@@ -1315,7 +1314,7 @@ const onKeyActivate = (fn) => (e) => {
           if (data.clips && data.clips.length > 0) {
             // Claude returned suggestions — populate directly
             const mapped = data.clips.map((c, i) => ({
-              id: `claude-${i}`,
+              clip_id: `claude-${i}`,
               title: c.title,
               start_second: c.start_second,
               end_second: c.end_second,
@@ -1358,7 +1357,6 @@ const onKeyActivate = (fn) => (e) => {
 
       const isProcessing = phase === 'parsing' || phase === 'suggesting' || phase === 'exporting' || transcribing || downloadingVideo;
       const sourceIsUrl = isHttpUrl(videoPath);
-      const selectedClips = suggestions.filter((_, i) => !deselected.has(i));
       const exportStats = phase === 'done' ? {
         total: results.length || selectedClips.length,
         ok: results.filter(r => r?.status === 'success').length,
@@ -1898,9 +1896,11 @@ const onKeyActivate = (fn) => (e) => {
                     const isRetryingThis = retryIdx === resultIdx;
                     const exportStatus = !off ? getExportStatus(clip, resultIdx) : null;
                     const isSelected = activeClipIdx === i && !previewSrc;
+                    const energy = energyData[clipKey(clip)];
 
                     return (
                       <div key={i} data-clip-row
+                        ref={el => { clipRowRefs.current[i] = el; }}
                         className={`clip-item ${off && phase === 'review' ? 'dimmed' : ''} ${phase === 'suggesting' ? 'clip-reveal' : ''} ${isSelected ? 'selected' : ''}`}
                         role="button" tabIndex={0} aria-label={`Preview clip: ${clip.title}`}
                         onClick={() => onClipClick(i)}
@@ -1930,9 +1930,9 @@ const onKeyActivate = (fn) => (e) => {
                           <div className="clip-title">{clip.title}</div>
                           <div className="clip-meta">
                             {fmt(clip.start_second)} {'\u2192'} {fmt(clip.end_second)} {'\u00B7'} {clip.duration}s
-                            {energyData[i] && (
-                              <span className={`energy-badge ${energyData[i].level}`} title={`Energy: ${energyData[i].score}/10`}>
-                                {energyData[i].level === 'high' ? <Activity size={10} /> : energyData[i].level === 'medium' ? '~' : '○'} {energyData[i].score.toFixed(1)}
+                            {energy && (
+                              <span className={`energy-badge ${energy.level}`} title={`Energy: ${energy.score}/10`}>
+                                {energy.level === 'high' ? <Activity size={10} /> : energy.level === 'medium' ? '~' : '○'} {energy.score.toFixed(1)}
                               </span>
                             )}
                             {r && !failed && <span> {'\u00B7'} {r.file_size_mb}MB</span>}
@@ -2102,7 +2102,8 @@ const onKeyActivate = (fn) => (e) => {
                   </div>
                 )}
 
-                {/* Style preview mockup — hidden when rendered clip is playing */}
+                {/* Style preview mockup — hidden when rendered clip is playing, whose
+                    captions are already burned in and whose clock is clip-relative */}
                 {!previewSrc && (
                   <LivePhonePreview
                     videoUrl={videoUrl}
@@ -2111,7 +2112,6 @@ const onKeyActivate = (fn) => (e) => {
                     activeClip={activeClip}
                     transcriptWords={transcript ? transcript.words : null}
                     logoPath={logoPath}
-                    previewSrc={previewSrc}
                     showTikTokFrame={showTikTokFrame}
                     onToggleFrame={() => setShowTikTokFrame(v => !v)}
                     clipEnded={clipEnded}

--- a/src/ui/client/EpisodeWorkspace.jsx
+++ b/src/ui/client/EpisodeWorkspace.jsx
@@ -30,7 +30,7 @@ import RecentSources from './RecentSources';
 import MomentTrim from './MomentTrim';
 import { useDialog } from './useDialog';
 import { PageHeader } from './Page';
-import { buildPreviewChunks, activePreviewChunk } from './captionChunks';
+import { buildPreviewChunks, activePreviewChunk, selectPreviewWords } from './captionChunks';
 import { findClipResult, resultBoundsKey } from './lib';
 
 const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
@@ -295,21 +295,9 @@ const onKeyActivate = (fn) => (e) => {
       const [logoBroken, setLogoBroken] = useState(false);
       useEffect(() => { setLogoBroken(false); }, [logoPath]);
 
-      // Pull all transcribed words from the active clip (or first N from the
-      // whole transcript). The chunker decides how many show at once.
       const sourcePool = useMemo(() => {
-        if (!transcriptWords || !transcriptWords.length) return null;
-        let pool = transcriptWords;
-        if (activeClip) {
-          pool = transcriptWords.filter(w =>
-            w.end > activeClip.start_second && w.start < activeClip.end_second
-          );
-        }
-        if (!pool.length) return null;
-        const out = pool.slice(0, 80)
-          .map(w => ({ text: (w.word || w.text || '').trim(), start: w.start, end: w.end, speaker: w.speaker }))
-          .filter(w => w.text);
-        return out.length >= 2 ? out : null;
+        const words = selectPreviewWords(transcriptWords, activeClip);
+        return words.length >= 2 ? words : null;
       }, [activeClip, transcriptWords]);
 
       const usingSample = !sourcePool;

--- a/src/ui/client/EpisodeWorkspace.jsx
+++ b/src/ui/client/EpisodeWorkspace.jsx
@@ -27,10 +27,17 @@ import {
 import CopyButton from './CopyButton';
 import AssetPicker from './AssetPicker';
 import RecentSources from './RecentSources';
+import MomentTrim from './MomentTrim';
+import { useDialog } from './useDialog';
 import { PageHeader } from './Page';
+import { buildPreviewChunks, activePreviewChunk } from './captionChunks';
+import { findClipResult, resultBoundsKey } from './lib';
 
 const fmt = (s) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, '0')}`;
 const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
+const onKeyActivate = (fn) => (e) => {
+  if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); fn(e); }
+};
     const api = async (path, opts = {}) => {
       const res = await fetch(`/api${path}`, { headers: { 'Content-Type': 'application/json', ...opts.headers }, ...opts });
       let body = null;
@@ -96,7 +103,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       branded: {
         fontSize: px(100), fontWeight: 700, bottom: PROD_TO_PCT(420),
         lineHeight: 1.2, uppercase: false,
-        wordsPerChunk: 3, maxCharsPerChunk: 18, splitLines: true,
+        wordsPerChunk: 3, maxCharsPerChunk: 18, splitTail: true, splitLines: true,
         color: '#fff', activeColor: '#fff',
         activePill: { background: 'rgba(0,0,0,0.85)', borderRadius: 8, paddingX: 8 },
         chunkBg: null, gradient: true,
@@ -105,7 +112,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       hormozi: {
         fontSize: px(90), fontWeight: 800, bottom: PROD_TO_PCT(400),
         lineHeight: 1.2, uppercase: true,
-        wordsPerChunk: 3, maxCharsPerChunk: 22, splitLines: false,
+        wordsPerChunk: 3, absorbTail: 1, splitLines: false,
         color: '#fff', activeColor: '#ffff00',
         activePill: null,
         chunkBg: { background: 'rgba(0,0,0,0.8)', borderRadius: 5, paddingX: 10, paddingY: 5 },
@@ -115,7 +122,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       karaoke: {
         fontSize: px(80), fontWeight: 600, bottom: PROD_TO_PCT(400),
         lineHeight: 1.25, uppercase: false,
-        wordsPerChunk: 5, maxCharsPerChunk: 28, splitLines: false,
+        wordsPerChunk: 5, absorbTail: 1, splitLines: false,
         color: 'rgba(255,255,255,0.4)', activeColor: '#fff',
         activePill: null, chunkBg: null, gradient: false,
         sample: ['the', 'secret', 'to', 'building', 'something'],
@@ -123,31 +130,13 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       subtle: {
         fontSize: px(64), fontWeight: 400, bottom: PROD_TO_PCT(200),
         lineHeight: 1.3, uppercase: false,
-        wordsPerChunk: 6, maxCharsPerChunk: 36, splitLines: false,
+        wordsPerChunk: 6, absorbTail: 2, splitLines: false,
         color: 'rgba(255,255,255,0.95)', activeColor: 'rgba(255,255,255,0.95)',
         activePill: null, chunkBg: null, gradient: false,
         sample: ['the', 'secret', 'to', 'building', 'something', 'people'],
       },
     };
 
-    function buildPreviewChunks(words, perChunk, maxChars) {
-      const out = [];
-      let i = 0;
-      while (i < words.length) {
-        let end = i, count = 0;
-        while (end < words.length && end - i < perChunk) {
-          const w = words[end];
-          const next = count === 0 ? w.length : count + 1 + w.length;
-          if (end > i && maxChars && next > maxChars) break;
-          count = next; end++;
-        }
-        if (end === i) end = i + 1;
-        if (words.length - end === 1 && end - i > 2) end -= 1;
-        out.push(words.slice(i, end));
-        i = end;
-      }
-      return out;
-    }
     function splitBrandedLines(chunk) {
       if (chunk.length <= 2) return [chunk, []];
       return [chunk.slice(0, 2), chunk.slice(2)];
@@ -301,7 +290,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       return <div style={{ whiteSpace: 'normal' }}>{inner}</div>;
     }
 
-    function LivePhonePreview({ videoUrl, videoRef, captionStyle, activeClip, transcriptWords, logoPath, previewSrc, showTikTokFrame, onToggleFrame }) {
+    function LivePhonePreview({ videoUrl, videoRef, captionStyle, activeClip, transcriptWords, logoPath, previewSrc, showTikTokFrame, onToggleFrame, clipEnded, onReplay }) {
       const cfg = STYLE_CONFIGS[captionStyle] || STYLE_CONFIGS.branded;
       const [logoBroken, setLogoBroken] = useState(false);
       useEffect(() => { setLogoBroken(false); }, [logoPath]);
@@ -317,42 +306,67 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
           );
         }
         if (!pool.length) return null;
-        const out = pool.slice(0, 80).map(w => (w.word || w.text || '').trim()).filter(Boolean);
+        const out = pool.slice(0, 80)
+          .map(w => ({ text: (w.word || w.text || '').trim(), start: w.start, end: w.end, speaker: w.speaker }))
+          .filter(w => w.text);
         return out.length >= 2 ? out : null;
       }, [activeClip, transcriptWords]);
 
       const usingSample = !sourcePool;
-      const poolWords = sourcePool || cfg.sample;
-
-      // Chunk the same way the Remotion renderer does. The active chunk
-      // is what appears on screen; the active word inside it gets the
-      // pill / accent color.
-      const chunks = useMemo(
-        () => buildPreviewChunks(poolWords, cfg.wordsPerChunk, cfg.maxCharsPerChunk),
-        [poolWords, cfg.wordsPerChunk, cfg.maxCharsPerChunk]
+      const poolWords = useMemo(
+        () => sourcePool || cfg.sample.map(text => ({ text, start: 0, end: 0 })),
+        [sourcePool, cfg.sample]
       );
 
-      const [cursor, setCursor] = useState(0); // global word index
+      const chunks = useMemo(
+        () => buildPreviewChunks(poolWords, cfg, activeClip?.end_second),
+        [poolWords, cfg, activeClip]
+      );
+
+      // Real timings drive the captions off the video clock, the way the renderer
+      // does. Sample words carry no timings, so they cycle on an interval instead.
+      const timed = !usingSample && !!videoUrl;
+      const [cursor, setCursor] = useState(0); // sample mode: global word index
+      const [clock, setClock] = useState(0);
       useEffect(() => {
         setCursor(0);
+        setClock(0);
         if (poolWords.length <= 1) return;
+        if (timed) {
+          let raf;
+          const step = () => {
+            const v = videoRef?.current;
+            if (v) setClock(v.currentTime);
+            raf = requestAnimationFrame(step);
+          };
+          raf = requestAnimationFrame(step);
+          return () => cancelAnimationFrame(raf);
+        }
         const tick = captionStyle === 'karaoke' ? 320 : 420;
         const iv = setInterval(() => setCursor(i => (i + 1) % poolWords.length), tick);
         return () => clearInterval(iv);
-      }, [captionStyle, poolWords.length, poolWords[0]]);
+      }, [captionStyle, poolWords, timed]);
 
-      // Find which chunk the cursor is currently in, and which word within it.
-      let activeChunkIdx = 0, activeWordInChunk = 0, consumed = 0;
-      for (let ci = 0; ci < chunks.length; ci++) {
-        const len = chunks[ci].length;
-        if (cursor < consumed + len) {
-          activeChunkIdx = ci;
-          activeWordInChunk = cursor - consumed;
-          break;
+      let activeChunk = null, activeWordInChunk = 0;
+      if (timed) {
+        activeChunk = activePreviewChunk(chunks, clock) || null;
+        if (activeChunk) {
+          for (let k = 0; k < activeChunk.words.length; k++) {
+            if (activeChunk.words[k].start <= clock) activeWordInChunk = k;
+            else break;
+          }
         }
-        consumed += len;
+      } else {
+        let consumed = 0;
+        for (const chunk of chunks) {
+          if (cursor < consumed + chunk.words.length) {
+            activeChunk = chunk;
+            activeWordInChunk = cursor - consumed;
+            break;
+          }
+          consumed += chunk.words.length;
+        }
       }
-      const activeChunk = chunks[activeChunkIdx] || [];
 
       return (
        <>
@@ -369,9 +383,22 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
             </div>
           )}
           {videoUrl && cfg.gradient && <div className="phone-gradient" />}
+          {videoUrl && clipEnded && (
+            <button onClick={onReplay} aria-label="Replay clip"
+              style={{
+                position: 'absolute', inset: 0, margin: 'auto', width: 48, height: 48,
+                borderRadius: '50%', background: 'rgba(0,0,0,0.65)',
+                border: '1px solid rgba(255,255,255,0.35)', color: '#fff',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                cursor: 'pointer', zIndex: 6,
+              }}>
+              <RotateCcw size={18} />
+            </button>
+          )}
           {videoUrl && captionStyle === 'branded' && logoPath && !logoBroken && (
             <div className="phone-logo">
               <img src={`/api/stream-source?path=${encodeURIComponent(logoPath)}`}
+                alt="Logo"
                 onError={() => setLogoBroken(true)}
                 style={{ width: '100%', height: '100%', objectFit: 'contain' }} />
             </div>
@@ -384,7 +411,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
               fontFamily: "'DM Sans', 'Inter', Arial, sans-serif",
             }}>
               <PhoneCaptionBody
-                chunk={activeChunk}
+                chunk={activeChunk ? activeChunk.words.map(w => w.text) : null}
                 activeWordInChunk={activeWordInChunk}
                 cfg={cfg}
               />
@@ -471,7 +498,10 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
 
       return (
         <div className="mcp-hints">
-          <div className="mcp-hints-header" style={{ cursor: 'pointer' }} onClick={() => setCollapsed(!collapsed)}>
+          <div className="mcp-hints-header" style={{ cursor: 'pointer' }}
+            role="button" tabIndex={0} aria-expanded={!collapsed}
+            onClick={() => setCollapsed(!collapsed)}
+            onKeyDown={onKeyActivate(() => setCollapsed(v => !v))}>
             <div className="mcp-hints-icon">AI</div>
             <div className="mcp-hints-title">MCP prompts</div>
             <div className="mcp-hints-subtitle">
@@ -577,6 +607,26 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       // Clip editing
       const [editingClip, setEditingClip] = useState(null); // index
       const [editForm, setEditForm] = useState({ title: '', start: 0, end: 0 });
+      const [editDuration, setEditDuration] = useState(0);
+      const editDialogRef = useDialog(editingClip !== null, () => setEditingClip(null));
+      const previewDialogRef = useDialog(!!previewFile, () => setPreviewFile(null));
+
+      // Transcript export menu
+      const [exportMenuOpen, setExportMenuOpen] = useState(false);
+      const exportMenuRef = useRef(null);
+      useEffect(() => {
+        if (!exportMenuOpen) return;
+        const onDown = (e) => {
+          if (exportMenuRef.current && !exportMenuRef.current.contains(e.target)) setExportMenuOpen(false);
+        };
+        const onKey = (e) => { if (e.key === 'Escape') setExportMenuOpen(false); };
+        document.addEventListener('mousedown', onDown);
+        document.addEventListener('keydown', onKey);
+        return () => {
+          document.removeEventListener('mousedown', onDown);
+          document.removeEventListener('keydown', onKey);
+        };
+      }, [exportMenuOpen]);
 
       // Energy analysis
       const [energyData, setEnergyData] = useState({}); // clip_id → { peak, avg, level }
@@ -666,15 +716,20 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       };
 
       // Clip editing
-      const openClipEdit = (idx, e) => {
-        e.stopPropagation();
+      const openClipEdit = (idx) => {
         const clip = suggestions[idx];
+        if (!clip) return;
         setEditingClip(idx);
         setEditForm({ title: clip.title, start: clip.start_second, end: clip.end_second });
       };
 
+      const clampEditTime = (v) => {
+        const n = Number.isFinite(v) ? Math.max(0, v) : 0;
+        return editDuration ? Math.min(n, editDuration) : n;
+      };
+
       const saveClipEdit = () => {
-        if (editingClip === null) return;
+        if (editingClip === null || editForm.end <= editForm.start) return;
         setSuggestions(prev => {
           const next = [...prev];
           next[editingClip] = { ...next[editingClip], title: editForm.title, start_second: editForm.start, end_second: editForm.end, duration: Math.round(editForm.end - editForm.start), segments: undefined };
@@ -798,7 +853,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
           filePath: file?.file_path || '',
           suggestions,
           deselectedIndices: Array.from(deselected),
-          settings: { captionStyle, cropStrategy, format, logoPath, outroPath, introPath },
+          settings: { captionStyle, cropStrategy, format, logoPath, outroPath, introPath, cleanFillers },
           phase,
           results,
           energyData,
@@ -807,7 +862,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
         if (key === prevSyncRef.current) return;
         prevSyncRef.current = key;
         fetch('/api/ui-state', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: key }).catch(() => { });
-      }, [videoPath, file, suggestions, deselected, captionStyle, cropStrategy, format, logoPath, outroPath, introPath, phase, results, energyData]);
+      }, [videoPath, file, suggestions, deselected, captionStyle, cropStrategy, format, logoPath, outroPath, introPath, cleanFillers, phase, results, energyData]);
 
       // Sync transcript separately (large payload)
       const prevTranscriptRef = useRef(null);
@@ -829,6 +884,22 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
         }
       }, [transcriptText]);
 
+      const resultFor = useCallback(
+        (clip, resultIdx) => findClipResult(results, clip, resultIdx),
+        [results],
+      );
+
+      const applyClipResult = useCallback((row) => {
+        if (!row || typeof row.clip_index !== 'number') return;
+        setResults(prev => {
+          const cur = prev[row.clip_index];
+          if (cur && cur.status === row.status && cur.output_path === row.output_path) return prev;
+          const next = [...prev];
+          next[row.clip_index] = row;
+          return next;
+        });
+      }, []);
+
       // React to SSE events from MCP
       const lastHandledTsRef = useRef(0);
       useEffect(() => {
@@ -838,8 +909,14 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
         if (sseEvent.type === 'state-sync' || sseEvent.type === 'state') {
           const d = sseEvent.data;
           if (d.suggestions) {
+            const sameClips = suggestions.length === d.suggestions.length &&
+              d.suggestions.every((c, i) => {
+                const p = suggestions[i];
+                return p && p.id === c.id && p.start_second === c.start_second && p.end_second === c.end_second;
+              });
             setSuggestions(d.suggestions);
-            setEnergyData(sseEvent.type === 'state' && d.energyData ? d.energyData : {});
+            if (d.energyData !== undefined) setEnergyData(d.energyData || {});
+            else if (!sameClips) setEnergyData({});
           }
           if (d.deselectedIndices !== undefined) setDeselected(new Set(d.deselectedIndices));
           else if (d.suggestions && !d.deselectedIndices) setDeselected(new Set());
@@ -860,6 +937,7 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
             if (d.settings.logoPath !== undefined) setLogoPath(d.settings.logoPath);
             if (d.settings.outroPath !== undefined) setOutroPath(d.settings.outroPath);
             if (d.settings.introPath !== undefined) setIntroPath(d.settings.introPath);
+            if (d.settings.cleanFillers !== undefined) setCleanFillers(d.settings.cleanFillers !== false);
           }
           // Mark initialized after first state restoration so sync useEffects don't overwrite with defaults
           if (sseEvent.type === 'state') {
@@ -868,6 +946,8 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
         } else if (sseEvent.type === 'export-started') {
           setBatchJobId(sseEvent.data.jobId);
           setPhase('exporting');
+        } else if (sseEvent.type === 'job-update') {
+          if (sseEvent.data.clip_result) applyClipResult(sseEvent.data.clip_result);
         } else if (sseEvent.type === 'job-complete') {
           if (phase === 'exporting' || sseEvent.data.result?.results) {
             setPhase('done');
@@ -881,15 +961,18 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
             setBatchJobId(null);
           }
         }
-        // phase/transcript are read above; the ts-guard makes re-runs on their
-        // change a no-op, so depending on them just keeps the reads fresh.
-      }, [sseEvent, phase, transcript]);
+        // phase/transcript/suggestions are read above; the ts-guard makes re-runs
+        // on their change a no-op, so depending on them just keeps the reads fresh.
+      }, [sseEvent, phase, transcript, suggestions, applyClipResult]);
 
       // Preview panel state
       const videoRef = useRef();
       const [activeClipIdx, setActiveClipIdx] = useState(null);
       const [previewSrc, setPreviewSrc] = useState(null); // null=source, string=rendered clip filename
       const [settingsFlash, setSettingsFlash] = useState(null);
+      const [clipEnded, setClipEnded] = useState(false);
+
+      const activeClip = activeClipIdx !== null ? suggestions[activeClipIdx] : null;
 
       // Video source URL
       const videoUrl = previewSrc
@@ -898,18 +981,39 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
           ? `/api/stream-source?path=${encodeURIComponent(videoPath)}`
           : null;
 
-      // Seek to clip when active clip changes (and showing source)
+      // Seek to clip when active clip changes (and showing source), pause at
+      // its end boundary so the preview doesn't run into the rest of the episode
       useEffect(() => {
+        setClipEnded(false);
         if (activeClipIdx === null || previewSrc) return;
-        const clip = suggestions[activeClipIdx];
-        if (!clip || !videoRef.current) return;
+        const v = videoRef.current;
+        if (!activeClip || !v) return;
         const seek = () => {
-          videoRef.current.currentTime = clip.start_second;
-          videoRef.current.play().catch(() => { });
+          v.currentTime = activeClip.start_second;
+          v.play().catch(() => { });
         };
-        if (videoRef.current.readyState >= 1) seek();
-        else videoRef.current.addEventListener('loadedmetadata', seek, { once: true });
-      }, [activeClipIdx, previewSrc]);
+        if (v.readyState >= 1) seek();
+        else v.addEventListener('loadedmetadata', seek, { once: true });
+        const onTime = () => {
+          if (v.currentTime >= activeClip.end_second) {
+            v.pause();
+            setClipEnded(true);
+          }
+        };
+        v.addEventListener('timeupdate', onTime);
+        return () => {
+          v.removeEventListener('loadedmetadata', seek);
+          v.removeEventListener('timeupdate', onTime);
+        };
+      }, [activeClipIdx, previewSrc, activeClip?.start_second, activeClip?.end_second]);
+
+      const replayClip = () => {
+        const v = videoRef.current;
+        if (!v || !activeClip) return;
+        v.currentTime = activeClip.start_second;
+        setClipEnded(false);
+        v.play().catch(() => { });
+      };
 
       // Flash settings when they change
       const flashSetting = (key) => {
@@ -1045,13 +1149,22 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       };
 
       useEffect(() => {
+        if (!batchStream) return;
+        const rows = Array.isArray(batchStream.clip_results)
+          ? batchStream.clip_results
+          : batchStream.clip_result ? [batchStream.clip_result] : [];
+        rows.forEach(applyClipResult);
+      }, [batchStream, applyClipResult]);
+
+      useEffect(() => {
         if (batchStream?.status === 'done') { setPhase('done'); setResults(batchStream.result?.results || []); setBatchJobId(null); }
         if (batchStream?.status === 'error') { setError('Export failed: ' + batchStream.error); setPhase('review'); setBatchJobId(null); }
       }, [batchStream?.status]);
 
+      const retryClipRef = useRef(null);
       const retryClip = async (idx) => {
         const sc = suggestions.filter((_, i) => !deselected.has(i));
-        const c = sc[idx]; setRetryIdx(idx); setRetryJobId(null);
+        const c = sc[idx]; retryClipRef.current = c; setRetryIdx(idx); setRetryJobId(null);
         const vp = file?.file_path || videoPath.trim();
         const data = await api('/create-clip', {
           method: 'POST', body: JSON.stringify({
@@ -1065,14 +1178,63 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       };
 
       useEffect(() => {
-        if (retryStream?.status === 'done') {
-          setResults(prev => { const n = [...prev]; n[retryIdx] = { ...retryStream.result, status: 'success' }; return n; });
-          setRetryIdx(null); setRetryJobId(null);
-        }
+        if (retryStream?.status !== 'done') return;
+        const c = retryClipRef.current;
+        const row = {
+          ...retryStream.result,
+          status: 'success',
+          ...(c && { source_start_second: c.start_second, source_end_second: c.end_second }),
+        };
+        setResults(prev => {
+          const key = resultBoundsKey(row);
+          const found = key ? prev.findIndex(r => resultBoundsKey(r) === key) : -1;
+          const at = found >= 0 ? found : typeof retryIdx === 'number' ? retryIdx : prev.length;
+          const next = [...prev];
+          next[at] = row;
+          return next;
+        });
+        setRetryIdx(null); setRetryJobId(null);
       }, [retryStream?.status]);
 
       const toggleClip = (i) => setDeselected(prev => { const n = new Set(prev); n.has(i) ? n.delete(i) : n.add(i); return n; });
       const selectedCount = suggestions.length - deselected.size;
+
+      // Keyboard shortcuts: j/k move clip selection, space toggles include, e edits
+      useEffect(() => {
+        const onKey = (e) => {
+          if (e.metaKey || e.ctrlKey || e.altKey) return;
+          const t = e.target instanceof Element ? e.target : null;
+          if (t?.closest('input, textarea, select, [contenteditable="true"]')) return;
+          // Reviewing a clip means focusing its row, so the row is the one control
+          // these keys must still reach. Anything else that activates on the same
+          // key would fire twice.
+          const control = t?.closest('button, a, [role="button"], [role="checkbox"], [role="switch"], [role="tab"], [role="menuitem"]');
+          if (control && !control.hasAttribute('data-clip-row')) return;
+          if (editingClip !== null || previewFile) return;
+          if (!suggestions.length) return;
+          const key = e.key.toLowerCase();
+          if (key === 'j' || key === 'k') {
+            e.preventDefault();
+            setPreviewSrc(null);
+            setActiveClipIdx(prev => {
+              const cur = prev === null ? -1 : prev;
+              return key === 'j'
+                ? Math.min(cur + 1, suggestions.length - 1)
+                : Math.max(cur - 1, 0);
+            });
+          } else if (key === ' ') {
+            if (phase !== 'review' || activeClipIdx === null) return;
+            e.preventDefault();
+            toggleClip(activeClipIdx);
+          } else if (key === 'e') {
+            if (phase !== 'review' || activeClipIdx === null) return;
+            e.preventDefault();
+            openClipEdit(activeClipIdx);
+          }
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+      }, [suggestions, phase, activeClipIdx, editingClip, previewFile]);
       const buildLocalPrompt = () => {
         const parts = [];
         const hasTranscriptReady = transcript || transcriptText.trim();
@@ -1210,19 +1372,18 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       const sourceIsUrl = isHttpUrl(videoPath);
       const selectedClips = suggestions.filter((_, i) => !deselected.has(i));
       const exportStats = phase === 'done' ? {
-        total: selectedClips.length,
+        total: results.length || selectedClips.length,
         ok: results.filter(r => r?.status === 'success').length,
         failed: results.filter(r => r?.status === 'error').length,
       } : null;
 
-      const getExportStatus = (resultIdx) => {
-        if (phase !== 'exporting' || !batchStream) return null;
-        const total = selectedClips.length; if (!total) return null;
-        const pct = batchStream.progress || 0;
-        const done = Math.floor(pct / (100 / total));
-        if (resultIdx < done) return 'exported';
-        if (resultIdx === done && pct < 100) return 'rendering';
-        return 'pending';
+      // Clips render in parallel and report as they finish, so a clip is only
+      // exported once its own row has arrived. Anything else is still in the queue.
+      const getExportStatus = (clip, resultIdx) => {
+        if (phase !== 'exporting') return null;
+        const r = resultFor(clip, resultIdx);
+        if (r) return r.status === 'error' ? 'failed' : 'exported';
+        return batchStream ? 'pending' : null;
       };
 
       const handleVideoDrop = (e) => {
@@ -1233,8 +1394,6 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
       const handleTranscriptDrop = (e) => { e.preventDefault(); setTranscriptDragOver(false); const files = e.dataTransfer?.files; if (!files?.length) return; const f = files[0]; setTranscriptFileName(f.name); const reader = new FileReader(); reader.onload = (ev) => setTranscriptText(ev.target.result); reader.readAsText(f); };
       const handleTranscriptFileSelect = (e) => { const f = e.target.files?.[0]; if (!f) return; setTranscriptFileName(f.name); const reader = new FileReader(); reader.onload = (ev) => setTranscriptText(ev.target.result); reader.readAsText(f); };
       const preventDef = (e) => e.preventDefault();
-
-      const activeClip = activeClipIdx !== null ? suggestions[activeClipIdx] : null;
 
       return (
         <div className="app">
@@ -1336,9 +1495,13 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
               {/* Transcript */}
               <div className="section card">
                 <div className="section-label">Transcript</div>
-                <div className="tabs">
-                  <div className={`tab ${transcriptMode === 'import' ? 'active' : ''}`} onClick={() => setTranscriptMode('import')}>Paste transcript</div>
-                  <div className={`tab ${transcriptMode === 'whisper' ? 'active' : ''}`} onClick={() => setTranscriptMode('whisper')}>Auto</div>
+                <div className="tabs" role="tablist" aria-label="Transcript source">
+                  {[['import', 'Paste transcript'], ['whisper', 'Auto']].map(([mode, label]) => (
+                    <div key={mode} className={`tab ${transcriptMode === mode ? 'active' : ''}`}
+                      role="tab" tabIndex={0} aria-selected={transcriptMode === mode}
+                      onClick={() => setTranscriptMode(mode)}
+                      onKeyDown={onKeyActivate(() => setTranscriptMode(mode))}>{label}</div>
+                  ))}
                 </div>
                 {transcriptMode === 'import' && (
                   <div className="fade-in">
@@ -1513,7 +1676,9 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
                 {/* Advanced Settings */}
                 <div style={{ marginTop: 14 }}>
                   <div style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, fontWeight: 700, letterSpacing: '0.8px', color: 'var(--text2)', textTransform: 'uppercase' }}
-                    onClick={() => setAdvancedOpen(!advancedOpen)}>
+                    role="button" tabIndex={0} aria-expanded={advancedOpen}
+                    onClick={() => setAdvancedOpen(!advancedOpen)}
+                    onKeyDown={onKeyActivate(() => setAdvancedOpen(v => !v))}>
                     <span style={{ transition: 'transform 0.15s', transform: advancedOpen ? 'rotate(90deg)' : 'rotate(0deg)', display: 'inline-flex' }}><ChevronRight size={12} /></span>
                     Advanced
                   </div>
@@ -1548,11 +1713,17 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
                       </div>
                       <div className="toggle-row" style={{ gridColumn: '1 / -1' }}>
                         <span className="toggle-label">Clean filler words (um, uh, hmm)</span>
-                        <div className={`toggle ${cleanFillers ? 'on' : ''}`} onClick={() => setCleanFillers(!cleanFillers)} />
+                        <div className={`toggle ${cleanFillers ? 'on' : ''}`} role="switch" tabIndex={0}
+                          aria-checked={cleanFillers} aria-label="Clean filler words"
+                          onClick={() => setCleanFillers(!cleanFillers)}
+                          onKeyDown={onKeyActivate(() => setCleanFillers(v => !v))} />
                       </div>
                       <div className="toggle-row" style={{ gridColumn: '1 / -1', paddingTop: 0 }}>
                         <span className="toggle-label">Energy boost (normalize loud moments)</span>
-                        <div className={`toggle ${energyBoost ? 'on' : ''}`} onClick={() => setEnergyBoost(!energyBoost)} />
+                        <div className={`toggle ${energyBoost ? 'on' : ''}`} role="switch" tabIndex={0}
+                          aria-checked={energyBoost} aria-label="Energy boost"
+                          onClick={() => setEnergyBoost(!energyBoost)}
+                          onKeyDown={onKeyActivate(() => setEnergyBoost(v => !v))} />
                       </div>
                     </div>
                   )}
@@ -1561,7 +1732,10 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
 
               {/* Word Corrections */}
               <div className="section">
-                <div className="section-label" style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6 }} onClick={() => setCorrectionsOpen(!correctionsOpen)}>
+                <div className="section-label" style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6 }}
+                  role="button" tabIndex={0} aria-expanded={correctionsOpen}
+                  onClick={() => setCorrectionsOpen(!correctionsOpen)}
+                  onKeyDown={onKeyActivate(() => setCorrectionsOpen(v => !v))}>
                   <span style={{ transition: 'transform 0.15s', transform: correctionsOpen ? 'rotate(90deg)' : 'rotate(0deg)', display: 'inline-flex' }}><ChevronRight size={12} /></span>
                   Word Corrections
                   {Object.keys(corrections).length > 0 && (
@@ -1686,6 +1860,16 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
                         : phase === 'review' ? `Clips \u00B7 ${selectedCount} selected` : 'Clips'}
                     </div>
                     <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                      {phase === 'review' && (
+                        <>
+                          <button className="btn btn-ghost btn-sm" onClick={() => setDeselected(new Set())} disabled={deselected.size === 0}>
+                            Select all
+                          </button>
+                          <button className="btn btn-ghost btn-sm" onClick={() => setDeselected(new Set(suggestions.keys()))} disabled={selectedCount === 0}>
+                            Select none
+                          </button>
+                        </>
+                      )}
                       {phase === 'review' && videoPath && (
                         <button className="btn btn-ghost btn-sm" onClick={analyzeEnergy} disabled={analyzingEnergy || suggestions.length === 0} title="Analyze audio energy levels">
                           {analyzingEnergy ? <><div className="spinner sm" /> Analyzing…</> : <><Activity size={14} /> Energy</>}
@@ -1697,18 +1881,21 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
                         </button>
                       )}
                       {transcript && (phase === 'review' || phase === 'done') && (
-                        <div style={{ position: 'relative' }}>
-                          <button className="btn btn-ghost btn-sm overflow-menu-btn" onClick={e => { const m = e.currentTarget.nextElementSibling; m.style.display = m.style.display === 'block' ? 'none' : 'block'; }} style={{ padding: '6px 10px', fontSize: 14, color: 'var(--text3)', lineHeight: 1 }}>
+                        <div style={{ position: 'relative' }} ref={exportMenuRef}>
+                          <button className="btn btn-ghost btn-sm overflow-menu-btn" aria-label="More actions" aria-haspopup="menu" aria-expanded={exportMenuOpen}
+                            onClick={() => setExportMenuOpen(v => !v)} style={{ padding: '6px 10px', fontSize: 14, color: 'var(--text3)', lineHeight: 1 }}>
                             {'\u22EF'}
                           </button>
-                          <div className="overflow-menu" style={{ display: 'none' }}>
-                            <div className="overflow-menu-label">Export transcript</div>
-                            {['SRT', 'VTT', 'JSON'].map(fmt => (
-                              <button key={fmt} className="overflow-menu-item" onClick={e => { window.open(`/api/export-transcript?format=${fmt.toLowerCase()}`, '_blank'); e.currentTarget.closest('.overflow-menu').style.display = 'none'; }}>
-                                {fmt}
-                              </button>
-                            ))}
-                          </div>
+                          {exportMenuOpen && (
+                            <div className="overflow-menu" role="menu">
+                              <div className="overflow-menu-label">Export transcript</div>
+                              {['SRT', 'VTT', 'JSON'].map(fmt => (
+                                <button key={fmt} role="menuitem" className="overflow-menu-item" onClick={() => { window.open(`/api/export-transcript?format=${fmt.toLowerCase()}`, '_blank'); setExportMenuOpen(false); }}>
+                                  {fmt}
+                                </button>
+                              ))}
+                            </div>
+                          )}
                         </div>
                       )}
                     </div>
@@ -1717,26 +1904,34 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
                   {suggestions.map((clip, i) => {
                     const off = deselected.has(i);
                     const resultIdx = [...suggestions.keys()].filter(k => !deselected.has(k)).indexOf(i);
-                    const r = results[resultIdx];
+                    const r = resultFor(clip, resultIdx);
                     const outputFile = r?.output_path?.split('/').pop();
                     const failed = r?.status === 'error';
                     const isRetryingThis = retryIdx === resultIdx;
-                    const exportStatus = !off ? getExportStatus(resultIdx) : null;
+                    const exportStatus = !off ? getExportStatus(clip, resultIdx) : null;
                     const isSelected = activeClipIdx === i && !previewSrc;
 
                     return (
-                      <div key={i}
-                        className={`clip-item ${off && phase === 'review' ? 'dimmed' : ''} ${exportStatus === 'rendering' ? 'active-clip' : ''} ${phase === 'suggesting' ? 'clip-reveal' : ''} ${isSelected ? 'selected' : ''}`}
-                        onClick={() => onClipClick(i)}>
+                      <div key={i} data-clip-row
+                        className={`clip-item ${off && phase === 'review' ? 'dimmed' : ''} ${phase === 'suggesting' ? 'clip-reveal' : ''} ${isSelected ? 'selected' : ''}`}
+                        role="button" tabIndex={0} aria-label={`Preview clip: ${clip.title}`}
+                        onClick={() => onClipClick(i)}
+                        onFocus={e => { if (e.target === e.currentTarget) onClipClick(i); }}
+                        onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); onClipClick(i); } }}>
 
                         {phase === 'review' && (
-                          <div className={`checkbox ${!off ? 'checked' : ''}`} onClick={(e) => { e.stopPropagation(); toggleClip(i); }}>
+                          <div className={`checkbox ${!off ? 'checked' : ''}`}
+                            role="checkbox" tabIndex={0} aria-checked={!off} aria-label={`Include ${clip.title} in export`}
+                            onClick={(e) => { e.stopPropagation(); toggleClip(i); }}
+                            onKeyDown={onKeyActivate(() => toggleClip(i))}>
                             {!off && <CheckIcon />}
                           </div>
                         )}
 
                         {phase === 'exporting' && !off && exportStatus && (
-                          <div className={`clip-status ${exportStatus}`}>{exportStatus === 'exported' && <CheckSmall />}</div>
+                          exportStatus === 'failed'
+                            ? <div className="status-dot fail"><X size={11} /></div>
+                            : <div className={`clip-status ${exportStatus}`}>{exportStatus === 'exported' && <CheckSmall />}</div>
                         )}
 
                         {phase === 'done' && !off && r && (
@@ -1755,12 +1950,11 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
                             {r && !failed && <span> {'\u00B7'} {r.file_size_mb}MB</span>}
                             {r && !failed && r.warning && <span className="warn"> {'\u00B7'} {r.warning}</span>}
                             {failed && <span className="err"> {'\u00B7'} {r.error?.slice(0, 60)}</span>}
-                            {exportStatus === 'rendering' && <span style={{ color: 'var(--accent)' }}> {'\u00B7'} rendering{'\u2026'}</span>}
                           </div>
                         </div>
 
                         {phase === 'review' && (
-                          <button className="btn btn-ghost btn-sm clip-edit-btn" onClick={(e) => openClipEdit(i, e)} title="Edit clip"><Pencil size={13} /></button>
+                          <button className="btn btn-ghost btn-sm clip-edit-btn" onClick={(e) => { e.stopPropagation(); openClipEdit(i); }} title="Edit clip"><Pencil size={13} /></button>
                         )}
 
                         {phase === 'done' && !off && r && !failed && outputFile && (
@@ -1855,7 +2049,9 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
               {clipHistory.length > 0 && (
                 <div className="section" style={{ marginTop: 16 }}>
                   <div className="section-label" style={{ cursor: 'pointer', userSelect: 'none', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
-                    onClick={() => setHistoryOpen(!historyOpen)}>
+                    role="button" tabIndex={0} aria-expanded={historyOpen}
+                    onClick={() => setHistoryOpen(!historyOpen)}
+                    onKeyDown={onKeyActivate(() => setHistoryOpen(v => !v))}>
                     <span>History ({clipHistory.length})</span>
                     <span className="hint-xs" style={{ transition: 'transform 0.2s', transform: historyOpen ? 'rotate(180deg)' : 'rotate(0)' }}><ChevronDown size={12} /></span>
                   </div>
@@ -1868,7 +2064,9 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
                         const fname = c.output_path?.split('/').pop() || c.title;
                         return (
                           <div key={c.id || i} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', background: 'var(--surface)', borderRadius: 'var(--radius-sm)', fontSize: 12, cursor: 'pointer' }}
-                            onClick={() => { const f = c.output_path?.split('/').pop(); if (f) setPreviewSrc(f); }}>
+                            role="button" tabIndex={0} aria-label={`Preview ${c.title || fname}`}
+                            onClick={() => { const f = c.output_path?.split('/').pop(); if (f) setPreviewSrc(f); }}
+                            onKeyDown={onKeyActivate(() => { const f = c.output_path?.split('/').pop(); if (f) setPreviewSrc(f); })}>
                             <div style={{ width: 6, height: 6, borderRadius: 3, background: 'var(--green)', flexShrink: 0 }} />
                             <div style={{ flex: 1, minWidth: 0 }}>
                               <div style={{ fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.title || fname}</div>
@@ -1928,6 +2126,8 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
                     previewSrc={previewSrc}
                     showTikTokFrame={showTikTokFrame}
                     onToggleFrame={() => setShowTikTokFrame(v => !v)}
+                    clipEnded={clipEnded}
+                    onReplay={replayClip}
                   />
                 )}
                 <SpecRecap
@@ -1946,30 +2146,46 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
           {/* Clip Edit Modal */}
           {editingClip !== null && suggestions[editingClip] && createPortal(
             <div className="clip-edit-overlay" onClick={() => setEditingClip(null)}>
-              <div className="clip-edit-panel" onClick={e => e.stopPropagation()}>
+              <div ref={editDialogRef} className="clip-edit-panel" role="dialog" aria-modal="true"
+                aria-label={`Edit clip ${editingClip + 1}`} tabIndex={-1} onClick={e => e.stopPropagation()}>
                 <h3>Edit clip #{editingClip + 1}</h3>
                 <div className="edit-field">
                   <label>Title</label>
                   <input type="text" value={editForm.title} onChange={e => setEditForm(f => ({ ...f, title: e.target.value }))}
                     onKeyDown={e => { if (e.key === 'Enter') saveClipEdit(); }} autoFocus />
                 </div>
+                {videoPath && !sourceIsUrl && (
+                  <div className="edit-field">
+                    <label>Trim</label>
+                    <MomentTrim
+                      src={`/api/stream-source?path=${encodeURIComponent(videoPath)}`}
+                      start={editForm.start}
+                      end={editForm.end}
+                      onCommit={(s, e2) => setEditForm(f => ({ ...f, start: clampEditTime(s), end: clampEditTime(e2) }))}
+                      onDuration={setEditDuration}
+                    />
+                  </div>
+                )}
                 <div className="edit-field">
                   <label>Time range</label>
                   <div className="time-row">
                     <div>
-                      <input type="number" step="0.5" value={editForm.start} onChange={e => setEditForm(f => ({ ...f, start: parseFloat(e.target.value) || 0 }))}
-                        style={{ textAlign: 'center' }} />
+                      <input type="number" step="0.5" min="0" max={editDuration || undefined} value={editForm.start}
+                        onChange={e => setEditForm(f => ({ ...f, start: clampEditTime(parseFloat(e.target.value)) }))}
+                        aria-label="Start time in seconds" style={{ textAlign: 'center' }} />
                       <div className="hint-xs" style={{ textAlign: 'center', marginTop: 2 }}>{fmt(editForm.start)}</div>
                     </div>
                     <div className="arrow"><ArrowRight size={14} /></div>
                     <div>
-                      <input type="number" step="0.5" value={editForm.end} onChange={e => setEditForm(f => ({ ...f, end: parseFloat(e.target.value) || 0 }))}
-                        style={{ textAlign: 'center' }} />
+                      <input type="number" step="0.5" min="0" max={editDuration || undefined} value={editForm.end}
+                        onChange={e => setEditForm(f => ({ ...f, end: clampEditTime(parseFloat(e.target.value)) }))}
+                        aria-label="End time in seconds" style={{ textAlign: 'center' }} />
                       <div className="hint-xs" style={{ textAlign: 'center', marginTop: 2 }}>{fmt(editForm.end)}</div>
                     </div>
                   </div>
                   <div className="hint" style={{ marginTop: 6, textAlign: 'center' }}>
                     Duration: {Math.round(editForm.end - editForm.start)}s
+                    {editForm.end <= editForm.start && <span style={{ color: 'var(--red)' }}> {'·'} end must be after start</span>}
                   </div>
                 </div>
                 <div className="clip-edit-actions">
@@ -1984,7 +2200,8 @@ const isHttpUrl = (value) => /^https?:\/\//i.test(value.trim());
           {/* Modal (mobile fallback) */}
           {previewFile && createPortal(
             <div className="modal-overlay" onClick={() => setPreviewFile(null)}>
-              <div className="modal-body" onClick={e => e.stopPropagation()}>
+              <div ref={previewDialogRef} className="modal-body" role="dialog" aria-modal="true"
+                aria-label="Clip preview" tabIndex={-1} onClick={e => e.stopPropagation()}>
                 <video src={`/api/preview/${previewFile}`} controls autoPlay />
                 <div style={{ textAlign: 'center', marginTop: 12 }}>
                   <button className="btn btn-ghost btn-sm" onClick={() => setPreviewFile(null)}>Close</button>

--- a/src/ui/client/HighlightsPage.tsx
+++ b/src/ui/client/HighlightsPage.tsx
@@ -4,7 +4,8 @@ import { api, basename, fmt } from "./lib";
 import { useJob } from "./useJob";
 import AssetPicker from "./AssetPicker";
 import RecentSources from "./RecentSources";
-import { BackIcon, TrashIcon, PlayIcon, PauseIcon, DownloadIcon } from "./icons";
+import MomentTrim from "./MomentTrim";
+import { BackIcon, TrashIcon, DownloadIcon } from "./icons";
 
 interface Moment {
   start: number;
@@ -59,137 +60,6 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
     </div>
   );
 }
-
-function MomentTrim({
-  src,
-  moment,
-  onCommit,
-  saving,
-}: {
-  src: string;
-  moment: Moment;
-  onCommit: (start: number, end: number) => void;
-  saving: boolean;
-}) {
-  const video = useRef<HTMLVideoElement>(null);
-  const trackRef = useRef<HTMLDivElement>(null);
-  const [dur, setDur] = useState(0);
-  const [cur, setCur] = useState(moment.start);
-  const [playing, setPlaying] = useState(false);
-  const [draft, setDraft] = useState<{ start: number; end: number } | null>(null);
-  const drag = useRef<null | "in" | "out">(null);
-
-  const start = draft?.start ?? moment.start;
-  const end = draft?.end ?? moment.end;
-
-  const pad = Math.max(8, (moment.end - moment.start) * 0.6);
-  const winA = Math.max(0, moment.start - pad);
-  const winB = Math.min(dur || moment.end + pad, moment.end + pad);
-  const span = Math.max(0.1, winB - winA);
-  const pct = (t: number) => `${((t - winA) / span) * 100}%`;
-
-  useEffect(() => {
-    const v = video.current;
-    if (v) v.currentTime = moment.start;
-    setCur(moment.start);
-  }, [moment.start, moment.end, src]);
-
-  const timeAt = (clientX: number) => {
-    const el = trackRef.current;
-    if (!el) return winA;
-    const r = el.getBoundingClientRect();
-    return winA + Math.max(0, Math.min(1, (clientX - r.left) / r.width)) * span;
-  };
-
-  const onMove = (e: React.PointerEvent) => {
-    if (!drag.current) return;
-    const t = timeAt(e.clientX);
-    setDraft((d) => {
-      const base = d ?? { start: moment.start, end: moment.end };
-      if (drag.current === "in") return { start: Math.min(t, base.end - 0.5), end: base.end };
-      return { start: base.start, end: Math.max(t, base.start + 0.5) };
-    });
-    if (video.current) {
-      video.current.currentTime = t;
-      setCur(t);
-    }
-  };
-
-  const endDrag = (e: React.PointerEvent) => {
-    if (!drag.current) return;
-    e.currentTarget.releasePointerCapture(e.pointerId);
-    drag.current = null;
-    if (draft) onCommit(round1(draft.start), round1(draft.end));
-  };
-
-  const toggle = () => {
-    const v = video.current;
-    if (!v) return;
-    if (v.paused) {
-      if (v.currentTime < start || v.currentTime >= end) v.currentTime = start;
-      v.play();
-    } else v.pause();
-  };
-
-  const onTime = (e: React.SyntheticEvent<HTMLVideoElement>) => {
-    const t = e.currentTarget.currentTime;
-    if (playing && t >= end) {
-      e.currentTarget.currentTime = start;
-      setCur(start);
-    } else setCur(t);
-  };
-
-  return (
-    <div>
-      <div className="clip-player" style={{ marginBottom: 10 }}>
-        <video
-          ref={video}
-          src={src}
-          playsInline
-          preload="metadata"
-          onClick={toggle}
-          onPlay={() => setPlaying(true)}
-          onPause={() => setPlaying(false)}
-          onTimeUpdate={onTime}
-          onLoadedMetadata={(e) => setDur(e.currentTarget.duration)}
-          style={{ maxHeight: 360, width: "100%", objectFit: "contain", background: "#000" }}
-        />
-      </div>
-
-      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-        <button className="clip-player-btn" onClick={toggle} aria-label={playing ? "Pause" : "Play"}
-          style={{ flexShrink: 0 }}>
-          {playing ? <PauseIcon /> : <PlayIcon />}
-        </button>
-        <div
-          ref={trackRef}
-          className="rf-track"
-          style={{ flex: 1, marginTop: 0 }}
-          onPointerMove={onMove}
-          onPointerUp={endDrag}
-        >
-          <div className="rf-region" style={{ left: pct(start), width: `calc(${pct(end)} - ${pct(start)})` }} />
-          <div className="rf-playhead" style={{ left: pct(cur) }} />
-          <div
-            className="rf-handle"
-            style={{ left: pct(start), background: "var(--accent)" }}
-            onPointerDown={(e) => { e.currentTarget.setPointerCapture(e.pointerId); drag.current = "in"; }}
-          />
-          <div
-            className="rf-handle"
-            style={{ left: pct(end), background: "var(--accent)" }}
-            onPointerDown={(e) => { e.currentTarget.setPointerCapture(e.pointerId); drag.current = "out"; }}
-          />
-        </div>
-        <span className="clip-player-time" style={{ minWidth: 118, textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
-          {saving ? "saving…" : `${fmt(start)}-${fmt(end)} · ${Math.round(end - start)}s`}
-        </span>
-      </div>
-    </div>
-  );
-}
-
-const round1 = (n: number) => Math.round(n * 10) / 10;
 
 function DownloadRow({
   jobId,
@@ -570,7 +440,8 @@ export default function HighlightsPage() {
               <MomentTrim
                 key={selected}
                 src={streamSrc}
-                moment={active}
+                start={active.start}
+                end={active.end}
                 saving={saving}
                 onCommit={(s, e) => commitTrim(selected, s, e)}
               />

--- a/src/ui/client/KnowledgePage.jsx
+++ b/src/ui/client/KnowledgePage.jsx
@@ -2,6 +2,9 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { PageHeader } from "./Page";
 import { Trash2 } from 'lucide-react';
 import { api, upload } from './lib';
+import CopyButton from './CopyButton';
+
+const BOOTSTRAP_COMMAND = 'podcli bootstrap-knowledge <channel-url>';
 
 export default function KnowledgePage() {
       const [files, setFiles] = useState([]);
@@ -12,6 +15,8 @@ export default function KnowledgePage() {
       const [toast, setToast] = useState(null);
       const [newName, setNewName] = useState('');
       const [kbDir, setKbDir] = useState('');
+      const [creating, setCreating] = useState(false);
+      const [created, setCreated] = useState(null);
 
       const showToast = (msg) => { setToast(msg); setTimeout(() => setToast(null), 2000); };
 
@@ -67,6 +72,16 @@ export default function KnowledgePage() {
         } catch (e) { showToast(`Create failed: ${e.message}`); }
       };
 
+      const createStarterFiles = async () => {
+        setCreating(true);
+        try {
+          const r = await api('/knowledge/init', { method: 'POST' });
+          setCreated(r.created || []);
+          await loadFiles();
+        } catch (e) { showToast(`Create failed: ${e.message}`); }
+        finally { setCreating(false); }
+      };
+
       const uploadFiles = async (fileList, label) => {
         const fd = new FormData();
         for (const f of fileList) {
@@ -114,6 +129,12 @@ export default function KnowledgePage() {
             <input type="file" accept=".md,.txt" multiple onChange={handleFileInput} />
           </div>
 
+          {created?.length > 0 && (
+            <div className="set-note ok" style={{ marginBottom: 16 }}>
+              Created {created.length} files. Fill in <strong>01-brand-identity.md</strong> and <strong>02-voice-and-tone.md</strong> first: the clip scorer reads those two on every run.
+            </div>
+          )}
+
           {realFiles.length > 0 ? (
             <div className="file-grid">
               {realFiles.map(f => (
@@ -130,8 +151,21 @@ export default function KnowledgePage() {
               ))}
             </div>
           ) : (
-            <div className="empty-state">
-              No knowledge files yet. Drop .md files above or create one below.
+            <div className="section card" style={{ marginTop: 16 }}>
+              <div className="section-label">Start here</div>
+              <div className="meta" style={{ marginBottom: 14 }}>
+                podcli reads 14 numbered files when it picks clips and writes titles. Create the starter set, then fill in the [brackets].
+              </div>
+              <button className="btn btn-primary" onClick={createStarterFiles} disabled={creating}>
+                {creating ? <div className="spinner sm" /> : 'Create starter templates'}
+              </button>
+              <div className="code-block">
+                <div className="code-block-head">
+                  <span>or draft them from a channel you already run</span>
+                  <CopyButton className="btn btn-ghost btn-sm" style={{ padding: '3px 10px' }} text={BOOTSTRAP_COMMAND} />
+                </div>
+                <pre>{BOOTSTRAP_COMMAND}</pre>
+              </div>
             </div>
           )}
 

--- a/src/ui/client/MomentTrim.tsx
+++ b/src/ui/client/MomentTrim.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useRef, useState } from "react";
+import { fmt } from "./lib";
+import { PlayIcon, PauseIcon } from "./icons";
+
+const round1 = (n: number) => Math.round(n * 10) / 10;
+
+export default function MomentTrim({
+  src,
+  start: startProp,
+  end: endProp,
+  onCommit,
+  saving = false,
+  onDuration,
+}: {
+  src: string;
+  start: number;
+  end: number;
+  onCommit: (start: number, end: number) => void;
+  saving?: boolean;
+  onDuration?: (duration: number) => void;
+}) {
+  const video = useRef<HTMLVideoElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [dur, setDur] = useState(0);
+  const [cur, setCur] = useState(startProp);
+  const [playing, setPlaying] = useState(false);
+  const [draft, setDraft] = useState<{ start: number; end: number } | null>(null);
+  const drag = useRef<null | "in" | "out">(null);
+
+  const start = draft?.start ?? startProp;
+  const end = draft?.end ?? endProp;
+
+  const pad = Math.max(8, (endProp - startProp) * 0.6);
+  const winA = Math.max(0, startProp - pad);
+  const winB = Math.min(dur || endProp + pad, endProp + pad);
+  const span = Math.max(0.1, winB - winA);
+  const pct = (t: number) => `${((t - winA) / span) * 100}%`;
+
+  useEffect(() => {
+    setDraft(null);
+    const v = video.current;
+    if (v) v.currentTime = startProp;
+    setCur(startProp);
+  }, [startProp, endProp, src]);
+
+  const timeAt = (clientX: number) => {
+    const el = trackRef.current;
+    if (!el) return winA;
+    const r = el.getBoundingClientRect();
+    return winA + Math.max(0, Math.min(1, (clientX - r.left) / r.width)) * span;
+  };
+
+  const onMove = (e: React.PointerEvent) => {
+    if (!drag.current) return;
+    const t = timeAt(e.clientX);
+    setDraft((d) => {
+      const base = d ?? { start: startProp, end: endProp };
+      if (drag.current === "in") return { start: Math.min(t, base.end - 0.5), end: base.end };
+      return { start: base.start, end: Math.max(t, base.start + 0.5) };
+    });
+    if (video.current) {
+      video.current.currentTime = t;
+      setCur(t);
+    }
+  };
+
+  const endDrag = (e: React.PointerEvent) => {
+    if (!drag.current) return;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+    drag.current = null;
+    if (draft) onCommit(round1(draft.start), round1(draft.end));
+  };
+
+  const toggle = () => {
+    const v = video.current;
+    if (!v) return;
+    if (v.paused) {
+      if (v.currentTime < start || v.currentTime >= end) v.currentTime = start;
+      v.play();
+    } else v.pause();
+  };
+
+  const onTime = (e: React.SyntheticEvent<HTMLVideoElement>) => {
+    const t = e.currentTarget.currentTime;
+    if (playing && t >= end) {
+      e.currentTarget.currentTime = start;
+      setCur(start);
+    } else setCur(t);
+  };
+
+  return (
+    <div>
+      <div className="clip-player" style={{ marginBottom: 10 }}>
+        <video
+          ref={video}
+          src={src}
+          playsInline
+          preload="metadata"
+          onClick={toggle}
+          onPlay={() => setPlaying(true)}
+          onPause={() => setPlaying(false)}
+          onTimeUpdate={onTime}
+          onLoadedMetadata={(e) => {
+            setDur(e.currentTarget.duration);
+            onDuration?.(e.currentTarget.duration);
+          }}
+          style={{ maxHeight: 360, width: "100%", objectFit: "contain", background: "#000" }}
+        />
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <button className="clip-player-btn" onClick={toggle} aria-label={playing ? "Pause" : "Play"}
+          style={{ flexShrink: 0 }}>
+          {playing ? <PauseIcon /> : <PlayIcon />}
+        </button>
+        <div
+          ref={trackRef}
+          className="rf-track"
+          style={{ flex: 1, marginTop: 0 }}
+          onPointerMove={onMove}
+          onPointerUp={endDrag}
+        >
+          <div className="rf-region" style={{ left: pct(start), width: `calc(${pct(end)} - ${pct(start)})` }} />
+          <div className="rf-playhead" style={{ left: pct(cur) }} />
+          <div
+            className="rf-handle"
+            style={{ left: pct(start), background: "var(--accent)" }}
+            onPointerDown={(e) => { e.currentTarget.setPointerCapture(e.pointerId); drag.current = "in"; }}
+          />
+          <div
+            className="rf-handle"
+            style={{ left: pct(end), background: "var(--accent)" }}
+            onPointerDown={(e) => { e.currentTarget.setPointerCapture(e.pointerId); drag.current = "out"; }}
+          />
+        </div>
+        <span className="clip-player-time" style={{ minWidth: 118, textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
+          {saving ? "saving…" : `${fmt(start)}-${fmt(end)} · ${Math.round(end - start)}s`}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/client/SetupChecklist.tsx
+++ b/src/ui/client/SetupChecklist.tsx
@@ -1,0 +1,120 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Check } from "lucide-react";
+import { api } from "./lib";
+
+interface Onboarding {
+  knowledge: { total: number; present: number; filled: string[]; missing: string[] };
+  assets: { count: number; branding: boolean };
+  aiCli: { available: boolean };
+  clips: { count: number };
+  dismissed: boolean;
+}
+
+interface Step {
+  title: string;
+  desc: string;
+  done: boolean;
+  action: React.ReactNode;
+}
+
+const BRAND_FILES = ["01-brand-identity.md", "02-voice-and-tone.md"];
+
+export default function SetupChecklist() {
+  const [state, setState] = useState<Onboarding | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    api<Onboarding>("/onboarding")
+      .then(setState)
+      .catch(() => setState(null));
+  }, []);
+
+  useEffect(load, [load]);
+
+  if (!state || state.dismissed || dismissed) return null;
+
+  const createKnowledge = async () => {
+    setCreating(true);
+    setError(null);
+    try {
+      await api("/knowledge/init", { method: "POST" });
+      load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create the knowledge base");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const dismiss = () => {
+    setDismissed(true);
+    api("/ui-state", {
+      method: "POST",
+      body: JSON.stringify({ _source: "ui", settings: { onboardingDismissed: true } }),
+    }).catch(() => { });
+  };
+
+  const steps: Step[] = [
+    {
+      title: "Create the knowledge base",
+      desc: "The files podcli reads before it picks a single clip.",
+      done: state.knowledge.total > 0 && state.knowledge.present === state.knowledge.total,
+      action: (
+        <button className="btn btn-primary btn-sm" onClick={createKnowledge} disabled={creating}>
+          {creating ? <div className="spinner sm" /> : "Create starter templates"}
+        </button>
+      ),
+    },
+    {
+      title: "Fill in brand identity and voice",
+      desc: "Who the show is for, and the words it never uses.",
+      done: BRAND_FILES.every((f) => state.knowledge.filled.includes(f)),
+      action: <Link to="/knowledge" className="btn btn-ghost btn-sm">Open knowledge</Link>,
+    },
+    {
+      title: "Add a logo or outro",
+      desc: "Branding that gets stamped onto every clip you render.",
+      done: state.assets.branding,
+      action: <Link to="/assets" className="btn btn-ghost btn-sm">Open assets</Link>,
+    },
+    {
+      title: "Connect an AI CLI",
+      desc: "Clip suggestions run through Claude Code or Codex on your machine.",
+      done: state.aiCli.available,
+      action: <Link to="/mcp" className="btn btn-ghost btn-sm">Setup guide</Link>,
+    },
+  ];
+
+  const done = steps.filter((s) => s.done).length;
+  if (done === steps.length) return null;
+
+  return (
+    <div className="section card setup fade-in">
+      <div className="setup-head">
+        <div>
+          <div className="section-label" style={{ marginBottom: 2 }}>Set up your studio</div>
+          <div className="meta">{done} of {steps.length} done</div>
+        </div>
+        <button className="btn btn-ghost btn-sm" onClick={dismiss}>Dismiss</button>
+      </div>
+
+      <ul className="setup-steps">
+        {steps.map((s) => (
+          <li key={s.title} className={`setup-step${s.done ? " done" : ""}`}>
+            <span className="setup-mark">{s.done && <Check size={12} strokeWidth={3} />}</span>
+            <div className="setup-body">
+              <div className="setup-title">{s.title}</div>
+              <div className="setup-desc">{s.desc}</div>
+            </div>
+            {!s.done && <div className="setup-action">{s.action}</div>}
+          </li>
+        ))}
+      </ul>
+
+      {error && <div className="set-note err">{error}</div>}
+    </div>
+  );
+}

--- a/src/ui/client/StudioHome.tsx
+++ b/src/ui/client/StudioHome.tsx
@@ -3,6 +3,7 @@ import { PageHeader } from "./Page";
 import { Link } from "react-router-dom";
 import { api, fmt, timeAgo, basename } from "./lib";
 import { TrashIcon, PlayIcon } from "./icons";
+import SetupChecklist from "./SetupChecklist";
 
 interface Clip {
   id: string;
@@ -86,6 +87,8 @@ export default function StudioHome() {
         title="Library"
         actions={<Link to="/episode" className="btn btn-primary btn-sm" style={{ textDecoration: "none" }}>+ New episode</Link>}
       />
+
+      <SetupChecklist />
 
       {exporting > 0 && (
         <div className="set-note ok" style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 16 }}>

--- a/src/ui/client/captionChunks.test.ts
+++ b/src/ui/client/captionChunks.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildPreviewChunks, activePreviewChunk, type PreviewWord } from "./captionChunks";
+import {
+  activePreviewChunk,
+  buildPreviewChunks,
+  selectPreviewWords,
+  type PreviewWord,
+} from "./captionChunks";
 import { buildChunks } from "../../../remotion/src/chunks";
 import type { Word } from "../../../remotion/src/types";
 
@@ -66,5 +71,22 @@ describe("buildPreviewChunks", () => {
   it("caps the last chunk's hold at the clip end", () => {
     const chunks = buildPreviewChunks(words, { wordsPerChunk: 6, absorbTail: 2 }, 5.0);
     expect(chunks[chunks.length - 1].displayEnd).toBeCloseTo(5.0);
+  });
+
+  it("keeps captions active beyond the first 80 transcript words", () => {
+    const transcript = Array.from({ length: 120 }, (_, index) => ({
+      word: `word-${index}`,
+      start: index * 0.5,
+      end: index * 0.5 + 0.4,
+      speaker: "A",
+    }));
+    const source = selectPreviewWords(transcript, {
+      start_second: 0,
+      end_second: 60,
+    });
+    const chunks = buildPreviewChunks(source, { wordsPerChunk: 5, absorbTail: 1 }, 60);
+
+    expect(source).toHaveLength(120);
+    expect(activePreviewChunk(chunks, 50.1)?.words.map((word) => word.text)).toContain("word-100");
   });
 });

--- a/src/ui/client/captionChunks.test.ts
+++ b/src/ui/client/captionChunks.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { buildPreviewChunks, activePreviewChunk, type PreviewWord } from "./captionChunks";
+import { buildChunks } from "../../../remotion/src/chunks";
+import type { Word } from "../../../remotion/src/types";
+
+const words: PreviewWord[] = [
+  { text: "the", start: 0, end: 0.2, speaker: "A" },
+  { text: "secret", start: 0.2, end: 0.6, speaker: "A" },
+  { text: "to", start: 0.6, end: 0.7, speaker: "A" },
+  { text: "growth.", start: 0.7, end: 1.2, speaker: "A" },
+  { text: "is", start: 1.3, end: 1.5, speaker: "A" },
+  { text: "boring", start: 1.5, end: 1.9, speaker: "A" },
+  { text: "work", start: 1.9, end: 2.3, speaker: "A" },
+  { text: "really?", start: 4.0, end: 4.4, speaker: "B" },
+  { text: "yes", start: 4.5, end: 4.8, speaker: "B" },
+];
+
+const asRendererWords = (ws: PreviewWord[]): Word[] =>
+  ws.map((w) => ({ word: w.text, start: w.start, end: w.end, speaker: w.speaker ?? null })) as Word[];
+
+const shapes = (chunks: { words: { text?: string; word?: string }[] }[]) =>
+  chunks.map((c) => c.words.map((w) => w.text ?? w.word));
+
+describe("buildPreviewChunks", () => {
+  // The phone preview exists to show what the MP4 will look like; if the two
+  // chunkers disagree, it is showing a different video.
+  it("groups and holds exactly like the renderer", () => {
+    for (const cfg of [
+      { wordsPerChunk: 3, maxCharsPerChunk: 18, splitTail: true },
+      { wordsPerChunk: 3, absorbTail: 1 },
+      { wordsPerChunk: 5, absorbTail: 1 },
+      { wordsPerChunk: 6, absorbTail: 2 },
+    ]) {
+      const preview = buildPreviewChunks(words, cfg, 6);
+      const rendered = buildChunks(asRendererWords(words), {
+        perChunk: cfg.wordsPerChunk,
+        maxChars: cfg.maxCharsPerChunk,
+        absorbTail: cfg.absorbTail,
+        splitTail: cfg.splitTail,
+        clipEnd: 6,
+      });
+      expect(shapes(preview)).toEqual(shapes(rendered));
+      expect(preview.map((c) => c.displayEnd)).toEqual(rendered.map((c) => c.displayEnd));
+    }
+  });
+
+  it("breaks on terminal punctuation, speaker change and long gaps", () => {
+    const chunks = buildPreviewChunks(words, { wordsPerChunk: 6, absorbTail: 2 });
+    expect(shapes(chunks)).toEqual([
+      ["the", "secret", "to", "growth."],
+      ["is", "boring", "work"],
+      ["really?"],
+      ["yes"],
+    ]);
+  });
+
+  it("holds a chunk through a short pause but not through a long one", () => {
+    const chunks = buildPreviewChunks(words, { wordsPerChunk: 6, absorbTail: 2 });
+    // 0.1s gap to the next chunk: held all the way to it.
+    expect(chunks[0].displayEnd).toBeCloseTo(1.3);
+    // 1.7s gap: held for the 0.4s fill, then the caption clears.
+    expect(chunks[1].displayEnd).toBeCloseTo(2.7);
+    expect(activePreviewChunk(chunks, 3.5)).toBeUndefined();
+  });
+
+  it("caps the last chunk's hold at the clip end", () => {
+    const chunks = buildPreviewChunks(words, { wordsPerChunk: 6, absorbTail: 2 }, 5.0);
+    expect(chunks[chunks.length - 1].displayEnd).toBeCloseTo(5.0);
+  });
+});

--- a/src/ui/client/captionChunks.ts
+++ b/src/ui/client/captionChunks.ts
@@ -1,0 +1,103 @@
+// Port of remotion/src/chunks.ts, the chunker the renderer burns into the MP4.
+// The studio's phone preview is only worth showing if it groups and holds words
+// exactly like the render, so the two must be changed together.
+
+export interface PreviewWord {
+  text: string;
+  start: number;
+  end: number;
+  speaker?: string | null;
+}
+
+export interface PreviewChunk {
+  words: PreviewWord[];
+  start: number;
+  end: number;
+  displayEnd: number;
+}
+
+export interface PreviewChunkOptions {
+  wordsPerChunk: number;
+  maxCharsPerChunk?: number;
+  absorbTail?: number;
+  splitTail?: boolean;
+}
+
+const BREAK_GAP_SECONDS = 0.8;
+const GAP_FILL_MAX_SECONDS = 0.4;
+const LAST_CHUNK_HOLD_SECONDS = 1.2;
+const TERMINAL_PUNCTUATION = /[.!?…]["')\]]?$/;
+
+function breaksAfter(prev: PreviewWord, next: PreviewWord): boolean {
+  return (
+    TERMINAL_PUNCTUATION.test(prev.text.trim()) ||
+    (prev.speaker != null && next.speaker != null && prev.speaker !== next.speaker) ||
+    next.start - prev.end > BREAK_GAP_SECONDS
+  );
+}
+
+function hasBreakBetween(words: PreviewWord[], from: number, to: number): boolean {
+  for (let i = from; i < to; i++) {
+    if (breaksAfter(words[i], words[i + 1])) return true;
+  }
+  return false;
+}
+
+export function buildPreviewChunks(
+  words: PreviewWord[],
+  cfg: PreviewChunkOptions,
+  clipEnd?: number,
+): PreviewChunk[] {
+  const chunks: PreviewChunk[] = [];
+  let i = 0;
+
+  while (i < words.length) {
+    let end = i + 1;
+    let charCount = words[i].text.trim().length;
+
+    while (end < words.length && end - i < cfg.wordsPerChunk) {
+      if (breaksAfter(words[end - 1], words[end])) break;
+      if (cfg.maxCharsPerChunk != null) {
+        const nextChars = charCount + 1 + words[end].text.trim().length;
+        if (nextChars > cfg.maxCharsPerChunk) break;
+        charCount = nextChars;
+      }
+      end += 1;
+    }
+
+    if (
+      cfg.absorbTail != null &&
+      end < words.length &&
+      words.length - end <= cfg.absorbTail &&
+      !hasBreakBetween(words, end - 1, words.length - 1)
+    ) {
+      end = words.length;
+    }
+    if (cfg.splitTail && words.length - end === 1 && end - i > 2) {
+      end -= 1;
+    }
+
+    const slice = words.slice(i, end);
+    const speechEnd = slice[slice.length - 1].end;
+    chunks.push({ words: slice, start: slice[0].start, end: speechEnd, displayEnd: speechEnd });
+    i = end;
+  }
+
+  for (let k = 0; k < chunks.length; k++) {
+    const next = chunks[k + 1];
+    const hold = next
+      ? Math.min(next.start, chunks[k].end + GAP_FILL_MAX_SECONDS)
+      : chunks[k].end + LAST_CHUNK_HOLD_SECONDS;
+    const capped = clipEnd != null ? Math.min(hold, clipEnd) : hold;
+    chunks[k].displayEnd = Math.max(chunks[k].end, capped);
+  }
+
+  return chunks;
+}
+
+export function activePreviewChunk(
+  chunks: PreviewChunk[],
+  time: number,
+): PreviewChunk | undefined {
+  return chunks.find((c) => time >= c.start && time < c.displayEnd);
+}

--- a/src/ui/client/captionChunks.ts
+++ b/src/ui/client/captionChunks.ts
@@ -23,10 +23,45 @@ export interface PreviewChunkOptions {
   splitTail?: boolean;
 }
 
+export interface TranscriptPreviewWord {
+  word?: string;
+  text?: string;
+  start: number;
+  end: number;
+  speaker?: string | null;
+}
+
+export interface PreviewClipBounds {
+  start_second: number;
+  end_second: number;
+}
+
 const BREAK_GAP_SECONDS = 0.8;
 const GAP_FILL_MAX_SECONDS = 0.4;
 const LAST_CHUNK_HOLD_SECONDS = 1.2;
 const TERMINAL_PUNCTUATION = /[.!?…]["')\]]?$/;
+
+export function selectPreviewWords(
+  transcriptWords: TranscriptPreviewWord[] | null | undefined,
+  activeClip?: PreviewClipBounds | null,
+): PreviewWord[] {
+  if (!transcriptWords?.length) return [];
+
+  const words = activeClip
+    ? transcriptWords.filter(
+        (word) => word.end > activeClip.start_second && word.start < activeClip.end_second,
+      )
+    : transcriptWords;
+
+  return words
+    .map((word) => ({
+      text: (word.word ?? word.text ?? "").trim(),
+      start: word.start,
+      end: word.end,
+      speaker: word.speaker,
+    }))
+    .filter((word) => word.text.length > 0);
+}
 
 function breaksAfter(prev: PreviewWord, next: PreviewWord): boolean {
   return (
@@ -99,5 +134,20 @@ export function activePreviewChunk(
   chunks: PreviewChunk[],
   time: number,
 ): PreviewChunk | undefined {
-  return chunks.find((c) => time >= c.start && time < c.displayEnd);
+  let low = 0;
+  let high = chunks.length - 1;
+
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const chunk = chunks[middle];
+    if (time < chunk.start) {
+      high = middle - 1;
+    } else if (time >= chunk.displayEnd) {
+      low = middle + 1;
+    } else {
+      return chunk;
+    }
+  }
+
+  return undefined;
 }

--- a/src/ui/client/lib.test.ts
+++ b/src/ui/client/lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fmt, fmtMs } from "./lib";
+import { fmt, fmtMs, findClipResult } from "./lib";
 
 describe("fmt", () => {
   it("formats sub-hour timestamps as m:ss", () => {
@@ -25,5 +25,46 @@ describe("fmtMs", () => {
   it("appends milliseconds", () => {
     expect(fmtMs(12.5)).toBe("0:12.500");
     expect(fmtMs(4711.25)).toBe("1:18:31.250");
+  });
+});
+
+describe("findClipResult", () => {
+  const clips = [
+    { start_second: 10, end_second: 40 },
+    { start_second: 120, end_second: 165 },
+    { start_second: 640, end_second: 700 },
+  ];
+
+  // An agent exporting only clip #3 gets one row back, at clip_index 0. Reading
+  // it positionally marked clip #1 as exported with clip #3's file.
+  it("lands an agent's single export on the clip it was rendered for", () => {
+    const results = [
+      { status: "success", output_path: "/out/third.mp4", source_start_second: 640, source_end_second: 700 },
+    ];
+    expect(findClipResult(results, clips[0], 0)).toBeUndefined();
+    expect(findClipResult(results, clips[1], 1)).toBeUndefined();
+    expect(findClipResult(results, clips[2], 2)?.output_path).toBe("/out/third.mp4");
+  });
+
+  // Parallel renders report as they finish, so results is sparse and out of order.
+  it("matches rows that arrived out of order", () => {
+    const results = [
+      undefined,
+      { status: "success", output_path: "/out/b.mp4", source_start_second: 120, source_end_second: 165 },
+    ];
+    expect(findClipResult(results, clips[0], 0)).toBeUndefined();
+    expect(findClipResult(results, clips[1], 1)?.output_path).toBe("/out/b.mp4");
+  });
+
+  it("falls back to position only for rows with no bounds", () => {
+    const results = [{ status: "success", output_path: "/out/legacy.mp4" }];
+    expect(findClipResult(results, clips[0], 0)?.output_path).toBe("/out/legacy.mp4");
+  });
+
+  it("tolerates float noise in the bounds", () => {
+    const results = [
+      { status: "success", output_path: "/out/a.mp4", source_start_second: 10.001, source_end_second: 40 },
+    ];
+    expect(findClipResult(results, clips[0], 0)?.output_path).toBe("/out/a.mp4");
   });
 });

--- a/src/ui/client/lib.test.ts
+++ b/src/ui/client/lib.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { fmt, fmtMs, findClipResult } from "./lib";
+import {
+  fmt,
+  fmtMs,
+  findClipResult,
+  buildEnergyMap,
+  clipKey,
+  dropEnergy,
+  clampClipIndex,
+} from "./lib";
 
 describe("fmt", () => {
   it("formats sub-hour timestamps as m:ss", () => {
@@ -66,5 +74,74 @@ describe("findClipResult", () => {
       { status: "success", output_path: "/out/a.mp4", source_start_second: 10.001, source_end_second: 40 },
     ];
     expect(findClipResult(results, clips[0], 0)?.output_path).toBe("/out/a.mp4");
+  });
+});
+
+describe("buildEnergyMap", () => {
+  const clips = [
+    { clip_id: "c1", start_second: 10, end_second: 40 },
+    { clip_id: "c2", start_second: 120, end_second: 165 },
+    { clip_id: "c3", start_second: 640, end_second: 700 },
+    { clip_id: "c4", start_second: 900, end_second: 940 },
+  ];
+
+  it("scores each clip on its own identity", () => {
+    const map = buildEnergyMap([8.2, 5, 2.5, 7], clips);
+    expect(map.c1).toEqual({ score: 8.2, level: "high" });
+    expect(map.c2).toEqual({ score: 5, level: "medium" });
+    expect(map.c3).toEqual({ score: 2.5, level: "low" });
+  });
+
+  // Keyed by position, deleting clip #2 slid every score up one row and left the
+  // last row showing a badge for a clip that no longer existed.
+  it("keeps scores on their clips after an agent deletes one", () => {
+    const map = buildEnergyMap([8.2, 5, 2.5, 7], clips);
+    const remaining = clips.filter((c) => c.clip_id !== "c2");
+    expect(remaining.map((c) => map[clipKey(c)]?.score)).toEqual([8.2, 2.5, 7]);
+    expect(Object.keys(map).filter((k) => !remaining.some((c) => clipKey(c) === k))).toEqual(["c2"]);
+  });
+
+  it("keeps scores on their clips after a range edit shifts a later clip", () => {
+    const map = buildEnergyMap([8.2, 5, 2.5, 7], clips);
+    const edited = { ...clips[1], start_second: 118, end_second: 170 };
+    const after = [clips[0], edited, clips[2], clips[3]];
+    expect(dropEnergy(map, clips[1])[clipKey(edited)]).toBeUndefined();
+    expect(after.map((c) => map[clipKey(c)]?.score)).toEqual([8.2, 5, 2.5, 7]);
+  });
+
+  // A session persisted before suggestions carried a clip_id.
+  it("falls back to bounds when a clip has no id", () => {
+    const legacy = [
+      { start_second: 10, end_second: 40 },
+      { start_second: 120, end_second: 165 },
+    ];
+    const map = buildEnergyMap([9, 3], legacy);
+    expect(map[clipKey(legacy[0])].score).toBe(9);
+    expect(map[clipKey(legacy[1])].score).toBe(3);
+  });
+
+  it("ignores scores with no clip and clips with no score", () => {
+    expect(buildEnergyMap([7, null, 4], clips.slice(0, 2))).toEqual({
+      c1: { score: 7, level: "high" },
+    });
+  });
+});
+
+describe("clampClipIndex", () => {
+  // j/k left the cursor past the end when an agent deleted the last clip, so
+  // space deselected an index no row owned and the header count lied.
+  it("pulls the cursor back onto the last row when the list shrinks", () => {
+    expect(clampClipIndex(4, 4)).toBe(3);
+    expect(clampClipIndex(9, 1)).toBe(0);
+  });
+
+  it("leaves an in-range cursor alone", () => {
+    expect(clampClipIndex(2, 5)).toBe(2);
+    expect(clampClipIndex(0, 1)).toBe(0);
+  });
+
+  it("clears the cursor when there are no clips", () => {
+    expect(clampClipIndex(0, 0)).toBeNull();
+    expect(clampClipIndex(null, 5)).toBeNull();
   });
 });

--- a/src/ui/client/lib.ts
+++ b/src/ui/client/lib.ts
@@ -83,3 +83,40 @@ export function timeAgo(iso: string): string {
 }
 
 export const basename = (p: string) => (p || "").split(/[/\\]/).pop() || "";
+
+// A render result's clip_index counts the clips submitted to the renderer, which
+// for an agent-driven export is not the studio's clip order. The server stamps
+// every row with the bounds of the clip it rendered; match a result to a clip on
+// those instead of on position.
+export const clipBoundsKey = (start?: number, end?: number): string | null =>
+  typeof start === "number" && typeof end === "number"
+    ? `${start.toFixed(2)}:${end.toFixed(2)}`
+    : null;
+
+export const resultBoundsKey = (row?: ClipResultRow | null): string | null =>
+  row ? clipBoundsKey(row.source_start_second, row.source_end_second) : null;
+
+interface ClipResultRow {
+  source_start_second?: number;
+  source_end_second?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * The result for `clip`, or undefined if it has not been rendered. Rows written
+ * before the server stamped bounds (a restored session) carry no key, so they
+ * still land by position.
+ */
+export function findClipResult<T extends ClipResultRow>(
+  results: (T | undefined)[],
+  clip: { start_second?: number; end_second?: number },
+  positionalIdx: number,
+): T | undefined {
+  const key = clipBoundsKey(clip.start_second, clip.end_second);
+  if (key) {
+    const keyed = results.find((row) => resultBoundsKey(row) === key);
+    if (keyed) return keyed;
+  }
+  const row = results[positionalIdx];
+  return row && !resultBoundsKey(row) ? row : undefined;
+}

--- a/src/ui/client/lib.ts
+++ b/src/ui/client/lib.ts
@@ -102,6 +102,58 @@ interface ClipResultRow {
   [key: string]: unknown;
 }
 
+interface ClipIdentity {
+  clip_id?: string;
+  start_second?: number;
+  end_second?: number;
+}
+
+// A suggestion's position shifts whenever an agent deletes or inserts a clip, so
+// anything the studio computes per clip is keyed by identity instead. Sessions
+// persisted before clips carried a clip_id fall back to their bounds, which also
+// makes a re-timed clip drop its stale score.
+export const clipKey = (clip: ClipIdentity): string =>
+  clip.clip_id || clipBoundsKey(clip.start_second, clip.end_second) || "";
+
+type EnergyLevel = "high" | "medium" | "low";
+interface EnergyEntry {
+  score: number;
+  level: EnergyLevel;
+}
+
+const energyLevel = (score: number): EnergyLevel =>
+  score >= 7 ? "high" : score >= 4 ? "medium" : "low";
+
+/** Maps the backend's positional segment scores onto the clips they were measured for. */
+export function buildEnergyMap(
+  scores: unknown[],
+  clips: ClipIdentity[],
+): Record<string, EnergyEntry> {
+  const map: Record<string, EnergyEntry> = {};
+  scores.forEach((score, i) => {
+    const clip = clips[i];
+    if (!clip || typeof score !== "number") return;
+    const key = clipKey(clip);
+    if (key) map[key] = { score, level: energyLevel(score) };
+  });
+  return map;
+}
+
+export function dropEnergy(
+  map: Record<string, EnergyEntry>,
+  clip: ClipIdentity,
+): Record<string, EnergyEntry> {
+  const key = clipKey(clip);
+  if (!key || !(key in map)) return map;
+  const next = { ...map };
+  delete next[key];
+  return next;
+}
+
+/** Keeps the keyboard cursor on a row that exists after the clip list changes. */
+export const clampClipIndex = (idx: number | null, length: number): number | null =>
+  idx === null || length === 0 ? null : Math.min(idx, length - 1);
+
 /**
  * The result for `clip`, or undefined if it has not been rendered. Rows written
  * before the server stamped bounds (a restored session) carry no key, so they

--- a/src/ui/client/useDialog.ts
+++ b/src/ui/client/useDialog.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), video[controls], [tabindex]:not([tabindex="-1"])';
+
+export function useDialog(active: boolean, onClose: () => void) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const closeRef = useRef(onClose);
+  closeRef.current = onClose;
+
+  useEffect(() => {
+    if (!active) return;
+    const node = ref.current;
+    if (!node) return;
+    const previous = document.activeElement as HTMLElement | null;
+    const focusables = () => Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE));
+    if (!node.contains(document.activeElement)) {
+      (focusables()[0] || node).focus();
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        closeRef.current();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const els = focusables();
+      if (!els.length) return;
+      const first = els[0];
+      const last = els[els.length - 1];
+      const current = document.activeElement;
+      const outside = !node.contains(current);
+      if (e.shiftKey && (current === first || outside)) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (current === last || outside)) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => {
+      document.removeEventListener("keydown", onKey, true);
+      previous?.focus?.();
+    };
+  }, [active]);
+
+  return ref;
+}

--- a/src/ui/public/css/styles.css
+++ b/src/ui/public/css/styles.css
@@ -636,7 +636,6 @@ select {
 }
 .clip-item:hover { border-color: var(--border-hover); }
 .clip-item.dimmed { opacity: 0.35; }
-.clip-item.active-clip { border-color: rgba(217, 118, 49, 0.3); background: rgba(217, 118, 49, 0.03); }
 .clip-item.selected { border-color: var(--accent); background: rgba(217, 118, 49, 0.04); }
 .checkbox {
   width: 20px; height: 20px; border-radius: 6px;
@@ -656,7 +655,6 @@ select {
 .clip-actions { display: flex; gap: 4px; flex-shrink: 0; }
 .clip-status { width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 11px; font-weight: 700; }
 .clip-status.pending { border: 1.5px dashed var(--border); }
-.clip-status.rendering { border: 2px solid var(--border); border-top-color: var(--accent); animation: spin 0.6s linear infinite; }
 .clip-status.exported { background: var(--green-subtle); color: var(--green); }
 .status-dot { width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 12px; }
 .status-dot.ok { background: var(--green-subtle); color: var(--green); }
@@ -998,6 +996,27 @@ pre .punct { color: var(--text2); }
   font-family: 'JetBrains Mono', monospace; font-size: 11.5px;
   color: var(--accent); border: 1px solid var(--border);
 }
+
+/* ─── Setup checklist ─── */
+.setup-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; margin-bottom: 14px; }
+.setup-steps { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+.setup-step {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 0; border-top: 1px solid var(--border);
+}
+.setup-step:first-child { border-top: none; }
+.setup-mark {
+  width: 20px; height: 20px; border-radius: 50%; flex-shrink: 0;
+  border: 1px dashed var(--border); color: var(--green);
+  display: flex; align-items: center; justify-content: center;
+}
+.setup-step.done .setup-mark { border: 1px solid var(--green-border); background: var(--green-subtle); }
+.setup-body { flex: 1; min-width: 0; }
+.setup-title { font-size: 13px; font-weight: 600; line-height: 1.4; }
+.setup-step.done .setup-title { color: var(--text2); }
+.setup-desc { font-size: 12px; color: var(--text3); line-height: 1.5; margin-top: 2px; }
+.setup-action { flex-shrink: 0; }
+.setup-action .btn { text-decoration: none; }
 .tool-grid { display: grid; gap: 8px; }
 .tool-item {
   display: flex; align-items: flex-start; gap: 12px;
@@ -1161,6 +1180,8 @@ input[type="range"]::-webkit-slider-thumb {
 @media (max-width: 640px) {
   .app { padding: 28px 16px 64px; }
   .file-grid { grid-template-columns: 1fr; }
+  .setup-step { flex-wrap: wrap; }
+  .setup-action { padding-left: 32px; }
 }
 
 /* ── Dashboard shell ── */

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -3468,6 +3468,15 @@ app.post("/api/ui-state", (req, res) => {
   res.json({ ok: true });
 });
 
+// Mirrors clipKey() in the studio client: energy scores are keyed by clip
+// identity, not by position, so they survive a suggestion being spliced out.
+function dropEnergy(clip: SuggestedClip): void {
+  const key =
+    clip.clip_id ||
+    `${clip.start_second.toFixed(2)}:${clip.end_second.toFixed(2)}`;
+  delete uiState.energyData[key];
+}
+
 /**
  * POST /api/suggestions/modify — mutate one suggestion in-place on the server.
  * Replaces the read-modify-replace cycle MCP tools used, which lost concurrent
@@ -3491,6 +3500,7 @@ app.post("/api/suggestions/modify", (req, res) => {
     uiState.deselectedIndices = uiState.deselectedIndices
       .filter((i) => i !== index)
       .map((i) => (i > index ? i - 1 : i));
+    dropEnergy(clip);
   } else if (action === "toggle") {
     if (typeof selected !== "boolean") {
       res.status(400).json({ error: "selected must be a boolean for action 'toggle'" });
@@ -3512,6 +3522,8 @@ app.post("/api/suggestions/modify", (req, res) => {
       res.status(400).json({ error: rangeError });
       return;
     }
+    // The energy score was measured over the old range.
+    if (nextStart !== clip.start_second || nextEnd !== clip.end_second) dropEnergy(clip);
     if (typeof upd.title === "string") clip.title = upd.title;
     clip.start_second = nextStart;
     clip.end_second = nextEnd;


### PR DESCRIPTION
Reviewing a clip meant watching the rest of the episode: the preview seeked
to the start and never stopped, and the caption overlay ran on a timer that
had nothing to do with the video clock.

- Previews stop at the clip boundary, with replay
- The caption preview follows the video and mirrors the renderer's chunking,
  with a parity test so the two cannot drift
- Clips flip to done or failed as each one finishes, from real events
- Trimming is a drag, reusing the highlights component, with bounds clamped
- Dialogs trap focus and close on escape; rows, toggles, and tabs are
  operable from the keyboard, with j, k, space, and e shortcuts

Part of the product audit. Stacked on `audit-5-mcp`, so review only this PR's diff and merge in order.