### PR TITLE
Give the clip renderer the same delayRender budget the episode renderer has

### DIFF
--- a/remotion/render-audiogram.mjs
+++ b/remotion/render-audiogram.mjs
@@ -22,6 +22,10 @@
  */
 
 import { renderMedia, selectComposition } from "@remotion/renderer";
+
+// Same reason as remotion/render.mjs: the 30s default is measured against
+// the font delayRender competing with the whole bundle.
+const DELAY_RENDER_TIMEOUT_MS = 120_000;
 import { getCachedBundle } from "./bundle-cache.mjs";
 import path from "path";
 import fs from "fs";
@@ -80,6 +84,7 @@ async function main() {
     onBundle: () => console.log("  Remotion: bundling (first run, or src/config changed)..."),
   });
   const composition = await selectComposition({
+    timeoutInMilliseconds: DELAY_RENDER_TIMEOUT_MS,
     serveUrl: bundleLocation,
     id: "Audiogram",
     inputProps,
@@ -95,6 +100,7 @@ async function main() {
   );
 
   await renderMedia({
+    timeoutInMilliseconds: DELAY_RENDER_TIMEOUT_MS,
     composition: { ...composition, durationInFrames, fps, width, height },
     serveUrl: bundleLocation,
     codec: "h264",

--- a/remotion/render.mjs
+++ b/remotion/render.mjs
@@ -52,6 +52,11 @@ function clampCaptionFontScale(raw) {
 }
 
 
+// Remotion's 30s default is measured against the font delayRender in Root.tsx,
+// which competes with evaluating the whole bundle. That bundle has three
+// compositions now, and the slowest CI runner does not finish inside 30s.
+const DELAY_RENDER_TIMEOUT_MS = 120_000;
+
 async function main() {
   const opts = parseArgs();
 
@@ -197,6 +202,7 @@ async function main() {
       serveUrl: bundleLocation,
       id: "CaptionedClip",
       inputProps,
+      timeoutInMilliseconds: DELAY_RENDER_TIMEOUT_MS,
     });
 
     const cpus = os.cpus().length;
@@ -227,6 +233,7 @@ async function main() {
       outputLocation: captionOverlay,
       inputProps,
       concurrency,
+      timeoutInMilliseconds: DELAY_RENDER_TIMEOUT_MS,
       onProgress: ({ progress }) => {
         const pct = Math.round(progress * 100);
         if (pct > lastPct + 9) {


### PR DESCRIPTION
## What this does

Blocks the v2.7.0 tag. `post-release-render` on `main` fails on `windows-latest` twice in a row while `ubuntu` and `macos` pass; the same workflow on the `v2.6.0` tag passes on all three. That is a regression this release introduced.

`Root.tsx` holds the render open with `delayRender("Waiting for DM Sans")` until the webfonts resolve, and that wait is measured against Remotion's 30s default while the whole bundle is evaluated alongside it. The bundle gained a third composition and roughly a thousand lines this release. The slowest runner stopped finishing inside 30s: it timed out, logged `falling back to ASS for this clip`, and `scripts/e2e_render.py` correctly refuses that fallback.

`remotion/render-full-episode.mjs` already carried `timeoutInMilliseconds: 120000` for exactly this. The number is not new, only its reach. `remotion/render.mjs` is the path every clip takes and never had it; `render-audiogram.mjs` is new this release and did not either.

## How I tested it

`post-release-render` dispatched on this branch: green on ubuntu, macos and windows, all four caption styles.

For contrast, on `main`: windows fails, twice. On `v2.6.0`: all three pass.

| ref | ubuntu | macos | windows |
|---|---|---|---|
| `v2.6.0` | pass | pass | pass |
| `main` (7c4d6f1) | pass | pass | **fail** |
| `main` (7c4d6f1), rerun | pass | pass | **fail** |
| this branch | pass | pass | pass |

## Checklist

- [x] `npx tsc --noEmit` and `npm test` pass (plus `pytest tests/` if you touched the backend)
- [x] Docs updated if commands or behavior changed
- [x] No secrets, personal config, or generated output committed