### PR TITLE
Preserve face maps from imported transcripts

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -73,6 +73,13 @@ from presets import MIN_CLIP_DURATION, MAX_CLIP_DURATION, TARGET_CLIP_DURATION_M
 from services.knowledge_base import is_empty as kb_is_empty, kb_files
 
 
+def _parse_json_transcript(raw_text):
+    data = json.loads(raw_text)
+    if isinstance(data, list):
+        return data, [], {}
+    return data.get("words", []), data.get("segments", []), data
+
+
 def _suggestions_session_path(cache_hash: str) -> str:
     return os.path.join(paths["home"], "sessions", f"clips-{cache_hash}.json")
 
@@ -716,12 +723,7 @@ def cmd_process(args):
 
         # Detect format
         if raw_text.strip().startswith("{") or raw_text.strip().startswith("["):
-            data = json.loads(raw_text)
-            if isinstance(data, list):
-                words = data
-            else:
-                words = data.get("words", [])
-                segments = data.get("segments", [])
+            words, segments, result = _parse_json_transcript(raw_text)
             print(f"         JSON transcript: {len(words)} words")
         else:
             parsed = parse_speaker_transcript(

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -82,6 +82,18 @@ def _parse_json_transcript(raw_text):
     return data.get("words", []), data.get("segments", []), data
 
 
+def _cached_face_map(video_path: str):
+    """Face maps are keyed by video content, not by transcript, so an imported
+    transcript can still borrow the map from an earlier run on the same file."""
+    try:
+        from services.transcript_packer import load_cached_transcript_for_video
+
+        cached = load_cached_transcript_for_video(video_path)
+    except Exception:
+        return None
+    return (cached or {}).get("face_map")
+
+
 def _suggestions_session_path(cache_hash: str) -> str:
     return os.path.join(paths["home"], "sessions", f"clips-{cache_hash}.json")
 
@@ -507,7 +519,7 @@ def cmd_reel(args):
 def cmd_process(args):
     """Full auto pipeline: transcribe → suggest → export."""
     from services.clip_generator import generate_clip
-    from services.transcript_parser import parse_speaker_transcript
+    from services.transcript_parser import detect_and_parse
     from services.audio_analyzer import get_energy_profile
     from services.audio_events import get_event_profile, is_available as audio_events_available
     from services.encoder import get_encoder_info
@@ -728,7 +740,7 @@ def cmd_process(args):
             words, segments, result = _parse_json_transcript(raw_text)
             print(f"         JSON transcript: {len(words)} words")
         else:
-            parsed = parse_speaker_transcript(
+            parsed = detect_and_parse(
                 raw_text,
                 time_adjust=config.get("time_adjust", 0),
             )
@@ -737,7 +749,17 @@ def cmd_process(args):
                 sys.exit(1)
             words = parsed["words"]
             segments = parsed["segments"]
-            print(f"         Parsed: {len(segments)} segments, {len(words)} words")
+            result = parsed
+            fmt = parsed.get("format", "speaker")
+            print(f"         Parsed {fmt}: {len(segments)} segments, {len(words)} words")
+
+        if not result.get("face_map"):
+            cached_face_map = _cached_face_map(video_path)
+            if cached_face_map:
+                result["face_map"] = cached_face_map
+                print("         Reusing cached face map (speaker framing preserved)")
+            else:
+                print("         No cached face map, crop falls back to per-clip face tracking")
     elif not skip_transcript:
         # Check cache first
         cached = load_cached_transcript_for_video(video_path)
@@ -3570,7 +3592,7 @@ def print_help():
     print(f"    {accent}info{reset}                 Show system info (encoder, codecs)")
     print()
     print(f"  {bold}Process options:{reset}")
-    print(f"    {green}-t{reset}, {green}--transcript{reset} {gray}<file>{reset}   Use existing transcript (.txt/.json)")
+    print(f"    {green}-t{reset}, {green}--transcript{reset} {gray}<file>{reset}   Use existing transcript (.srt/.vtt/.txt/.json)")
     print(f"    {green}-n{reset}, {green}--top{reset} {gray}<N>{reset}            Export top N clips {dim}(default: 5){reset}")
     print(f"    {green}-o{reset}, {green}--output{reset} {gray}<dir>{reset}        Output directory {dim}(default: ./clips){reset}")
     print(f"    {green}-p{reset}, {green}--preset{reset} {gray}<name>{reset}       Load a saved preset")
@@ -3794,7 +3816,7 @@ def main():
     # ── process ──
     proc = sub.add_parser("process", help="Process a video into clips")
     proc.add_argument("video", nargs="?", default=None, help="Path to podcast video file (optional if preset has video_path)")
-    proc.add_argument("-t", "--transcript", help="Path to transcript file (.txt or .json)")
+    proc.add_argument("-t", "--transcript", help="Path to transcript file (.srt, .vtt, .txt, or .json)")
     proc.add_argument("-n", "--top", type=int, help="Number of top clips to export (default: 5)")
     proc.add_argument("-o", "--output", help="Output directory (default: ./clips)")
     proc.add_argument("-p", "--preset", help="Load a saved preset")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,9 @@ podcli config migrate             # apply
 ## Transcript format
 
 podcli auto-transcribes with Whisper, and it accepts an existing transcript with
-`--transcript`. Drag-drop `.txt`, `.srt`, and `.vtt` work in the studio.
+`--transcript`: `.txt`, `.srt`, `.vtt`, and `.json` are detected by content. The
+same formats drag-drop into the studio. When the video was transcribed before,
+`--transcript` reuses the cached face map so speaker framing survives the swap.
 
 ```
 Speaker Name (00:00)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,36 @@
+import json
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BACKEND_ROOT = os.path.join(ROOT, "backend")
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+from cli import _parse_json_transcript
+
+
+class CliTranscriptTests(unittest.TestCase):
+    def test_json_transcript_preserves_face_map(self):
+        face_map = {
+            "is_split_screen": True,
+            "is_mixed_layout": True,
+            "clusters": [{"center_x": 1148}, {"center_x": 2949}],
+        }
+        payload = {
+            "words": [{"word": "hello", "start": 0.0, "end": 0.5}],
+            "segments": [{"start": 0.0, "end": 0.5, "text": "hello"}],
+            "face_map": face_map,
+        }
+
+        words, segments, result = _parse_json_transcript(json.dumps(payload))
+
+        self.assertEqual(words, payload["words"])
+        self.assertEqual(segments, payload["segments"])
+        self.assertEqual(result["face_map"], face_map)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,62 +15,72 @@ if BACKEND_ROOT not in sys.path:
 import cli as cli_mod
 
 
+FACE_MAP = {
+    "is_split_screen": True,
+    "is_mixed_layout": True,
+    "clusters": [{"center_x": 1148}, {"center_x": 2949}],
+}
+
+SRT = """1
+00:00:00,000 --> 00:00:04,000
+Hello and welcome to the show.
+
+2
+00:00:04,500 --> 00:00:08,000
+Today we talk about split screens.
+"""
+
+
+def _process_args(video_path, transcript_path, output_dir):
+    return argparse.Namespace(
+        video=video_path,
+        transcript=transcript_path,
+        top=1,
+        output=output_dir,
+        preset=None,
+        engine=None,
+        assemblyai_api_key=None,
+        fast=False,
+        thumbnails=False,
+        caption_style=None,
+        crop=None,
+        format=None,
+        profile=None,
+        logo=None,
+        outro=None,
+        no_outro=True,
+        intro=None,
+        time_adjust=None,
+        no_energy=True,
+        no_speakers=False,
+        no_cache=True,
+        no_resume=True,
+        quality=None,
+        allow_ass_fallback=False,
+        review_each=False,
+        post_review=False,
+    )
+
+
 class CliTranscriptTests(unittest.TestCase):
-    def test_process_passes_json_transcript_face_map_to_clip_generator(self):
-        face_map = {
-            "is_split_screen": True,
-            "is_mixed_layout": True,
-            "clusters": [{"center_x": 1148}, {"center_x": 2949}],
-        }
-        payload = {
-            "words": [{"word": "hello", "start": 0.0, "end": 0.5}],
-            "segments": [{"start": 0.0, "end": 0.5, "text": "hello"}],
-            "face_map": face_map,
+    def _run_process(self, transcript_text, cached_transcript=None):
+        """Run cmd_process with --transcript and return the generate_clip mock."""
+        clip = {
+            "title": "Test clip",
+            "start_second": 0.0,
+            "end_second": 0.5,
+            "duration": 0.5,
         }
 
         with tempfile.TemporaryDirectory() as temp_dir:
             video_path = os.path.join(temp_dir, "episode.mp4")
-            transcript_path = os.path.join(temp_dir, "transcript.json")
+            transcript_path = os.path.join(temp_dir, "transcript")
             output_dir = os.path.join(temp_dir, "clips")
             with open(video_path, "wb") as video_file:
                 video_file.write(b"video")
             with open(transcript_path, "w", encoding="utf-8") as transcript_file:
-                json.dump(payload, transcript_file)
+                transcript_file.write(transcript_text)
 
-            args = argparse.Namespace(
-                video=video_path,
-                transcript=transcript_path,
-                top=1,
-                output=output_dir,
-                preset=None,
-                engine=None,
-                assemblyai_api_key=None,
-                fast=False,
-                thumbnails=False,
-                caption_style=None,
-                crop=None,
-                format=None,
-                profile=None,
-                logo=None,
-                outro=None,
-                no_outro=True,
-                intro=None,
-                time_adjust=None,
-                no_energy=True,
-                no_speakers=False,
-                no_cache=True,
-                no_resume=True,
-                quality=None,
-                allow_ass_fallback=False,
-                review_each=False,
-                post_review=False,
-            )
-            clip = {
-                "title": "Test clip",
-                "start_second": 0.0,
-                "end_second": 0.5,
-                "duration": 0.5,
-            }
             generated = {
                 "output_path": os.path.join(output_dir, "test-clip.mp4"),
                 "file_size_mb": 1.0,
@@ -88,6 +98,10 @@ class CliTranscriptTests(unittest.TestCase):
                     "services.claude_suggest._find_ai_cli",
                     return_value=(None, None),
                 ),
+                mock.patch(
+                    "services.transcript_packer.load_cached_transcript_for_video",
+                    return_value=cached_transcript,
+                ),
                 mock.patch.object(cli_mod, "_suggest_clips", return_value=[clip]),
                 mock.patch.object(cli_mod, "_review_clips", return_value=[clip]),
                 mock.patch.object(
@@ -98,10 +112,45 @@ class CliTranscriptTests(unittest.TestCase):
                     return_value=generated,
                 ) as generate_clip,
             ):
-                cli_mod.cmd_process(args)
+                cli_mod.cmd_process(_process_args(video_path, transcript_path, output_dir))
 
         generate_clip.assert_called_once()
-        self.assertEqual(generate_clip.call_args.kwargs["face_map"], face_map)
+        return generate_clip
+
+    def test_json_transcript_face_map_reaches_clip_generator(self):
+        payload = {
+            "words": [{"word": "hello", "start": 0.0, "end": 0.5}],
+            "segments": [{"start": 0.0, "end": 0.5, "text": "hello"}],
+            "face_map": FACE_MAP,
+        }
+
+        generate_clip = self._run_process(json.dumps(payload))
+
+        self.assertEqual(generate_clip.call_args.kwargs["face_map"], FACE_MAP)
+
+    def test_srt_transcript_recovers_cached_face_map(self):
+        generate_clip = self._run_process(
+            SRT, cached_transcript={"words": [], "segments": [], "face_map": FACE_MAP}
+        )
+
+        self.assertEqual(generate_clip.call_args.kwargs["face_map"], FACE_MAP)
+
+    def test_srt_transcript_without_cache_degrades_to_no_face_map(self):
+        generate_clip = self._run_process(SRT, cached_transcript=None)
+
+        self.assertIsNone(generate_clip.call_args.kwargs["face_map"])
+
+    def test_json_transcript_face_map_wins_over_cache(self):
+        payload = {
+            "words": [{"word": "hello", "start": 0.0, "end": 0.5}],
+            "segments": [{"start": 0.0, "end": 0.5, "text": "hello"}],
+            "face_map": FACE_MAP,
+        }
+        stale = {"words": [], "segments": [], "face_map": {"is_split_screen": False}}
+
+        generate_clip = self._run_process(json.dumps(payload), cached_transcript=stale)
+
+        self.assertEqual(generate_clip.call_args.kwargs["face_map"], FACE_MAP)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,10 @@
+import argparse
 import json
 import os
 import sys
+import tempfile
 import unittest
+from unittest import mock
 
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -9,11 +12,11 @@ BACKEND_ROOT = os.path.join(ROOT, "backend")
 if BACKEND_ROOT not in sys.path:
     sys.path.insert(0, BACKEND_ROOT)
 
-from cli import _parse_json_transcript
+import cli as cli_mod
 
 
 class CliTranscriptTests(unittest.TestCase):
-    def test_json_transcript_preserves_face_map(self):
+    def test_process_passes_json_transcript_face_map_to_clip_generator(self):
         face_map = {
             "is_split_screen": True,
             "is_mixed_layout": True,
@@ -25,11 +28,80 @@ class CliTranscriptTests(unittest.TestCase):
             "face_map": face_map,
         }
 
-        words, segments, result = _parse_json_transcript(json.dumps(payload))
+        with tempfile.TemporaryDirectory() as temp_dir:
+            video_path = os.path.join(temp_dir, "episode.mp4")
+            transcript_path = os.path.join(temp_dir, "transcript.json")
+            output_dir = os.path.join(temp_dir, "clips")
+            with open(video_path, "wb") as video_file:
+                video_file.write(b"video")
+            with open(transcript_path, "w", encoding="utf-8") as transcript_file:
+                json.dump(payload, transcript_file)
 
-        self.assertEqual(words, payload["words"])
-        self.assertEqual(segments, payload["segments"])
-        self.assertEqual(result["face_map"], face_map)
+            args = argparse.Namespace(
+                video=video_path,
+                transcript=transcript_path,
+                top=1,
+                output=output_dir,
+                preset=None,
+                engine=None,
+                assemblyai_api_key=None,
+                fast=False,
+                thumbnails=False,
+                caption_style=None,
+                crop=None,
+                format=None,
+                profile=None,
+                logo=None,
+                outro=None,
+                no_outro=True,
+                intro=None,
+                time_adjust=None,
+                no_energy=True,
+                no_speakers=False,
+                no_cache=True,
+                no_resume=True,
+                quality=None,
+                allow_ass_fallback=False,
+                review_each=False,
+                post_review=False,
+            )
+            clip = {
+                "title": "Test clip",
+                "start_second": 0.0,
+                "end_second": 0.5,
+                "duration": 0.5,
+            }
+            generated = {
+                "output_path": os.path.join(output_dir, "test-clip.mp4"),
+                "file_size_mb": 1.0,
+            }
+
+            with (
+                mock.patch.object(cli_mod, "kb_is_empty", return_value=False),
+                mock.patch(
+                    "services.encoder.get_encoder_info",
+                    return_value={"best": "mock", "system": "test"},
+                ),
+                mock.patch("services.asset_store.default_intro", return_value=None),
+                mock.patch("services.corrections.apply_corrections"),
+                mock.patch(
+                    "services.claude_suggest._find_ai_cli",
+                    return_value=(None, None),
+                ),
+                mock.patch.object(cli_mod, "_suggest_clips", return_value=[clip]),
+                mock.patch.object(cli_mod, "_review_clips", return_value=[clip]),
+                mock.patch.object(
+                    cli_mod, "_should_enter_post_render_loop", return_value=False
+                ),
+                mock.patch(
+                    "services.clip_generator.generate_clip",
+                    return_value=generated,
+                ) as generate_clip,
+            ):
+                cli_mod.cmd_process(args)
+
+        generate_clip.assert_called_once()
+        self.assertEqual(generate_clip.call_args.kwargs["face_map"], face_map)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve the complete podcli JSON transcript payload when using `--transcript`
- keep mixed-layout face metadata available to crop selection
- cover face-map preservation with a focused regression test

## Test plan
- [x] Render the affected 430-465s Riverside segment with the imported face map and inspect frames at 432s, 437s, 442s, and 452s
- [x] Confirm sampled treatment frames contain the speaker and do not cross the panel seam
- [x] Run `venv/bin/python -m pytest tests/test_cli.py -q`
- [x] Run `venv/bin/python -m pytest tests/ -q` (536 passed; 3 pre-existing environment-dependent failures in `tests/test_ai_fallback.py`)

Made with [Cursor](https://cursor.com)