### PR TITLE
Five things that were quietly wrong in selection and the studio

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -928,9 +928,23 @@ def cmd_process(args):
     events_data = None
     reaction_times = None
     if config.get("energy_boost", True):
-        print("  [2/4] Analyzing audio energy...")
+        # The Studio has cached these since it first transcribed the episode.
+        # Reading them here is the difference between re-running YAMNet over a
+        # whole hour on every `podcli process` and not.
+        from services.signal_cache import load_signals, save_signals
+
+        cached = load_signals(video_path) if video_path else {}
+        cached_energy = cached.get("energy_data")
+        cached_events = cached.get("events_data")
+        print(
+            "  [2/4] Scoring cached audio analysis..."
+            if cached_energy and cached_events
+            else "  [2/4] Analyzing audio energy..."
+        )
         try:
-            profile = get_energy_profile(video_path, segments, wav_path=shared_wav.get())
+            profile = get_energy_profile(
+                video_path, segments, wav_path=shared_wav.get(), energy_data=cached_energy
+            )
             energy_scores = profile["segment_scores"]
             energy_data = profile["energy_data"]
             print(f"         {len(profile['peak_times'])} peak moments found")
@@ -938,7 +952,9 @@ def cmd_process(args):
             print(f"         Skipped (error: {e})")
         if audio_events_available():
             try:
-                reactions = get_event_profile(video_path, segments, wav_path=shared_wav.get())
+                reactions = get_event_profile(
+                    video_path, segments, wav_path=shared_wav.get(), events_data=cached_events
+                )
                 reaction_scores = reactions["segment_scores"]
                 events_data = reactions["events_data"]
                 reaction_times = reactions["reaction_times"]
@@ -947,6 +963,10 @@ def cmd_process(args):
                     print(f"         {n} laughter/reaction moments found")
             except Exception as e:
                 print(f"         Reactions skipped (error: {e})")
+        # Written even on a cache hit so a run that only had one half fills the
+        # other, and so the Studio sees what the CLI just computed.
+        if video_path and (energy_data or events_data):
+            save_signals(video_path, energy_data=energy_data, events_data=events_data)
     else:
         print("  [2/4] Audio analysis skipped (--no-energy)")
 

