### PR TITLE
Guide first-run setup in the CLI and the studio

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -3687,8 +3687,18 @@ Add the cliches your niche is drowning in as you spot them.
 """
 
 
+def _wizard_ask(question, on_eof=None):
+    """questionary turns Ctrl-C into None itself, but lets Ctrl-D escape as EOFError."""
+    try:
+        return question.ask()
+    except EOFError:
+        return on_eof
+
+
 def _first_run_setup() -> bool:
-    """Guided setup on the first interactive run. Skippable, asked once."""
+    """Guided setup on the first interactive run. Skippable, asked once.
+    False means the user cancelled: nothing is saved and the caller must not
+    treat the run as a success."""
     accent = "\033[38;2;212;135;74m"
     gray = "\033[38;5;245m"
     green = "\033[38;2;74;222;128m"
@@ -3715,7 +3725,7 @@ def _first_run_setup() -> bool:
     print(f"  {gray}Six questions, then podcli scores clips against your show instead of a generic template.{reset}")
     print()
 
-    start = questionary.confirm("Set it up now?", default=True, style=qstyle).ask()
+    start = _wizard_ask(questionary.confirm("Set it up now?", default=True, style=qstyle), on_eof=False)
     if start is None:
         return False
     if not start:
@@ -3733,7 +3743,7 @@ def _first_run_setup() -> bool:
     ]
     answers = {}
     for key, prompt in questions:
-        value = questionary.text(prompt, style=qstyle).ask()
+        value = _wizard_ask(questionary.text(prompt, style=qstyle))
         if value is None:
             return False
         answers[key] = value.strip()
@@ -3755,14 +3765,14 @@ def _first_run_setup() -> bool:
 
     cmd_knowledge(argparse.Namespace(knowledge_action="init"))
 
-    nxt = questionary.select(
+    nxt = _wizard_ask(questionary.select(
         "The other 12 files are starter templates. Next:",
         choices=[
             questionary.Choice("Draft them from an existing channel", value="bootstrap"),
             questionary.Choice("Fill them in later", value="later"),
         ],
         style=qstyle,
-    ).ask()
+    ))
 
     if nxt is None:
         return False
@@ -4122,7 +4132,8 @@ def main():
         return
 
     if _needs_onboarding() and not _first_run_setup():
-        return
+        print("  Setup cancelled. Your command did not run.", file=sys.stderr)
+        sys.exit(130)
 
     if args.command == "process":
         if not getattr(args, "no_banner", False):

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -20,6 +20,8 @@ import textwrap
 import time
 from pathlib import Path
 
+import questionary
+from questionary import Style
 from version import VERSION
 
 # Windows streams default to cp1252, which can't encode chars like '→'; podcli is UTF-8.
@@ -3685,12 +3687,8 @@ Add the cliches your niche is drowning in as you spot them.
 """
 
 
-def _first_run_setup() -> None:
+def _first_run_setup() -> bool:
     """Guided setup on the first interactive run. Skippable, asked once."""
-    import argparse as _ap
-    import questionary
-    from questionary import Style
-
     accent = "\033[38;2;212;135;74m"
     gray = "\033[38;5;245m"
     green = "\033[38;2;74;222;128m"
@@ -3710,7 +3708,7 @@ def _first_run_setup() -> None:
     kb_dir = paths["knowledge"]
     if not kb_is_empty(kb_dir):
         _mark_onboarded()
-        return
+        return True
 
     print()
     print(f"  {bold}Welcome to podcli{reset}")
@@ -3719,11 +3717,11 @@ def _first_run_setup() -> None:
 
     start = questionary.confirm("Set it up now?", default=True, style=qstyle).ask()
     if start is None:
-        return
+        return False
     if not start:
         _mark_onboarded()
         print(f"  {gray}Later: run{reset} podcli knowledge init {gray}and fill in the templates.{reset}\n")
