### PR TITLE
Let a download use a signed-in browser, and stop three argv copies drifting

### DIFF
--- a/backend/services/asset_store.py
+++ b/backend/services/asset_store.py
@@ -332,8 +332,12 @@ def _download_direct(url: str, dest: str):
 
 def _download_yt_dlp(url: str, dest_dir: str, name: str) -> str:
     slug = "".join(c if c.isalnum() or c in "._-" else "_" for c in name) or "asset"
+    # Keep in step with src/utils/ytdlp-args.ts, the other side of this pair.
     cmd = [
         sys.executable, "-m", "yt_dlp",
+        # A user's own yt-dlp config can carry --extract-audio or a narrower
+        # --format and hand podcli an audio-only or 360p file as the episode.
+        "--ignore-config", "--no-config-locations", "--no-plugin-dirs",
         "--no-playlist",
         "--format", "bv*[height<=1080]+ba/b[height<=1080]/bv*+ba/b",
         "--merge-output-format", "mp4",
@@ -342,6 +346,12 @@ def _download_yt_dlp(url: str, dest_dir: str, name: str) -> str:
         "--output", f"{slug}.%(ext)s",
         "--print", "after_move:podcli-filepath:%(filepath)s",
     ]
+    browser = (os.environ.get("PODCLI_YTDLP_BROWSER") or "").strip().lower()
+    if browser:
+        cmd += ["--cookies-from-browser", browser]
+    extractor_args = (os.environ.get("PODCLI_YT_EXTRACTOR_ARGS") or "").strip()
+    if extractor_args:
+        cmd += ["--extractor-args", extractor_args]
     # Hermetic installs bundle ffmpeg off-PATH; yt-dlp needs it to merge streams.
     ffmpeg = os.environ.get("PODCLI_FFMPEG")
     if ffmpeg and os.path.exists(ffmpeg):

--- a/backend/services/env_settings.py
+++ b/backend/services/env_settings.py
@@ -27,6 +27,15 @@ SETTINGS = [
         "placeholder": "aai_...",
     },
     {
+        "key": "PODCLI_YTDLP_BROWSER",
+        "label": "Browser for download cookies",
+        "help": "Read cookies from this browser so yt-dlp can fetch members-only, "
+        "age-gated, unlisted or private videos you have access to. One of: brave, "
+        "chrome, chromium, edge, firefox, opera, safari, vivaldi, whale.",
+        "secret": False,
+        "placeholder": "chrome",
+    },
+    {
         "key": "PODCLI_CLAUDE_PATH",
         "label": "Claude Code CLI path",
         "help": "Full path to the claude binary when auto-discovery fails. "

--- a/src/services/asset-manager.ts
+++ b/src/services/asset-manager.ts
@@ -7,6 +7,7 @@ import { pipeline } from "stream/promises";
 import { paths, pythonEnv } from "../config/paths.js";
 import { ASSETS_SCHEMA_VERSION } from "../models/index.js";
 import type { Asset, AssetType, AssetRegistry } from "../models/index.js";
+import { buildYtDlpArgs } from "../utils/ytdlp-args.js";
 
 const VIDEO_EXTS = new Set([".mp4", ".mov", ".mkv", ".webm", ".m4v"]);
 const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".svg", ".webp", ".gif"]);