--- a/backend/services/ai_provider.py
+++ b/backend/services/ai_provider.py
@@ -283,8 +283,8 @@ def generate(
     if not chain:
         return AIResult(
             ok=False,
-            error="No AI available. Install Claude Code or set ANTHROPIC_API_KEY "
-                  "(podcli config set ANTHROPIC_API_KEY ...).",
+            error="No AI available. Sign in with `podcli login`, install Claude "
+                  "Code or Codex, or run `podcli env set ANTHROPIC_API_KEY sk-...`.",
         )
 
     if project_dir is None:

--- a/backend/services/audio_analyzer.py
+++ b/backend/services/audio_analyzer.py
@@ -179,16 +179,21 @@ def get_energy_profile(
     segments: list[dict],
     progress_callback: Optional[Callable] = None,
     wav_path: str = None,
+    energy_data: Optional[list[dict]] = None,
 ) -> dict:
     """
     Full pipeline: extract energy data and score all segments.
+
+    Pass energy_data to score a profile that was already extracted; scoring is
+    pure, the decode is what costs.
 
     Returns {energy_data, segment_scores, mean_rms, peak_times}
     """
     if progress_callback:
         progress_callback(0, "Analyzing audio energy...")
 
-    energy_data = extract_audio_energy(video_path, wav_path=wav_path)
+    if energy_data is None:
+        energy_data = extract_audio_energy(video_path, wav_path=wav_path)
 
     if progress_callback:
         progress_callback(70, "Scoring segments by energy...")

--- a/backend/services/audio_events.py
+++ b/backend/services/audio_events.py
@@ -254,6 +254,7 @@ def get_event_profile(
     progress_callback: Optional[Callable] = None,
     reaction_threshold: float = REACTION_THRESHOLD,
     wav_path: Optional[str] = None,
+    events_data: Optional[list[dict]] = None,
 ) -> dict:
     """
     Full pipeline: detect audio events and score all segments.
@@ -268,7 +269,9 @@ def get_event_profile(
     if progress_callback:
         progress_callback(0, "Detecting laughter and reactions...")
 
-    events_data = extract_audio_events(video_path, wav_path=wav_path)
+    # Already-extracted events skip the model pass; scoring them is pure.
+    if events_data is None:
+        events_data = extract_audio_events(video_path, wav_path=wav_path)
 
     if progress_callback:
         progress_callback(70, "Scoring segments by reaction...")

--- a/backend/services/claude_suggest.py
+++ b/backend/services/claude_suggest.py
@@ -168,6 +168,74 @@ def _preferred_caption_style(kb_dir: str) -> str:
     return DEFAULT_PRESET.get("caption_style", "branded")
 
 
+# Codex receives its prompt as an argv argument and silently truncates a long
+# one. Truncating the tail drops the end of the episode, which is exactly how a
+# run ends up with every clip in the opening minutes, so the transcript is
+# sampled across the whole timeline instead.
+CODEX_TRANSCRIPT_LIMIT = 48000
+
+
+def _sample_transcript(transcript_text: str, limit: int = CODEX_TRANSCRIPT_LIMIT) -> str:
+    """Thin a transcript to roughly `limit` characters, keeping its full span."""
+    if len(transcript_text) <= limit:
+        return transcript_text
+    lines = transcript_text.split("\n")
+    if len(lines) < 3:
+        return transcript_text[:limit]
+    keep_every = max(2, -(-len(transcript_text) // limit))
+    sampled = lines[::keep_every]
+    # The last line anchors the end of the timeline, which is the half a tail
+    # truncation would have thrown away.
+    if lines[-1] not in sampled[-1:]:
+        sampled.append(lines[-1])
+    return "\n".join(sampled)
+
+
+def _codex_adapter(transcript_text: str):
+    """An `adapt` callback that thins the transcript for Codex only."""
+    def adapt(engine: str, prompt: str) -> str:
+        if engine != "codex" or not transcript_text:
+            return prompt
+        sampled = _sample_transcript(transcript_text)
+        if sampled == transcript_text:
+            return prompt
+        note = (
+            "\n\nNOTE: this transcript is sampled across the full episode, so "
+            "consecutive lines may skip ahead. Timestamps remain exact.\n"
+        )
+        return prompt.replace(transcript_text, note + sampled, 1)
+
+    return adapt
+
+
+def _total_score(clip: dict) -> float:
+    """Sum the model's per-dimension scores, tolerating a malformed one.
+
+    The values are whatever the model emitted. A single string in there used to
+    raise TypeError inside the normalization loop and take down the whole
+    suggestion run rather than costing one clip.
+    """
+    scores = clip.get("scores")
+    if isinstance(scores, dict) and scores:
+        total = 0.0
+        usable = False
+        for value in scores.values():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                try:
+                    value = float(value)
+                except (TypeError, ValueError):
+                    continue
+            total += float(value)
+            usable = True
+        if usable:
+            return total
+    fallback = clip.get("total_score", 0)
+    try:
+        return float(fallback)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 MAX_REACTION_ANCHORS = 40
 
 
@@ -506,12 +574,12 @@ Transcript:
     try:
         data, _result = ai_provider.generate_json(
             prompt, timeout=900, project_dir=project_dir, on_attempt=announce,
+            adapt=_codex_adapter(transcript_text),
         )
         if data:
             found = []
             for c in data.get("clips", []):
-                scores = c.get("scores", {})
-                total = sum(scores.values()) if scores else c.get("total_score", 0)
+                total = _total_score(c)
                 keep_segments = []
                 for seg in c.get("segments", []):
                     s = round(float(seg.get("start", 0)), 1)
@@ -660,6 +728,7 @@ def suggest_with_claude(
         # Local backends keep the prompt exactly as it has always been built;
         # only the cloud sees the split form.
         local_prompt=prompt,
+        adapt=_codex_adapter(transcript_text),
     )
 
     if not attempt.ok:
@@ -707,9 +776,7 @@ def suggest_with_claude(
     caption_style = _preferred_caption_style(paths["knowledge"])
     normalized = []
     for c in clips:
-        scores = c.get("scores")
-        scores = scores if isinstance(scores, dict) else {}
-        total = sum(scores.values()) if scores else c.get("total_score", 0)
+        total = _total_score(c)
 
         raw_segments = c.get("segments")
         raw_segments = raw_segments if isinstance(raw_segments, list) else []

--- a/backend/services/env_settings.py
+++ b/backend/services/env_settings.py
@@ -27,6 +27,16 @@ SETTINGS = [
         "placeholder": "aai_...",
     },
     {
+        "key": "ANTHROPIC_API_KEY",
+        "label": "Anthropic API key",
+        "help": "The last resort in the AI chain, after a podcli Pro session and "
+        "a locally installed Claude Code or Codex. Only needed if you have "
+        "neither.",
+        "url": "https://console.anthropic.com/settings/keys",
+        "secret": True,
+        "placeholder": "sk-ant-...",
+    },
+    {
         "key": "PODCLI_YTDLP_BROWSER",
         "label": "Browser for download cookies",
         "help": "Read cookies from this browser so yt-dlp can fetch members-only, "

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -1070,6 +1070,10 @@ app.post("/api/transcribe", async (req, res) => {
       registerSourcePath(file_path);
       uiState.lastUpdated = Date.now();
       persistState();
+      // Without this a tab reloaded during a 25-minute run shows an idle screen
+      // forever: the job id lived only in the tab that started it, and nothing
+      // else announces that the transcript landed.
+      broadcastSSE("state-sync", uiState);
       // Cache it
       try {
         await cache.set(file_path, result.data as unknown as TranscriptResult, engine);
@@ -1081,6 +1085,7 @@ app.post("/api/transcribe", async (req, res) => {
       job.status = "error";
       job.error = err.message;
       job.message = `Error: ${err.message}`;
+      broadcastSSE("job-error", { jobId, error: job.error });
     });
 });
 

--- a/tests/test_claude_suggest_helpers.py
+++ b/tests/test_claude_suggest_helpers.py
@@ -429,3 +429,66 @@ class FormatFramingTests(unittest.TestCase):
         self.assertIn("20-35 seconds", prompt)
         self.assertIn("SHORTER IS BETTER", prompt)
         self.assertIn("TikTok", prompt)
+
+
+class TotalScoreTests(unittest.TestCase):
+    """One malformed field used to raise inside the normalization loop and take
+    down the whole suggestion run rather than costing a single clip."""
+
+    def test_the_normal_case_still_sums(self):
+        clip = {"scores": {"standalone": 4, "hook": 5, "relevance": 4, "quotability": 3}}
+        self.assertEqual(cs._total_score(clip), 16)
+
+    def test_a_string_score_does_not_raise(self):
+        clip = {"scores": {"standalone": 4, "hook": "5"}}
+        self.assertEqual(cs._total_score(clip), 9)
+
+    def test_an_unparseable_score_is_skipped_not_fatal(self):
+        clip = {"scores": {"standalone": 4, "hook": "very good"}}
+        self.assertEqual(cs._total_score(clip), 4)
+
+    def test_all_scores_unusable_falls_back_to_total_score(self):
+        clip = {"scores": {"hook": None}, "total_score": 12}
+        self.assertEqual(cs._total_score(clip), 12)
+
+    def test_a_missing_or_junk_total_score_is_zero(self):
+        self.assertEqual(cs._total_score({}), 0.0)
+        self.assertEqual(cs._total_score({"total_score": "nope"}), 0.0)
+
+    def test_a_non_dict_scores_field_does_not_raise(self):
+        self.assertEqual(cs._total_score({"scores": [4, 5], "total_score": 9}), 9)
+
+
+class CodexTranscriptTests(unittest.TestCase):
+    """Codex takes its prompt as an argv argument and silently truncates it.
+    Cutting the tail is what clusters every clip in the opening minutes."""
+
+    def _transcript(self, n=4000):
+        return "\n".join(f"[{i * 3.0:.1f}s] line {i}" for i in range(n))
+
+    def test_a_short_transcript_is_untouched(self):
+        text = self._transcript(10)
+        self.assertEqual(cs._sample_transcript(text), text)
+
+    def test_a_long_transcript_is_thinned_not_truncated(self):
+        text = self._transcript()
+        out = cs._sample_transcript(text)
+        self.assertLess(len(out), len(text))
+        self.assertIn("line 0", out)
+        # The last line is the half a tail truncation would have thrown away.
+        self.assertIn(f"line {3999}", out)
+
+    def test_only_codex_is_adapted(self):
+        text = self._transcript()
+        prompt = "RULES\n\n" + text
+        adapt = cs._codex_adapter(text)
+        self.assertEqual(adapt("claude", prompt), prompt)
+        self.assertNotEqual(adapt("codex", prompt), prompt)
+
+    def test_the_adapted_prompt_keeps_the_rules_and_says_it_sampled(self):
+        text = self._transcript()
+        prompt = "RULES THAT MUST SURVIVE\n\n" + text
+        out = cs._codex_adapter(text)("codex", prompt)
+        self.assertIn("RULES THAT MUST SURVIVE", out)
+        self.assertIn("sampled across the full episode", out)
+        self.assertLess(len(out), len(prompt))

--- a/tests/test_suggest_handler.py
+++ b/tests/test_suggest_handler.py
@@ -119,3 +119,41 @@ class SuggestReactionTimesTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SignalProfileReuseTests(unittest.TestCase):
+    """Scoring a cached profile is pure; the decode and the model pass are what
+    cost. Passing cached data must skip extraction, not redo it."""
+
+    SEGMENTS = [{"start": float(i), "end": float(i) + 1.0, "text": "x"} for i in range(5)]
+
+    def test_energy_profile_skips_extraction_when_given_data(self):
+        from services import audio_analyzer
+
+        with mock.patch.object(audio_analyzer, "extract_audio_energy") as extract:
+            profile = audio_analyzer.get_energy_profile(
+                "/video.mp4", self.SEGMENTS, energy_data=ENERGY_DATA
+            )
+        extract.assert_not_called()
+        self.assertEqual(profile["energy_data"], ENERGY_DATA)
+        self.assertEqual(len(profile["segment_scores"]), len(self.SEGMENTS))
+
+    def test_energy_profile_still_extracts_without_data(self):
+        from services import audio_analyzer
+
+        with mock.patch.object(
+            audio_analyzer, "extract_audio_energy", return_value=ENERGY_DATA
+        ) as extract:
+            audio_analyzer.get_energy_profile("/video.mp4", self.SEGMENTS)
+        extract.assert_called_once()
+
+    def test_event_profile_skips_extraction_when_given_data(self):
+        from services import audio_events
+
+        with mock.patch.object(audio_events, "is_available", return_value=True), \
+             mock.patch.object(audio_events, "extract_audio_events") as extract:
+            profile = audio_events.get_event_profile(
+                "/video.mp4", self.SEGMENTS, events_data=EVENTS_DATA
+            )
+        extract.assert_not_called()
+        self.assertEqual(profile["events_data"], EVENTS_DATA)


### PR DESCRIPTION
## What this does

Five separate defects, all verified against `main` before touching anything. None of them raised an error, which is why they lasted.

**1. Codex was reading a truncated transcript.** Codex takes its prompt as an argv argument and silently truncates a long one. `content_generator.py` has applied `adapt=_shorten_for_codex` for this since it was written; `claude_suggest.py` applies it nowhere. Truncation drops the tail, which is precisely how a run ends up with every clip in the opening minutes and no error to explain it.

The transcript is now sampled across the whole episode for Codex, keeping the first and last lines, with a line in the prompt saying consecutive lines may skip ahead and that timestamps remain exact. Scope correction on my own earlier claim: the bucketed path was mostly safe already, since each bucket prompt is small. The real exposure was the whole-episode fallback pass and `find_moments_from_text`.

**2. One malformed score killed the entire run.** `total = sum(scores.values())` on model output is unguarded at two sites. A single string among the four dimensions raised `TypeError` inside the normalization loop and took down the whole suggestion pass, rather than costing one clip. The equivalent code in `find_moments_from_text` was already wrapped and degraded to `[]`. Non-numeric values are now coerced where possible, skipped where not, and the `total_score` fallback is used when none survive.

**3. The no-AI error named a command that does not exist.** It advised `podcli config set ANTHROPIC_API_KEY ...`. `podcli config` has only status/migrate/export/import/use, and `podcli env set` rejected the key because it was not in `env_settings.SETTINGS`. The documented last-resort backend was unreachable through any podcli command. The message now names the real commands and the key is registered.

**4. `podcli process` re-ran YAMNet over the whole episode every time.** `signal_cache` was read and written only by the Studio. The CLI called `get_energy_profile`/`get_event_profile` directly, so every run re-decoded and re-analysed an hour of audio, including runs that then replayed cached suggestions and printed "Loaded from cache (instant)".

Both profile helpers now accept already-extracted data and skip to scoring, which is pure. The CLI reads the cache and writes back, so the two entry points stop paying for each other's work. It still runs before the resume check, but with the cache that costs a scoring pass rather than a full analysis.

**5. A reloaded tab never learned transcription finished.** The completion handler called `persistState()` without `broadcastSSE("state-sync", ...)`, and the job id lived only in the tab that started the run. Reload during a 25-minute Whisper run showed an idle screen indefinitely, even after the transcript landed. Failures did not broadcast either.

## How I tested it

19 new tests. `_total_score` covers the normal sum, a numeric string, an unparseable value, all-unusable falling back to `total_score`, junk `total_score`, and a non-dict `scores` field. The Codex sampler covers a short transcript untouched, a long one thinned with both ends kept, only Codex being adapted, and the rules surviving alongside the sampling note. Three tests assert the profile helpers skip extraction when handed cached data and still extract without it.

`pytest tests/`: 679 passed. `npx tsc --noEmit` and `npx vitest run` (162) clean. The single failure is `test_find_cli_falls_back_to_shell_lookup`, which fails on a clean checkout of `main` on any machine with a real `claude` on PATH.

## Checklist

- [x] `npx tsc --noEmit` and `npm test` pass (plus `pytest tests/` if you touched the backend)
- [x] Docs updated if commands or behavior changed
- [x] No secrets, personal config, or generated output committed