-        return
+        return True
 
     questions = [
         ("show_name", "Show name:"),
@@ -3737,13 +3735,13 @@ def _first_run_setup() -> None:
     for key, prompt in questions:
         value = questionary.text(prompt, style=qstyle).ask()
         if value is None:
-            return
+            return False
         answers[key] = value.strip()
 
     if not answers["show_name"]:
         _mark_onboarded()
         print(f"  {gray}Nothing to save. Run{reset} podcli knowledge init {gray}when you're ready.{reset}\n")
-        return
+        return True
 
     os.makedirs(kb_dir, exist_ok=True)
     for fname, content in (
@@ -3755,7 +3753,7 @@ def _first_run_setup() -> None:
     print(f"\n  {green}✓{reset} 01-brand-identity.md")
     print(f"  {green}✓{reset} 02-voice-and-tone.md")
 
-    cmd_knowledge(_ap.Namespace(knowledge_action="init"))
+    cmd_knowledge(argparse.Namespace(knowledge_action="init"))
 
     nxt = questionary.select(
         "The other 12 files are starter templates. Next:",
@@ -3766,6 +3764,8 @@ def _first_run_setup() -> None:
         style=qstyle,
     ).ask()
 
+    if nxt is None:
+        return False
     if nxt == "bootstrap":
         print(f"\n  {gray}In Claude Code, run:{reset} {accent}/bootstrap-knowledge <channel-url>{reset}")
         print(f"  {gray}It reads the channel and drafts the remaining files for you.{reset}")
@@ -3775,6 +3775,7 @@ def _first_run_setup() -> None:
 
     _mark_onboarded()
     print()
+    return True
 
 
 def main():
@@ -4120,8 +4121,8 @@ def main():
         print_help()
         return
 
-    if _needs_onboarding():
-        _first_run_setup()
+    if _needs_onboarding() and not _first_run_setup():
+        return
 
     if args.command == "process":
         if not getattr(args, "no_banner", False):

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -18,6 +18,8 @@ import subprocess
 import sys
 import textwrap
 import time
+from pathlib import Path
+
 from version import VERSION
 
 # Windows streams default to cp1252, which can't encode chars like '→'; podcli is UTF-8.
@@ -47,7 +49,6 @@ if os.path.exists(_env_file):
 os.environ["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
 if sys.platform == "darwin":
     os.environ.setdefault("DYLD_LIBRARY_PATH", "")
-os.environ.setdefault("PODCLI_TRANSITION_AUTOFIX_PASSES", "2")
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -69,6 +70,7 @@ def _reveal_in_os(path: str) -> None:
 
 from config.paths import paths
 from presets import MIN_CLIP_DURATION, MAX_CLIP_DURATION, TARGET_CLIP_DURATION_MIN, TARGET_CLIP_DURATION_MAX
+from services.knowledge_base import is_empty as kb_is_empty, kb_files
 
 
 def _suggestions_session_path(cache_hash: str) -> str:
@@ -315,6 +317,44 @@ def _resolve_output_dir(
     if os.path.basename(normalized_base) == preset_folder:
         return base_output_dir
     return os.path.join(base_output_dir, preset_folder)
+
+
+class _SharedWav:
+    """Lazily extracted 16 kHz mono WAV shared by transcription, energy and
+    reaction analysis so the source video is decoded once per run."""
+
+    def __init__(self, media_path: str):
+        self.media_path = media_path
+        self.path = None
+        self.error = None
+        self._failed = False
+        import atexit
+        atexit.register(self.cleanup)
+
+    def get(self) -> str | None:
+        if self.path and os.path.exists(self.path):
+            return self.path
+        # A decode that fails slowly (or hangs to the 1800s timeout) would be
+        # retried by each caller, so the failure is remembered too.
+        if self._failed:
+            return None
+        try:
+            from services.audio_extract import extract_wav_16k_mono
+            self.path = extract_wav_16k_mono(self.media_path)
+        except Exception as e:
+            self.error = e
+            self.path = None
+        if not self.path:
+            self._failed = True
+        return self.path
+
+    def cleanup(self) -> None:
+        if self.path and os.path.exists(self.path):
+            try:
+                os.unlink(self.path)
+            except OSError:
+                pass
+        self.path = None
 
 
 def _has_successful_results(results: list) -> bool:
@@ -618,6 +658,13 @@ def cmd_process(args):
     print(f"  Video:   {os.path.basename(video_path)}")
     print()
 
+    if kb_is_empty():
+        yellow = "\033[38;2;250;204;21m"
+        reset = "\033[0m"
+        print(f"  {yellow}⚠ Knowledge base empty, clips will be scored without your show context.{reset}")
+        print(f"  {yellow}  Run: podcli knowledge init{reset}")
+        print()
+
     # Cache hash for resume — keyed by video size+mtime. Disabled when a custom
     # transcript is supplied, since the hash ignores transcript contents and
     # would otherwise resume suggestions made from a different transcript.
@@ -635,6 +682,7 @@ def cmd_process(args):
     words = []
     segments = []
     result = {}
+    shared_wav = _SharedWav(video_path)
 
     # Saliency profiles (party/action) select on audio/visual signals, not dialogue,
     # so transcribing a long video would be wasted work — skip it entirely.
@@ -725,12 +773,16 @@ def cmd_process(args):
                 _spin_msg[0] = f"{msg} ({pct}%)" if pct < 100 else msg
 
             try:
+                # Only pre-extract the shared wav when the energy step will
+                # reuse it anyway; otherwise let the engine decide (whisper-py
+                # and AssemblyAI decode the source themselves).
                 result = transcribe_file(
                     file_path=video_path,
                     model_size=config.get("whisper_model", "base"),
                     engine=os.environ.get("PODCLI_ENGINE") or None,
                     enable_diarization=not config.get("no_speakers", False),
                     progress_callback=_transcribe_progress,
+                    wav_path=shared_wav.get() if config.get("energy_boost", True) else None,
                 )
             except (RuntimeError, FileNotFoundError, subprocess.CalledProcessError) as e:
                 _spin_stop.set()
@@ -772,18 +824,24 @@ def cmd_process(args):
     # ── Step 2: Analyze audio energy ──
     energy_scores = None
     reaction_scores = None
+    energy_data = None
+    events_data = None
+    reaction_times = None
     if config.get("energy_boost", True):
         print("  [2/4] Analyzing audio energy...")
         try:
-            profile = get_energy_profile(video_path, segments)
+            profile = get_energy_profile(video_path, segments, wav_path=shared_wav.get())
             energy_scores = profile["segment_scores"]
+            energy_data = profile["energy_data"]
             print(f"         {len(profile['peak_times'])} peak moments found")
         except Exception as e:
             print(f"         Skipped (error: {e})")
         if audio_events_available():
             try:
-                reactions = get_event_profile(video_path, segments)
+                reactions = get_event_profile(video_path, segments, wav_path=shared_wav.get())
                 reaction_scores = reactions["segment_scores"]
+                events_data = reactions["events_data"]
+                reaction_times = reactions["reaction_times"]
                 n = len(reactions["reaction_times"])
                 if n:
                     print(f"         {n} laughter/reaction moments found")
@@ -824,6 +882,9 @@ def cmd_process(args):
             segments=segments or None,
             words=words or None,
             progress_callback=lambda pct, msg: print(f"         {msg}") if msg else None,
+            energy_data=energy_data,
+            events_data=events_data,
+            wav_path=shared_wav.get(),
         )
         if clips:
             print(f"         ✓ {len(clips)} highlights found")
@@ -832,7 +893,9 @@ def cmd_process(args):
             print("         ⚠ No highlights found, falling back to transcript selection")
 
     # Try an AI CLI first (uses PodStack knowledge base for intelligent selection)
-    from services.claude_suggest import suggest_initial_with_claude, _engine_label, _find_ai_cli
+    from services.claude_suggest import (
+        suggest_initial_with_claude, blend_signal_scores, _engine_label, _find_ai_cli,
+    )
 
     ai_path, ai_engine = _find_ai_cli()
     if clips:
@@ -844,8 +907,10 @@ def cmd_process(args):
             segments=segments,
             top_n=top_n,
             progress_callback=lambda pct, msg: print(f"         {msg}") if msg else None,
+            reaction_times=reaction_times,
         )
         if clips:
+            blend_signal_scores(clips, energy_data=energy_data, events_data=events_data)
             actual_engine = next((c.get("_ai_engine") for c in clips if c.get("_ai_engine")), ai_engine)
             print(f"         ✓ {_engine_label(actual_engine)} selected {len(clips)} clips")
             _save_suggestions_session(cache_hash, top_n, actual_engine, clips, selection_sig)
@@ -873,6 +938,9 @@ def cmd_process(args):
     if not clips:
         print("  No clips found. Try a longer transcript or lower --min-duration.", file=sys.stderr)
         sys.exit(1)
+
+    # Rendering reads the source video directly; the shared wav is done.
+    shared_wav.cleanup()
 
     # ── Step 3.5: Interactive review ──
     clips = _review_clips(clips, segments, energy_scores, config)
@@ -2700,15 +2768,42 @@ def cmd_knowledge(args):
 
     action = getattr(args, "knowledge_action", None) or "list"
 
-    if action == "list":
+    if action == "init":
+        templates_dir = Path(__file__).resolve().parent / "templates" / "knowledge"
+        templates = sorted(templates_dir.glob("*.md"))
+        if not templates:
+            print(f"  {red}✗{reset} No templates found at {templates_dir}", file=sys.stderr)
+            return
+        os.makedirs(kb_dir, exist_ok=True)
+        created, skipped = [], []
+        for tpl in templates:
+            target = os.path.join(kb_dir, tpl.name)
+            if os.path.exists(target):
+                skipped.append(tpl.name)
+                continue
+            shutil.copyfile(tpl, target)
+            created.append(tpl.name)
         print(f"\n  {bold}Knowledge Base{reset}")
         print(f"  {'─' * 45}")
-        if not os.path.isdir(kb_dir):
-            print(f"  {gray}Empty — no knowledge files{reset}\n")
-            return
-        files = sorted(f for f in os.listdir(kb_dir) if f.endswith(".md"))
+        for fname in created:
+            print(f"  {green}✓{reset} {fname}")
+        for fname in skipped:
+            print(f"  {gray}• {fname} (exists, kept){reset}")
+        print(f"  {'─' * 45}")
+        print(f"  {gray}{len(created)} created, {len(skipped)} kept in {kb_dir}{reset}")
+        if created:
+            print(f"  {gray}Fill in the [brackets], starting with 01-brand-identity and 02-voice-and-tone,{reset}")
+            print(f"  {gray}or run /bootstrap-knowledge in your agent to draft them from an existing channel.{reset}\n")
+        else:
+            print()
+
+    elif action == "list":
+        print(f"\n  {bold}Knowledge Base{reset}")
+        print(f"  {'─' * 45}")
+        empty_hint = f"  {gray}Empty — run{reset} podcli knowledge init {gray}to create the starter templates{reset}\n"
+        files = kb_files(kb_dir)
         if not files:
-            print(f"  {gray}Empty — no knowledge files{reset}\n")
+            print(empty_hint)
             return
         for fname in files:
             fpath = os.path.join(kb_dir, fname)
@@ -2994,7 +3089,7 @@ def cmd_clips(args):
         print(f"\n  {green}✓{reset} Reopened {accent}{str(clip.get('id'))[:8]}{reset}  {bold}{clip.get('title')}{reset}")
         if not transcript:
             print(f"      {gray}Transcript not loaded — re-transcribe in the studio to edit captions.{reset}")
-        print(f"      {gray}Open the studio:{reset} {accent}http://localhost:3847/clip/{clip.get('id')}{reset}\n")
+        print(f"      {gray}Open the studio:{reset} {accent}http://localhost:{_webui_port()}/clip/{clip.get('id')}{reset}\n")
         return
 
 
@@ -3340,9 +3435,7 @@ def print_banner():
     except Exception:
         encoder_label = "CPU"
 
-    # Count knowledge base files
-    kb_path = paths["knowledge"]
-    kb_count = len([f for f in os.listdir(kb_path) if f.endswith(".md")]) if os.path.isdir(kb_path) else 0
+    kb_count = len(kb_files())
 
     gray = "\033[38;5;245m"
     accent = "\033[38;2;212;135;74m"
@@ -3388,7 +3481,8 @@ def print_banner():
     ai_tag = f"{green}✓ {ai_label}{reset}" if ai_path else f"{yellow}✗{reset}"
     speaker_tag = f"{green}✓{reset}" if speakers_ok else f"{yellow}✗{reset}"
     cache_tag = f"{green}{cache_count}{reset}" if cache_count else f"{gray}0{reset}"
-    print(f"  {gray}Encoder {green}{encoder_label}{reset} {gray}· {ai_tag} {gray}· Speakers {speaker_tag} {gray}· Cache {cache_tag}{reset}")
+    kb_tag = f"{green}{kb_count}{reset}" if kb_count else f"{yellow}0{reset}"
+    print(f"  {gray}Encoder {green}{encoder_label}{reset} {gray}· {ai_tag} {gray}· Speakers {speaker_tag} {gray}· Cache {cache_tag} {gray}· Knowledge {kb_tag}{reset}")
 
     # Assets — one line if any
     try:
@@ -3437,6 +3531,9 @@ def print_banner():
         else:
             print(f"  {yellow}⚠ Speaker detection needs a token — run: podcli env set HF_TOKEN <token>{reset}")
 
+    if not kb_count:
+        print(f"  {yellow}⚠ Knowledge base empty, clips get scored without your show context. Run: podcli knowledge init{reset}")
+
     print()
 
 
@@ -3461,7 +3558,8 @@ def print_help():
     print(f"    {accent}assets{reset}  {gray}<action>{reset}      Manage logos, intros, outros")
     print(f"    {accent}presets{reset} {gray}<action>{reset}      Save/load rendering presets")
     print(f"    {accent}thumbnails{reset} {gray}<title>{reset}   Generate thumbnail variations")
-    print(f"    {accent}knowledge{reset} {gray}<action>{reset}    Manage knowledge base (.podcli/knowledge/)")
+    print(f"    {accent}knowledge init{reset}        Create the starter templates for your show")
+    print(f"    {accent}knowledge{reset} {gray}<action>{reset}    list | read | edit | delete knowledge files")
     print(f"    {accent}config{reset} {gray}<action>{reset}        Export/import/migrate config profiles")
     print(f"    {accent}corrections{reset} {gray}<action>{reset}  Fix Whisper misheard words (Boxel→Voxel)")
     print(f"    {accent}cache{reset}  {gray}[clear]{reset}       Show/clear transcription cache")
@@ -3493,15 +3591,189 @@ def print_help():
     print()
     print(f"  {bold}PodStack{reset} {dim}(Claude Code slash commands):{reset}")
     print(f"    {accent}/auto{reset}                  One-verb pipeline: confirm strategy → render clips")
-    print(f"    {accent}/prep-episode{reset}          Full pipeline: transcript → publish-ready")
+    print(f"    {accent}/bootstrap-knowledge{reset}   Draft your knowledge base from an existing channel")
+    print(f"    {accent}/plan-episode{reset}          Design questions and target moments before recording")
+    print(f"    {accent}/produce-shorts{reset}        Full pipeline: transcript → publish-ready")
     print(f"    {accent}/process-transcript{reset}    Extract clip-worthy moments from transcript")
     print(f"    {accent}/generate-titles{reset}       Generate 8 title options with verification")
     print(f"    {accent}/generate-descriptions{reset} Descriptions + hashtags + SEO")
     print(f"    {accent}/plan-thumbnails{reset}       Thumbnail text + layout briefs")
     print(f"    {accent}/review-content{reset}        Brand voice & quality gate check")
     print(f"    {accent}/publish-checklist{reset}     Pre/post-publish checklist")
+    print(f"    {accent}/retro-episode{reset}         Performance review + learnings after publishing")
     print()
     print(f"  {gray}Run {reset}podcli <command> --help{gray} for command-specific options{reset}")
+    print()
+
+
+def _onboarding_marker() -> str:
+    return os.path.join(paths["home"], ".onboarded")
+
+
+def _needs_onboarding() -> bool:
+    if os.environ.get("PODCLI_NO_ONBOARDING"):
+        return False
+    if os.path.exists(_onboarding_marker()):
+        return False
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _mark_onboarded() -> None:
+    marker = _onboarding_marker()
+    os.makedirs(os.path.dirname(marker), exist_ok=True)
+    with open(marker, "w", encoding="utf-8") as f:
+        f.write(VERSION + "\n")
+
+
+def _render_brand_identity(answers: dict) -> str:
+    hosts = [h.strip() for h in answers.get("hosts", "").split(",") if h.strip()]
+    host_lines = "\n".join(f"- {h}" for h in hosts) or "- (add the hosts)"
+    return f"""# Brand identity
+
+## Show
+
+- Name: {answers.get('show_name', '').strip()}
+- Format: {answers.get('format', '').strip()}
+- Language: {answers.get('language', '').strip()}
+
+## Hosts
+
+{host_lines}
+
+## Audience
+
+- Who watches: {answers.get('audience', '').strip()}
+
+## Still to write
+
+- One-line positioning: who the show is for and what they get out of it.
+- The promise: what every episode leaves the viewer with.
+- What this show is not: two or three things it deliberately avoids.
+"""
+
+
+def _render_voice_and_tone(answers: dict) -> str:
+    hosts = [h.strip() for h in answers.get("hosts", "").split(",") if h.strip()]
+    host_phrase = " and ".join(hosts) if hosts else "a host"
+    return f"""# Voice and tone
+
+## Voice fingerprint
+
+{answers.get('show_name', '').strip()} sounds: {answers.get('voice', '').strip()}
+
+Every title, description, and thumbnail line has to sound like {host_phrase} talking, in {answers.get('language', '').strip()}.
+
+## The coffee test
+
+Copy should sound like something a host would say to a friend over coffee. If it reads like marketing, rewrite it.
+
+## Banned words and phrases
+
+Never use these in titles, descriptions, or thumbnails:
+
+- insane, mind-blowing, game-changer
+- you won't believe
+- this changed everything
+
+Add the cliches your niche is drowning in as you spot them.
+
+## Punctuation and style
+
+- Sentence case titles, no all-caps words.
+- Numerals over spelled-out numbers.
+- Emoji: none in titles.
+"""
+
+
+def _first_run_setup() -> None:
+    """Guided setup on the first interactive run. Skippable, asked once."""
+    import argparse as _ap
+    import questionary
+    from questionary import Style
+
+    accent = "\033[38;2;212;135;74m"
+    gray = "\033[38;5;245m"
+    green = "\033[38;2;74;222;128m"
+    bold = "\033[1m"
+    reset = "\033[0m"
+
+    qstyle = Style([
+        ("qmark", "fg:#d97631 bold"),
+        ("question", "bold"),
+        ("answer", "fg:#4ade80"),
+        ("pointer", "fg:#d97631 bold"),
+        ("highlighted", "fg:#d97631 bold"),
+        ("selected", "fg:#4ade80"),
+        ("instruction", "fg:#a1a1aa"),
+    ])
+
+    kb_dir = paths["knowledge"]
+    if not kb_is_empty(kb_dir):
+        _mark_onboarded()
+        return
+
+    print()
+    print(f"  {bold}Welcome to podcli{reset}")
+    print(f"  {gray}Six questions, then podcli scores clips against your show instead of a generic template.{reset}")
+    print()
+
+    start = questionary.confirm("Set it up now?", default=True, style=qstyle).ask()
+    if start is None:
+        return
+    if not start:
+        _mark_onboarded()
+        print(f"  {gray}Later: run{reset} podcli knowledge init {gray}and fill in the templates.{reset}\n")
+        return
+
+    questions = [
+        ("show_name", "Show name:"),
+        ("hosts", "Host names (comma separated):"),
+        ("audience", "Who watches, in one line:"),
+        ("language", "Main language:"),
+        ("format", "Format (e.g. interview, 60 min, weekly):"),
+        ("voice", "The show's voice in three words:"),
+    ]
+    answers = {}
+    for key, prompt in questions:
+        value = questionary.text(prompt, style=qstyle).ask()
+        if value is None:
+            return
+        answers[key] = value.strip()
+
+    if not answers["show_name"]:
+        _mark_onboarded()
+        print(f"  {gray}Nothing to save. Run{reset} podcli knowledge init {gray}when you're ready.{reset}\n")
+        return
+
+    os.makedirs(kb_dir, exist_ok=True)
+    for fname, content in (
+        ("01-brand-identity.md", _render_brand_identity(answers)),
+        ("02-voice-and-tone.md", _render_voice_and_tone(answers)),
+    ):
+        with open(os.path.join(kb_dir, fname), "w", encoding="utf-8") as f:
+            f.write(content)
+    print(f"\n  {green}✓{reset} 01-brand-identity.md")
+    print(f"  {green}✓{reset} 02-voice-and-tone.md")
+
+    cmd_knowledge(_ap.Namespace(knowledge_action="init"))
+
+    nxt = questionary.select(
+        "The other 12 files are starter templates. Next:",
+        choices=[
+            questionary.Choice("Draft them from an existing channel", value="bootstrap"),
+            questionary.Choice("Fill them in later", value="later"),
+        ],
+        style=qstyle,
+    ).ask()
+
+    if nxt == "bootstrap":
+        print(f"\n  {gray}In Claude Code, run:{reset} {accent}/bootstrap-knowledge <channel-url>{reset}")
+        print(f"  {gray}It reads the channel and drafts the remaining files for you.{reset}")
+    else:
+        print(f"\n  {gray}The files live in{reset} {kb_dir}")
+        print(f"  {gray}Fill in the [brackets] whenever you like. Start with 04-shorts-creation-guide.md.{reset}")
+
+    _mark_onboarded()
     print()
 
 
@@ -3743,6 +4015,7 @@ def main():
     # ── knowledge ──
     kb = sub.add_parser("knowledge", help="Manage knowledge base files")
     kb_sub = kb.add_subparsers(dest="knowledge_action")
+    kb_sub.add_parser("init", help="Create the 14 starter templates (never overwrites)")
     kb_sub.add_parser("list", help="List all knowledge files")
     kb_read = kb_sub.add_parser("read", help="Print a knowledge file")
     kb_read.add_argument("filename", help="File name (e.g. 01-brand-identity)")
@@ -3847,6 +4120,9 @@ def main():
         print_help()
         return
 
+    if _needs_onboarding():
+        _first_run_setup()
+
     if args.command == "process":
         if not getattr(args, "no_banner", False):
             print()
@@ -3895,6 +4171,16 @@ def main():
         interactive_menu()
 
 
+def _webui_port() -> int:
+    """Resolve the Studio port the same way the Node server does."""
+    raw = os.environ.get("PODCLI_PORT") or os.environ.get("PORT")
+    try:
+        port = int(raw)
+    except (TypeError, ValueError):
+        return 3847
+    return port if 0 < port <= 65535 else 3847
+
+
 def launch_webui():
     """Launch the Studio web UI server (http://localhost:3847)."""
     import subprocess as sp
@@ -3907,7 +4193,7 @@ def launch_webui():
     reset = "\033[0m"
 
     backend_dir = os.path.dirname(os.path.abspath(__file__))
-    port = os.environ.get("PORT", "3847")
+    port = _webui_port()
     node = os.environ.get("PODCLI_NODE") or _shutil.which("node")
     studio = os.environ.get("PODCLI_STUDIO") or os.path.join(backend_dir, "..", "studio")
     server = os.path.join(studio, "web-server.mjs")
@@ -4523,7 +4809,7 @@ def _interactive_config():
         if action == "webui":
             import webbrowser
 
-            port = os.environ.get("PORT", "3847")
+            port = _webui_port()
             url = f"http://localhost:{port}/config"
             print(f"\n  {gray}Config UI:{reset} {url}")
             print(f"  {dim}Serve the UI first if needed: npm run build && npm run ui:prod{reset}\n")
@@ -4817,7 +5103,7 @@ def _interactive_knowledge():
     ])
 
     kb_dir = paths["knowledge"]
