### PR TITLE
Run e2e render after release instead of every night

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,11 +1,12 @@
-# CI only ran unit tests, so a change could break the render pipeline and still
-# go green: nothing in the pipeline ever produced a clip. This renders real ones.
-# Nightly rather than per-PR because it installs ffmpeg and a headless browser.
-name: nightly
+# PR CI never produces a real clip, so a change can break the render pipeline
+# and still go green. This runs the real path once a release is published
+# (plus manual dispatch). Scheduled daily was dropping unrelated failures when
+# nothing in the repo changed.
+name: post-release-render
 
 on:
-  schedule:
-    - cron: '0 4 * * *'
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -48,8 +49,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy Pillow python-dotenv opencv-python-headless
 
-      # The caption renderer runs in a headless browser Remotion downloads on
-      # first use; failing here is a real failure, not a flake to retry away.
       - name: Render a clip per caption style
         shell: bash
         run: |


### PR DESCRIPTION
## What this does

Agrees with running the heavy cross-OS render check when something actually ships, not every morning on an unchanged `main`.

- Drops the daily `cron`
- Triggers on `release: published` (after a `v*` release is cut)
- Keeps `workflow_dispatch` for manual runs
- Renames the workflow to `post-release-render` (same file)

Merge **after** #118 so the first post-release run isn’t red on the DM Sans timeout.

## How I tested it

- Workflow YAML review against `release.yml` (`softprops/action-gh-release` publishes a GitHub release, which fires `release: published`)

## Checklist

- [x] `npx tsc --noEmit` and `npm test` pass (plus `pytest tests/` if you touched the backend)
- [x] Docs updated if commands or behavior changed
- [x] No secrets, personal config, or generated output committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated rendering checks to run after a release is published.
  * Retained the option to trigger rendering checks manually.
  * Removed the nightly scheduled run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->