@@ -268,19 +269,15 @@ async function downloadDirect(url: string, destPath: string): Promise<string> {
 
 function downloadWithYtDlp(url: string, destDir: string, name: string): Promise<string> {
   const slug = name.replace(/[^a-zA-Z0-9._-]/g, "_") || "asset";
-  const args = [
-    "-m", "yt_dlp",
-    "--js-runtimes", `node:${process.execPath}`,
-    "--no-playlist",
-    "--format", "bv*[height<=1080]+ba/b[height<=1080]/bv*+ba/b",
-    "--merge-output-format", "mp4",
-    "--ffmpeg-location", paths.ffmpegPath,
-    "--restrict-filenames", "--windows-filenames",
-    "--paths", destDir,
-    "--output", `${slug}.%(ext)s`,
-    "--print", "after_move:podcli-filepath:%(filepath)s",
+  const args = buildYtDlpArgs({
     url,
-  ];
+    outputDir: destDir,
+    outputTemplate: `${slug}.%(ext)s`,
+    ffmpegLocation: paths.ffmpegPath,
+    jsRuntimeNodePath: process.execPath,
+    cookiesFromBrowser: (process.env.PODCLI_YTDLP_BROWSER || "").trim().toLowerCase() || undefined,
+    extractorArgs: process.env.PODCLI_YT_EXTRACTOR_ARGS || undefined,
+  });
   return new Promise((resolveP, rejectP) => {
     const proc = spawn(paths.pythonPath, args, { env: pythonEnv() });
     let stdout = "";

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -52,6 +52,7 @@ import {
   fullEpisodeOutputStem,
   parseFullEpisodeProgress,
 } from "../utils/full-episode-export.js";
+import { buildYtDlpArgs, isCookieBrowser, ytDlpHint } from "../utils/ytdlp-args.js";
 import type {
   AssetType,
   BatchClipsResult,
@@ -674,6 +675,13 @@ app.post("/api/upload", upload.single("file"), (req, res) => {
 /**
  * POST /api/download-video — Download a video URL with yt-dlp into uploads.
  */
+/** The browser whose cookies yt-dlp should read, from the request or the env. */
+function cookieBrowser(fromRequest: unknown): string | undefined {
+  if (isCookieBrowser(fromRequest)) return fromRequest;
+  const configured = (process.env.PODCLI_YTDLP_BROWSER || "").trim().toLowerCase();
+  return isCookieBrowser(configured) ? configured : undefined;
+}
+
 app.post("/api/download-video", async (req, res) => {
   let url: string;
   try {
@@ -701,35 +709,16 @@ app.post("/api/download-video", async (req, res) => {
   };
   jobs.set(jobId, job);
 
-  const args = [
-    "-m",
-    "yt_dlp",
-    // Node is enabled only as a local JS runtime; remote EJS components stay disabled.
-    "--js-runtimes",
-    `node:${process.execPath}`,
-    "--no-playlist",
-    // Best video+audio up to 1080p merged to mp4. A bare muxed stream (b[ext=mp4])
-    // is 360p on YouTube, which then upscales into a terrible-looking reel.
-    "--format",
-    "bv*[height<=1080]+ba/b[height<=1080]/bv*+ba/b",
-    "--merge-output-format",
-    "mp4",
-    "--ffmpeg-location",
-    paths.ffmpegPath,
-    "--restrict-filenames",
-    "--windows-filenames",
-    "--paths",
-    uploadDir,
-    "--output",
-    "%(title).200B [%(id)s].%(ext)s",
-    "--newline",
-    "--progress",
-    "--progress-template",
-    "download:podcli-progress:%(progress._percent_str)s",
-    "--print",
-    "after_move:podcli-filepath:%(filepath)s",
+  const args = buildYtDlpArgs({
     url,
-  ];
+    outputDir: uploadDir,
+    outputTemplate: "%(title).200B [%(id)s].%(ext)s",
+    ffmpegLocation: paths.ffmpegPath,
+    jsRuntimeNodePath: process.execPath,
+    cookiesFromBrowser: cookieBrowser(req.body?.browser),
+    extractorArgs: process.env.PODCLI_YT_EXTRACTOR_ARGS || undefined,
+    progressTemplate: "download:podcli-progress:%(progress._percent_str)s",
+  });
   // Detached so a kill takes out yt-dlp's ffmpeg children with it.
   const proc = spawn(paths.pythonPath, args, {
     env: pythonEnv(),
@@ -790,7 +779,8 @@ app.post("/api/download-video", async (req, res) => {
     finish(() => {
       if (code !== 0) {
         job.status = "error";
-        job.error = `yt-dlp failed for ${url} with exit code ${code}. stderr: ${stderr.slice(-1200)}`;
+        const hint = ytDlpHint(stderr);
+        job.error = `yt-dlp failed for ${url} with exit code ${code}.${hint ? ` ${hint}` : ""} stderr: ${stderr.slice(-1200)}`;
         job.message = job.error;
         broadcastSSE("job-error", { jobId, error: job.error });
         return;

--- a/src/utils/ytdlp-args.test.ts
+++ b/src/utils/ytdlp-args.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { buildYtDlpArgs, isCookieBrowser, ytDlpHint } from "./ytdlp-args.js";
+
+const base = {
+  url: "https://example.com/watch?v=abc",
+  outputDir: "/tmp/out",
+  outputTemplate: "%(title)s.%(ext)s",
+};
+
+describe("buildYtDlpArgs", () => {
+  it("always isolates from the user's own yt-dlp config", () => {
+    const args = buildYtDlpArgs(base);
+    expect(args).toContain("--ignore-config");
+    expect(args).toContain("--no-config-locations");
+    expect(args).toContain("--no-plugin-dirs");
+  });
+
+  it("keeps the 1080p merge selector that stops a 360p muxed stream", () => {
+    const args = buildYtDlpArgs(base);
+    const i = args.indexOf("--format");
+    expect(args[i + 1]).toBe("bv*[height<=1080]+ba/b[height<=1080]/bv*+ba/b");
+    expect(args).toContain("--merge-output-format");
+  });
+
+  it("puts the url last so it cannot be read as a flag value", () => {
+    expect(buildYtDlpArgs(base).at(-1)).toBe(base.url);
+  });
+
+  it("omits cookies and extractor args when unset", () => {
+    const args = buildYtDlpArgs(base);
+    expect(args).not.toContain("--cookies-from-browser");
+    expect(args).not.toContain("--extractor-args");
+  });
+
+  it("passes cookies and extractor args through when set", () => {
+    const args = buildYtDlpArgs({
+      ...base,
+      cookiesFromBrowser: "firefox",
+      extractorArgs: "youtube:player_client=android",
+    });
+    expect(args[args.indexOf("--cookies-from-browser") + 1]).toBe("firefox");
+    expect(args[args.indexOf("--extractor-args") + 1]).toBe("youtube:player_client=android");
+  });
+
+  it("only asks for progress when a template is given", () => {
+    expect(buildYtDlpArgs(base)).not.toContain("--progress-template");
+    expect(buildYtDlpArgs({ ...base, progressTemplate: "download:x" })).toContain(
+      "--progress-template",
+    );
+  });
+});
+
+describe("isCookieBrowser", () => {
+  it("accepts yt-dlp's own list", () => {
+    expect(isCookieBrowser("safari")).toBe(true);
+    expect(isCookieBrowser("vivaldi")).toBe(true);
+  });
+
+  it("rejects anything else, including injection attempts", () => {
+    expect(isCookieBrowser("netscape")).toBe(false);
+    expect(isCookieBrowser("chrome; rm -rf /")).toBe(false);
+    expect(isCookieBrowser(undefined)).toBe(false);
+    expect(isCookieBrowser(7)).toBe(false);
+  });
+});
+
+describe("ytDlpHint", () => {
+  it("names the setting when the site wants a signed-in session", () => {
+    expect(ytDlpHint("ERROR: Sign in to confirm you're not a bot")).toContain(
+      "PODCLI_YTDLP_BROWSER",
+    );
+  });
+
+  it("covers members-only and private videos", () => {
+    expect(ytDlpHint("This video is available to this channel's members-only")).toContain(
+      "PODCLI_YTDLP_BROWSER",
+    );
+    expect(ytDlpHint("ERROR: Private video. Sign in if you've been granted access")).toBeTruthy();
+  });
+
+  it("stays quiet on an unrelated failure", () => {
+    expect(ytDlpHint("ERROR: unable to write to disk")).toBeNull();
+  });
+});

--- a/src/utils/ytdlp-args.ts
+++ b/src/utils/ytdlp-args.ts
@@ -1,0 +1,98 @@
+/**
+ * One place to build a yt-dlp argv.
+ *
+ * The format selector was copy-pasted across three call sites and had already
+ * drifted: the Python one lacked --js-runtimes. Whatever is added here reaches
+ * every download instead of the one that happened to be edited.
+ */
+
+/** yt-dlp's SUPPORTED_BROWSERS, per yt_dlp/cookies.py. */
+export const COOKIE_BROWSERS = [
+  "brave",
+  "chrome",
+  "chromium",
+  "edge",
+  "firefox",
+  "opera",
+  "safari",
+  "vivaldi",
+  "whale",
+] as const;
+
+export type CookieBrowser = (typeof COOKIE_BROWSERS)[number];
+
+export function isCookieBrowser(value: unknown): value is CookieBrowser {
+  return typeof value === "string" && (COOKIE_BROWSERS as readonly string[]).includes(value);
+}
+
+export interface YtDlpOptions {
+  url: string;
+  outputDir: string;
+  outputTemplate: string;
+  ffmpegLocation?: string;
+  jsRuntimeNodePath?: string;
+  /** Read cookies from this browser's profile, for members-only or unlisted URLs. */
+  cookiesFromBrowser?: string;
+  /** Passed through to --extractor-args, e.g. "youtube:player_client=android". */
+  extractorArgs?: string;
+  progressTemplate?: string;
+}
+
+export function buildYtDlpArgs(opts: YtDlpOptions): string[] {
+  const args = ["-m", "yt_dlp"];
+
+  if (opts.jsRuntimeNodePath) {
+    // Node as a local JS runtime; remote EJS components stay disabled.
+    args.push("--js-runtimes", `node:${opts.jsRuntimeNodePath}`);
+  }
+
+  // A user's own ~/.config/yt-dlp/config can carry --extract-audio or a narrower
+  // --format, which would hand podcli an audio-only or 360p file and call it the
+  // episode. Plugin dirs are a separate switch that --ignore-config does not cover.
+  args.push("--ignore-config", "--no-config-locations", "--no-plugin-dirs");
+
+  args.push("--no-playlist");
+  // Best video+audio up to 1080p merged to mp4. A bare muxed stream (b[ext=mp4])
+  // is 360p on YouTube, which then upscales into a terrible-looking reel.
+  args.push("--format", "bv*[height<=1080]+ba/b[height<=1080]/bv*+ba/b");
+  args.push("--merge-output-format", "mp4");
+
+  if (opts.ffmpegLocation) args.push("--ffmpeg-location", opts.ffmpegLocation);
+  if (opts.cookiesFromBrowser) args.push("--cookies-from-browser", opts.cookiesFromBrowser);
+  // Free-text rather than an enum: YouTube rotates which clients work every few
+  // months, and an enum guarantees shipping a stale list.
+  if (opts.extractorArgs) args.push("--extractor-args", opts.extractorArgs);
+
+  args.push("--restrict-filenames", "--windows-filenames");
+  args.push("--paths", opts.outputDir);
+  args.push("--output", opts.outputTemplate);
+
+  if (opts.progressTemplate) {
+    args.push("--newline", "--progress", "--progress-template", opts.progressTemplate);
+  }
+  args.push("--print", "after_move:podcli-filepath:%(filepath)s");
+  args.push(opts.url);
+  return args;
+}
+
+/** Turns a yt-dlp failure into one line naming what to do about it. */
+export function ytDlpHint(stderr: string): string | null {
+  const s = stderr.toLowerCase();
+  if (
+    s.includes("sign in to confirm") ||
+    s.includes("confirm you're not a bot") ||
+    s.includes("cookies")
+  ) {
+    return "The site asked for a signed-in session. Set PODCLI_YTDLP_BROWSER to the browser you are logged into (chrome, firefox, safari, edge, brave, chromium, opera, vivaldi, whale).";
+  }
+  if (s.includes("members-only") || s.includes("members only")) {
+    return "This is members-only. Set PODCLI_YTDLP_BROWSER to a browser signed in to an account with access.";
+  }
+  if (s.includes("private video")) {
+    return "This video is private. If it is yours, set PODCLI_YTDLP_BROWSER to a browser signed in to that account.";
+  }
+  if (s.includes("video unavailable") || s.includes("not available in your")) {
+    return "The video is unavailable from here, which is usually a region or age restriction. A signed-in browser profile via PODCLI_YTDLP_BROWSER often clears it.";
+  }
+  return null;
+}


### PR DESCRIPTION
## What this does

A podcast host could not download their own unlisted episode. `grep -rni cookie src backend cli` returned nothing, so members-only, age-gated, private and unlisted URLs all died on a wall of yt-dlp stderr with no next step.

**Cookies.** `PODCLI_YTDLP_BROWSER` names a browser whose cookies yt-dlp should read, validated against yt-dlp's own `SUPPORTED_BROWSERS` (nine entries, per `yt_dlp/cookies.py`) rather than a hardcoded four that would go stale. It is registered in `env_settings.SETTINGS`, so `podcli env set` and the `manage_env` MCP tool can write it. The Studio can override it per request.

**One argv builder.** The same argument list was hand-rolled at three call sites and had already drifted: the Python one was missing `--js-runtimes`. `src/utils/ytdlp-args.ts` owns the flag list now. The Python copy stays separate because it is a different language and the AGPL-adjacent boundary is not the issue here, just language; each side carries a comment pointing at the other.

**Config isolation.** Every download now passes `--ignore-config`, `--no-config-locations` and `--no-plugin-dirs`. A user's own `~/.config/yt-dlp/config` carrying `--extract-audio` or a narrower `--format` would otherwise hand podcli an audio-only or 360p file, which then gets treated as the episode and upscaled into a bad-looking reel.

**An actionable failure.** `ytDlpHint` matches the stderr signatures for bot checks, members-only, private and region-locked, and appends one line naming the setting that fixes it, instead of only the raw stderr tail.

### Two things deliberately not copied

- **No env sanitizer.** The implementation that prompted this strips `YT_DLP*`/`YTDL*`/`YOUTUBE_DL*` before invoking. Verified against yt-dlp 2026.08: no such configuration variables exist. The only two matches in the whole package are `YTDLP_NO_PLUGINS` and `YTDLP_NO_LAZY_EXTRACTORS`, so porting it would have stripped `YTDLP_NO_PLUGINS` and re-enabled exactly the plugin loading `--no-plugin-dirs` is there to prevent.
- **No `--no-cache-dir`.** It disables the player-JS and nsig solver cache, so every download re-fetches and re-solves. It buys no isolation from user config that `--ignore-config` does not already give.

`PODCLI_YT_EXTRACTOR_ARGS` is free text rather than an enum. YouTube rotates which player clients work every few months, so an enum guarantees shipping a stale list; this way the workaround is a config change instead of a release.

## How I tested it

11 new tests in `src/utils/ytdlp-args.test.ts`: config isolation always present, the 1080p merge selector preserved, the URL last so it cannot be read as a flag value, cookies and extractor args omitted when unset and passed through when set, progress only when a template is given, browser validation accepting yt-dlp's list and rejecting `chrome; rm -rf /`, and the hint firing on bot-check, members-only and private while staying quiet on an unrelated failure.

`npx tsc --noEmit` clean, `npx vitest run` 162 passed, `pytest tests/` 666 passed. The single failure is `test_find_cli_falls_back_to_shell_lookup`, which fails on a clean checkout of `main` on any machine with a real `claude` on PATH.

## Checklist

- [x] `npx tsc --noEmit` and `npm test` pass (plus `pytest tests/` if you touched the backend)
- [x] Docs updated if commands or behavior changed
- [x] No secrets, personal config, or generated output committed