-    files = sorted(f for f in os.listdir(kb_dir) if f.endswith(".md")) if os.path.isdir(kb_dir) else []
+    files = kb_files(kb_dir)
 
     # Show current files
     cmd_knowledge(_ap.Namespace(knowledge_action="list"))
@@ -4829,13 +5115,18 @@ def _interactive_knowledge():
     if files:
         actions.insert(1, questionary.Choice("Read a file", value="read"))
         actions.append(questionary.Choice("Delete a file", value="delete"))
+    else:
+        actions.insert(0, questionary.Choice("Create the 14 starter templates", value="init"))
     actions.append(questionary.Choice("← Back", value="_back"))
 
     action = questionary.select("Knowledge base:", choices=actions, style=qstyle).ask()
     if action is None or action == "_back":
         return
 
-    if action == "read":
+    if action == "init":
+        cmd_knowledge(_ap.Namespace(knowledge_action="init"))
+
+    elif action == "read":
         choice = questionary.select("Which file?", choices=files, style=qstyle).ask()
         if choice:
             cmd_knowledge(_ap.Namespace(knowledge_action="read", filename=choice))

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -53,25 +53,5 @@ class SharedWavTests(unittest.TestCase):
         self.assertEqual(extract.call_count, 1)
 
 
-class WebuiPortTests(unittest.TestCase):
-    def _port(self, env):
-        with mock.patch.dict(os.environ, env, clear=True):
-            return cli_mod._webui_port()
-
-    def test_defaults_to_3847(self):
-        self.assertEqual(self._port({}), 3847)
-
-    def test_port_is_honored(self):
-        self.assertEqual(self._port({"PORT": "4100"}), 4100)
-
-    def test_podcli_port_wins_over_port(self):
-        self.assertEqual(self._port({"PODCLI_PORT": "4000", "PORT": "4100"}), 4000)
-
-    def test_invalid_values_fall_back_to_default(self):
-        self.assertEqual(self._port({"PODCLI_PORT": "abc"}), 3847)
-        self.assertEqual(self._port({"PODCLI_PORT": "0"}), 3847)
-        self.assertEqual(self._port({"PODCLI_PORT": "70000"}), 3847)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,0 +1,77 @@
+"""Tests for backend.cli helpers: the shared WAV cache and Studio port resolution."""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BACKEND_ROOT = os.path.join(ROOT, "backend")
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+import cli as cli_mod
+from services import audio_extract
+
+
+class SharedWavTests(unittest.TestCase):
+    def test_successful_extraction_is_reused(self):
+        fd, wav_path = tempfile.mkstemp(suffix=".wav")
+        os.close(fd)
+        try:
+            with mock.patch.object(
+                audio_extract, "extract_wav_16k_mono", return_value=wav_path
+            ) as extract:
+                shared = cli_mod._SharedWav("/video.mp4")
+                self.assertEqual(shared.get(), wav_path)
+                self.assertEqual(shared.get(), wav_path)
+            self.assertEqual(extract.call_count, 1)
+        finally:
+            if os.path.exists(wav_path):
+                os.unlink(wav_path)
+
+    def test_failed_extraction_is_attempted_once(self):
+        with mock.patch.object(
+            audio_extract, "extract_wav_16k_mono", side_effect=RuntimeError("decode failed")
+        ) as extract:
+            shared = cli_mod._SharedWav("/video.mp4")
+            for _ in range(4):
+                self.assertIsNone(shared.get())
+
+        self.assertEqual(extract.call_count, 1)
+        self.assertIsInstance(shared.error, RuntimeError)
+
+    def test_empty_result_is_treated_as_failure(self):
+        with mock.patch.object(
+            audio_extract, "extract_wav_16k_mono", return_value=None
+        ) as extract:
+            shared = cli_mod._SharedWav("/video.mp4")
+            self.assertIsNone(shared.get())
+            self.assertIsNone(shared.get())
+
+        self.assertEqual(extract.call_count, 1)
+
+
+class WebuiPortTests(unittest.TestCase):
+    def _port(self, env):
+        with mock.patch.dict(os.environ, env, clear=True):
+            return cli_mod._webui_port()
+
+    def test_defaults_to_3847(self):
+        self.assertEqual(self._port({}), 3847)
+
+    def test_port_is_honored(self):
+        self.assertEqual(self._port({"PORT": "4100"}), 4100)
+
+    def test_podcli_port_wins_over_port(self):
+        self.assertEqual(self._port({"PODCLI_PORT": "4000", "PORT": "4100"}), 4000)
+
+    def test_invalid_values_fall_back_to_default(self):
+        self.assertEqual(self._port({"PODCLI_PORT": "abc"}), 3847)
+        self.assertEqual(self._port({"PODCLI_PORT": "0"}), 3847)
+        self.assertEqual(self._port({"PODCLI_PORT": "70000"}), 3847)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_first_run_setup.py
+++ b/tests/test_first_run_setup.py
@@ -1,0 +1,169 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BACKEND_ROOT = os.path.join(ROOT, "backend")
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+import cli as cli_mod
+from services import knowledge_base as kb
+
+ANSWERS = {
+    "show_name": "Deep Tech Weekly",
+    "hosts": "Nika, Sandro",
+    "audience": "Founders building hard tech",
+    "language": "English",
+    "format": "Interview, 60 min, weekly",
+    "voice": "blunt, curious, technical",
+}
+
+
+class RenderTests(unittest.TestCase):
+    def test_brand_identity_carries_every_answer(self):
+        out = cli_mod._render_brand_identity(ANSWERS)
+        self.assertIn("- Name: Deep Tech Weekly", out)
+        self.assertIn("- Nika", out)
+        self.assertIn("- Sandro", out)
+        self.assertIn("Founders building hard tech", out)
+        self.assertIn("- Language: English", out)
+        self.assertIn("- Format: Interview, 60 min, weekly", out)
+
+    def test_voice_file_carries_voice_and_hosts(self):
+        out = cli_mod._render_voice_and_tone(ANSWERS)
+        self.assertIn("blunt, curious, technical", out)
+        self.assertIn("Nika and Sandro", out)
+        self.assertIn("Banned words", out)
+
+    def test_missing_hosts_do_not_break_rendering(self):
+        answers = dict(ANSWERS, hosts="")
+        self.assertIn("Deep Tech Weekly", cli_mod._render_brand_identity(answers))
+        self.assertIn("a host", cli_mod._render_voice_and_tone(answers))
+
+
+class GatingTests(unittest.TestCase):
+    def setUp(self):
+        self.home = tempfile.TemporaryDirectory()
+        self.addCleanup(self.home.cleanup)
+        patcher = mock.patch.dict(
+            cli_mod.paths,
+            {"home": self.home.name, "knowledge": os.path.join(self.home.name, "knowledge")},
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        env = mock.patch.dict(os.environ, {}, clear=False)
+        env.start()
+        self.addCleanup(env.stop)
+        os.environ.pop("PODCLI_NO_ONBOARDING", None)
+
+    def test_needs_onboarding_on_a_fresh_tty(self):
+        with mock.patch.object(sys.stdin, "isatty", return_value=True), \
+                mock.patch.object(sys.stdout, "isatty", return_value=True):
+            self.assertTrue(cli_mod._needs_onboarding())
+
+    def test_non_tty_never_onboards(self):
+        with mock.patch.object(sys.stdin, "isatty", return_value=False), \
+                mock.patch.object(sys.stdout, "isatty", return_value=True):
+            self.assertFalse(cli_mod._needs_onboarding())
+
+    def test_marker_stops_the_wizard(self):
+        cli_mod._mark_onboarded()
+        self.assertTrue(os.path.exists(os.path.join(self.home.name, ".onboarded")))
+        with mock.patch.object(sys.stdin, "isatty", return_value=True), \
+                mock.patch.object(sys.stdout, "isatty", return_value=True):
+            self.assertFalse(cli_mod._needs_onboarding())
+
+    def test_env_opt_out(self):
+        with mock.patch.dict(os.environ, {"PODCLI_NO_ONBOARDING": "1"}), \
+                mock.patch.object(sys.stdin, "isatty", return_value=True), \
+                mock.patch.object(sys.stdout, "isatty", return_value=True):
+            self.assertFalse(cli_mod._needs_onboarding())
+
+    def test_existing_knowledge_base_skips_the_wizard_and_marks_it_done(self):
+        kb_dir = os.path.join(self.home.name, "knowledge")
+        os.makedirs(kb_dir)
+        with open(os.path.join(kb_dir, "01-brand-identity.md"), "w", encoding="utf-8") as f:
+            f.write("# Brand identity\n\n- Name: Deep Tech Weekly\n")
+
+        with mock.patch.object(cli_mod, "cmd_knowledge") as init:
+            cli_mod._first_run_setup()
+
+        init.assert_not_called()
+        self.assertTrue(os.path.exists(os.path.join(self.home.name, ".onboarded")))
+
+    def test_readme_only_knowledge_base_still_runs_the_wizard(self):
+        kb_dir = os.path.join(self.home.name, "knowledge")
+        os.makedirs(kb_dir)
+        with open(os.path.join(kb_dir, "README.md"), "w", encoding="utf-8") as f:
+            f.write("# Knowledge base\n")
+        self.assertTrue(kb.is_empty(kb_dir))
+
+
+def _answering(confirm, answers, choice):
+    """Drive questionary through a wizard run without a terminal."""
+    replies = iter(answers)
+    return [
+        mock.patch("questionary.confirm", return_value=mock.Mock(ask=lambda: confirm)),
+        mock.patch("questionary.text", side_effect=lambda *a, **k: mock.Mock(ask=lambda: next(replies))),
+        mock.patch("questionary.select", return_value=mock.Mock(ask=lambda: choice)),
+    ]
+
+
+class WizardRunTests(unittest.TestCase):
+    def setUp(self):
+        self.home = tempfile.TemporaryDirectory()
+        self.addCleanup(self.home.cleanup)
+        self.kb_dir = os.path.join(self.home.name, "knowledge")
+        patcher = mock.patch.dict(
+            cli_mod.paths, {"home": self.home.name, "knowledge": self.kb_dir}
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _run(self, confirm=True, answers=None, choice="later"):
+        answers = answers if answers is not None else [
+            ANSWERS["show_name"], ANSWERS["hosts"], ANSWERS["audience"],
+            ANSWERS["language"], ANSWERS["format"], ANSWERS["voice"],
+        ]
+        patches = _answering(confirm, answers, choice)
+        for p in patches:
+            p.start()
+        try:
+            cli_mod._first_run_setup()
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_wizard_writes_answers_and_the_remaining_templates(self):
+        self._run()
+
+        created = sorted(os.listdir(self.kb_dir))
+        self.assertEqual(len(created), 14)
+
+        with open(os.path.join(self.kb_dir, "01-brand-identity.md"), encoding="utf-8") as f:
+            brand = f.read()
+        self.assertIn("Deep Tech Weekly", brand)
+        self.assertFalse(kb.is_unfilled_template(brand, "01-brand-identity.md"))
+
+        context = kb.load_kb_context([("01-brand-identity.md", 4000)], self.kb_dir)
+        self.assertIn("Deep Tech Weekly", context)
+        self.assertTrue(os.path.exists(os.path.join(self.home.name, ".onboarded")))
+
+    def test_declining_marks_it_done_and_writes_nothing(self):
+        self._run(confirm=False)
+
+        self.assertFalse(os.path.isdir(self.kb_dir))
+        self.assertTrue(os.path.exists(os.path.join(self.home.name, ".onboarded")))
+
+    def test_empty_show_name_writes_nothing(self):
+        self._run(answers=["", "", "", "", "", ""])
+
+        self.assertFalse(os.path.isdir(self.kb_dir))
+        self.assertTrue(os.path.exists(os.path.join(self.home.name, ".onboarded")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_first_run_setup.py
+++ b/tests/test_first_run_setup.py
@@ -101,25 +101,48 @@ class GatingTests(unittest.TestCase):
             f.write("# Knowledge base\n")
         self.assertTrue(kb.is_empty(kb_dir))
 
-    def test_main_does_not_dispatch_requested_command_after_cancellation(self):
+    def test_cancelling_the_wizard_fails_instead_of_silently_skipping_the_command(self):
         with mock.patch.object(sys, "argv", ["podcli", "info"]), \
                 mock.patch.object(cli_mod, "_auto_migrate_cli"), \
                 mock.patch.object(cli_mod, "_needs_onboarding", return_value=True), \
                 mock.patch.object(cli_mod, "_first_run_setup", return_value=False) as setup, \
                 mock.patch.object(cli_mod, "cmd_info") as info:
-            cli_mod.main()
+            with self.assertRaises(SystemExit) as exit_ctx:
+                cli_mod.main()
 
+        self.assertEqual(exit_ctx.exception.code, 130)
         setup.assert_called_once_with()
         info.assert_not_called()
+
+    def test_completed_wizard_dispatches_the_requested_command(self):
+        with mock.patch.object(sys, "argv", ["podcli", "info"]), \
+                mock.patch.object(cli_mod, "_auto_migrate_cli"), \
+                mock.patch.object(cli_mod, "_needs_onboarding", return_value=True), \
+                mock.patch.object(cli_mod, "_first_run_setup", return_value=True), \
+                mock.patch.object(cli_mod, "cmd_info") as info:
+            cli_mod.main()
+
+        info.assert_called_once()
+
+
+CTRL_D = object()
+
+
+def _reply(value):
+    def ask():
+        if value is CTRL_D:
+            raise EOFError
+        return value
+    return ask
 
 
 def _answering(confirm, answers, choice):
     """Drive questionary through a wizard run without a terminal."""
     replies = iter(answers)
     return [
-        mock.patch("questionary.confirm", return_value=mock.Mock(ask=lambda: confirm)),
-        mock.patch("questionary.text", side_effect=lambda *a, **k: mock.Mock(ask=lambda: next(replies))),
-        mock.patch("questionary.select", return_value=mock.Mock(ask=lambda: choice)),
+        mock.patch("questionary.confirm", return_value=mock.Mock(ask=_reply(confirm))),
+        mock.patch("questionary.text", side_effect=lambda *a, **k: mock.Mock(ask=_reply(next(replies)))),
+        mock.patch("questionary.select", return_value=mock.Mock(ask=_reply(choice))),
     ]
 
 
@@ -196,6 +219,25 @@ class WizardRunTests(unittest.TestCase):
 
         self.assertFalse(result)
         self.assertTrue(os.path.isdir(self.kb_dir))
+        self.assertFalse(os.path.exists(os.path.join(self.home.name, ".onboarded")))
+
+    def test_eof_at_the_confirmation_declines_without_crashing(self):
+        result = self._run(confirm=CTRL_D)
+
+        self.assertTrue(result)
+        self.assertFalse(os.path.isdir(self.kb_dir))
+        self.assertTrue(os.path.exists(os.path.join(self.home.name, ".onboarded")))
+
+    def test_eof_mid_wizard_cancels_without_crashing(self):
+        result = self._run(answers=[ANSWERS["show_name"], CTRL_D])
+
+        self.assertFalse(result)
+        self.assertFalse(os.path.exists(os.path.join(self.home.name, ".onboarded")))
+
+    def test_eof_at_the_next_step_cancels_without_crashing(self):
+        result = self._run(choice=CTRL_D)
+
+        self.assertFalse(result)
         self.assertFalse(os.path.exists(os.path.join(self.home.name, ".onboarded")))
 
 

--- a/tests/test_first_run_setup.py
+++ b/tests/test_first_run_setup.py
@@ -101,6 +101,17 @@ class GatingTests(unittest.TestCase):
             f.write("# Knowledge base\n")
         self.assertTrue(kb.is_empty(kb_dir))
 
+    def test_main_does_not_dispatch_requested_command_after_cancellation(self):
+        with mock.patch.object(sys, "argv", ["podcli", "info"]), \
+                mock.patch.object(cli_mod, "_auto_migrate_cli"), \
+                mock.patch.object(cli_mod, "_needs_onboarding", return_value=True), \
+                mock.patch.object(cli_mod, "_first_run_setup", return_value=False) as setup, \
+                mock.patch.object(cli_mod, "cmd_info") as info:
+            cli_mod.main()
+
+        setup.assert_called_once_with()
+        info.assert_not_called()
+
 
 def _answering(confirm, answers, choice):
     """Drive questionary through a wizard run without a terminal."""
@@ -132,14 +143,15 @@ class WizardRunTests(unittest.TestCase):
         for p in patches:
             p.start()
         try:
-            cli_mod._first_run_setup()
+            return cli_mod._first_run_setup()
         finally:
             for p in patches:
                 p.stop()
 
     def test_wizard_writes_answers_and_the_remaining_templates(self):
-        self._run()
+        result = self._run()
 
+        self.assertTrue(result)
         created = sorted(os.listdir(self.kb_dir))
         self.assertEqual(len(created), 14)
 
@@ -153,16 +165,38 @@ class WizardRunTests(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.home.name, ".onboarded")))
 
     def test_declining_marks_it_done_and_writes_nothing(self):
-        self._run(confirm=False)
+        result = self._run(confirm=False)
 
+        self.assertTrue(result)
         self.assertFalse(os.path.isdir(self.kb_dir))
         self.assertTrue(os.path.exists(os.path.join(self.home.name, ".onboarded")))
 
     def test_empty_show_name_writes_nothing(self):
-        self._run(answers=["", "", "", "", "", ""])
+        result = self._run(answers=["", "", "", "", "", ""])
 
+        self.assertTrue(result)
         self.assertFalse(os.path.isdir(self.kb_dir))
         self.assertTrue(os.path.exists(os.path.join(self.home.name, ".onboarded")))
+
+    def test_cancelling_setup_confirmation_returns_false(self):
+        result = self._run(confirm=None)
+
+        self.assertFalse(result)
+        self.assertFalse(os.path.exists(os.path.join(self.home.name, ".onboarded")))
+
+    def test_cancelling_a_setup_question_returns_false(self):
+        result = self._run(answers=[ANSWERS["show_name"], None])
+
+        self.assertFalse(result)
+        self.assertFalse(os.path.isdir(self.kb_dir))
+        self.assertFalse(os.path.exists(os.path.join(self.home.name, ".onboarded")))
+
+    def test_cancelling_next_step_returns_false(self):
+        result = self._run(choice=None)
+
+        self.assertFalse(result)
+        self.assertTrue(os.path.isdir(self.kb_dir))
+        self.assertFalse(os.path.exists(os.path.join(self.home.name, ".onboarded")))
 
 
 if __name__ == "__main__":

--- a/tests/test_knowledge_context.py
+++ b/tests/test_knowledge_context.py
@@ -1,0 +1,194 @@
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BACKEND_ROOT = os.path.join(ROOT, "backend")
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+from services import knowledge_base as kb
+
+TEMPLATE_DIR = os.path.join(BACKEND_ROOT, "templates", "knowledge")
+
+# Every file the clip-scoring and title/description prompts inline.
+PROMPT_TEMPLATES = [
+    "00-master-instructions.md",
+    "01-brand-identity.md",
+    "02-voice-and-tone.md",
+    "04-shorts-creation-guide.md",
+    "05-title-formulas.md",
+    "06-descriptions-template.md",
+    "07-thumbnail-guide.md",
+    "08-topics-themes.md",
+    "11-inspiration-channels.md",
+    "12-quick-reference.md",
+]
+
+FILLED_BRAND_IDENTITY = """# Brand identity
+
+## Show
+
+- Name: Deep Tech Weekly
+- One-line positioning: For founders building hard tech, the messy parts nobody posts about.
+- Format: Interview, 60 minutes, weekly on Thursday.
+- Language: English, some Georgian slang from the hosts.
+
+## Hosts
+
+| Host | Role | Voice in one line |
+|------|------|-------------------|
+| Nika | Host | Asks the blunt question everyone else skips |
+| Sandro | Co-host | Pushes back with numbers |
+
+## Audience
+
+- Who watches: 25-40, founders and engineers, mostly pre-seed to Series A.
+- Why they watch: they want the operator detail, not the keynote version.
+- Where they watch: YouTube long-form, Shorts, and TikTok.
+
+## Promise
+
+Every episode should leave the viewer with one decision they can make differently on Monday.
+
+## What this show is not
+
+We do not do news recaps and we do not do guest promo hours.
+"""
+
+FILLED_QUICK_REFERENCE = """# Quick reference
+
+## Links
+
+- Show: youtube.com/@deeptechweekly
+- Website: deeptechweekly.com
+
+## Boilerplate
+
+- Guest intro line: "This week [guest] joins us to break down what actually shipped."
+- Sponsor disclosure: "This episode is sponsored by Acme."
+
+## Hashtag sets
+
+- Default: #startups #deeptech #founders
+"""
+
+
+class UnfilledTemplateTests(unittest.TestCase):
+    def test_shipped_templates_are_detected_as_unfilled(self):
+        for name in PROMPT_TEMPLATES:
+            with open(os.path.join(TEMPLATE_DIR, name), encoding="utf-8") as f:
+                content = f.read()
+            with self.subTest(template=name):
+                self.assertTrue(kb.is_unfilled_template(content, name))
+
+    def test_every_shipped_template_is_unfilled_by_identity(self):
+        for name in sorted(os.listdir(TEMPLATE_DIR)):
+            with open(os.path.join(TEMPLATE_DIR, name), encoding="utf-8") as f:
+                content = f.read()
+            with self.subTest(template=name):
+                self.assertTrue(kb.is_unfilled_template(content, name))
+
+    def test_barely_touched_template_is_still_unfilled(self):
+        with open(os.path.join(TEMPLATE_DIR, "01-brand-identity.md"), encoding="utf-8") as f:
+            content = f.read().replace("[Show name]", "Deep Tech Weekly")
+        self.assertTrue(kb.is_unfilled_template(content, "01-brand-identity.md"))
+        self.assertTrue(kb.is_unfilled_template(content))
+
+    def test_filled_files_are_kept(self):
+        self.assertFalse(kb.is_unfilled_template(FILLED_BRAND_IDENTITY, "01-brand-identity.md"))
+        self.assertFalse(kb.is_unfilled_template(FILLED_QUICK_REFERENCE, "12-quick-reference.md"))
+
+    def test_filled_file_keeps_a_few_legitimate_brackets(self):
+        content = FILLED_QUICK_REFERENCE + "\n- Chapter marker: [00:00] intro\n- Guest tag: [guest]\n"
+        self.assertFalse(kb.is_unfilled_template(content, "12-quick-reference.md"))
+
+    def test_empty_file_is_unfilled(self):
+        self.assertTrue(kb.is_unfilled_template("   \n\n", "01-brand-identity.md"))
+
+    def test_wizard_output_is_not_flagged_as_a_template(self):
+        import cli as cli_mod
+
+        answers = {
+            "show_name": "Deep Tech Weekly",
+            "hosts": "Nika, Sandro",
+            "audience": "Founders building hard tech",
+            "language": "English",
+            "format": "Interview, 60 min, weekly",
+            "voice": "blunt, curious, technical",
+        }
+        self.assertFalse(
+            kb.is_unfilled_template(cli_mod._render_brand_identity(answers), "01-brand-identity.md")
+        )
+        self.assertFalse(
+            kb.is_unfilled_template(cli_mod._render_voice_and_tone(answers), "02-voice-and-tone.md")
+        )
+
+
+class LoadContextTests(unittest.TestCase):
+    def test_unfilled_templates_never_reach_the_prompt(self):
+        with tempfile.TemporaryDirectory() as kb_dir:
+            for name in ("01-brand-identity.md", "02-voice-and-tone.md"):
+                with open(os.path.join(TEMPLATE_DIR, name), encoding="utf-8") as src:
+                    with open(os.path.join(kb_dir, name), "w", encoding="utf-8") as dst:
+                        dst.write(src.read())
+            context = kb.load_kb_context(
+                [("01-brand-identity.md", 4000), ("02-voice-and-tone.md", 4000)], kb_dir
+            )
+            self.assertEqual(context, "")
+
+    def test_filled_file_is_inlined_and_truncated(self):
+        with tempfile.TemporaryDirectory() as kb_dir:
+            with open(os.path.join(kb_dir, "01-brand-identity.md"), "w", encoding="utf-8") as f:
+                f.write(FILLED_BRAND_IDENTITY)
+            context = kb.load_kb_context([("01-brand-identity.md", 4000)], kb_dir)
+            self.assertIn("--- 01-brand-identity.md ---", context)
+            self.assertIn("Deep Tech Weekly", context)
+
+            short = kb.load_kb_context([("01-brand-identity.md", 20)], kb_dir)
+            self.assertLess(len(short), len(context))
+
+    def test_missing_dir_yields_no_context(self):
+        self.assertEqual(kb.load_kb_context([("01-brand-identity.md", 100)], "/nope/nowhere"), "")
+
+
+class EmptinessTests(unittest.TestCase):
+    def test_readme_only_counts_as_empty(self):
+        with tempfile.TemporaryDirectory() as kb_dir:
+            with open(os.path.join(kb_dir, "README.md"), "w", encoding="utf-8") as f:
+                f.write("# Knowledge base\n")
+            self.assertEqual(kb.kb_files(kb_dir), [])
+            self.assertTrue(kb.is_empty(kb_dir))
+
+            with open(os.path.join(kb_dir, "01-brand-identity.md"), "w", encoding="utf-8") as f:
+                f.write(FILLED_BRAND_IDENTITY)
+            self.assertEqual(kb.kb_files(kb_dir), ["01-brand-identity.md"])
+            self.assertFalse(kb.is_empty(kb_dir))
+
+    def test_missing_dir_is_empty(self):
+        self.assertTrue(kb.is_empty("/nope/nowhere"))
+
+
+class WarningTests(unittest.TestCase):
+    def setUp(self):
+        kb._warned = False
+
+    def tearDown(self):
+        kb._warned = False
+
+    def test_warns_once_per_run(self):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            kb.warn_missing_context("clip scoring")
+            kb.warn_missing_context("clip scoring")
+        out = buf.getvalue()
+        self.assertEqual(out.count("Warning:"), 1)
+        self.assertIn("clip scoring", out)
+        self.assertIn("podcli knowledge init", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_knowledge_init.py
+++ b/tests/test_knowledge_init.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+TEMPLATE_DIR = os.path.join(ROOT, "backend", "templates", "knowledge")
+EXPECTED = [f"{i:02d}" for i in range(14)]
+
+
+def run_init(home):
+    env = dict(os.environ, PODCLI_HOME=home)
+    return subprocess.run(
+        [sys.executable, os.path.join(ROOT, "backend", "cli.py"), "knowledge", "init"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+class KnowledgeInitTests(unittest.TestCase):
+    def test_templates_ship_all_fourteen_files(self):
+        names = sorted(os.listdir(TEMPLATE_DIR))
+        self.assertEqual([n[:2] for n in names], EXPECTED)
+
+    def test_init_creates_templates_and_never_overwrites(self):
+        with tempfile.TemporaryDirectory() as home:
+            result = run_init(home)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            kb_dir = os.path.join(home, "knowledge")
+            created = sorted(os.listdir(kb_dir))
+            self.assertEqual(len(created), 14)
+
+            marker = os.path.join(kb_dir, "01-brand-identity.md")
+            with open(marker, "w", encoding="utf-8") as f:
+                f.write("user content")
+            os.remove(os.path.join(kb_dir, "13-learnings.md"))
+
+            result = run_init(home)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with open(marker, encoding="utf-8") as f:
+                self.assertEqual(f.read(), "user content")
+            self.assertIn("1 created, 13 kept", result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The docs promised starter knowledge templates that nothing ever created, the
slash commands read a directory that does not exist on a real install, and
the studio had no route to create the files at all. So the content workflow
failed for every new user, quietly.

- podcli knowledge init writes the 14 templates, and a first-run wizard fills
  brand identity and voice from a few answers. It is marker gated and tty
  gated, so it never nags or blocks a script
- The studio gets a setup checklist and a button that seeds the templates
- /bootstrap-knowledge drafts the knowledge base from an existing channel
- An unfilled template no longer leaks into the scoring prompt: the old guard
  matched a placeholder string the templates never used, so the model was
  being told the show's voice was a bracketed example
- Scoring says so when it runs without show context, instead of degrading in
  silence

Part of the product audit. Stacked on `audit-6-studio`, so review only this PR's diff and merge in order.