### PR TITLE
Bring the question with the answer, and make every clip state its payoff

### DIFF
--- a/.claude/commands/auto.md
+++ b/.claude/commands/auto.md
@@ -23,6 +23,7 @@ This command orchestrates the existing MCP tools on top of the compact packed tr
 2. **Strategy first, render after.** Propose the cut list and WAIT for user confirmation before calling `batch_create_clips`.
 3. **Knowledge base is context, not template.** If `` exists, read it for brand voice and format preferences. If not, infer from the content itself.
 4. **Never silently render.** Every clip that ships must appear in the proposal the user approved.
+5. **Every clip carries its own context.** A stranger who never heard the episode has to follow it from the first second. If the moment is an answer, the question comes with it.
 
 ---
 
@@ -53,7 +54,60 @@ This command orchestrates the existing MCP tools on top of the compact packed tr
 
 **Fallback**: if `transcribe_start` returns an error about the Web UI not running, tell the user and offer either (a) run `npm run ui` in another terminal then retry, or (b) fall back to the synchronous `transcribe_podcast` (no live progress, works silently).
 
-### Phase 2 — Strategy Proposal (GATE)
+### Phase 2 — Topic Map (silent)
+
+Before picking a single clip, map the whole episode. Clips get cut out of topics, never out of loose lines.
+
+1. Sweep the packed transcript end to end and mark every topic change.
+2. Emit 2-5 topics per 30 minutes of runtime, 6-12 for a full hour. Each topic covers 3-12 minutes.
+3. Cover the whole runtime. The first 10 minutes and the last 5 get skipped most often, and they hold the setup and the summary. Anything that fits nowhere goes into a "loose ends" topic rather than being dropped.
+4. Merge adjacent topics that both run under 2 minutes and cover the same ground.
+
+Per topic, hold:
+
+| Field | Value |
+|-------|-------|
+| `span` | `[hh:mm:ss-hh:mm:ss]` |
+| `title` | what the topic is about, not a headline |
+| `beats` | 2-5 sub-points actually said |
+| `speakers` | who drives it |
+
+Keep the map internal. It feeds Phase 3 and is only shown if the user asks for it.
+
+### Phase 3 — Cut Planning (silent)
+
+Work inside one topic at a time. Set boundaries by meaning, not by the clock.
+
+**start_second**
+
+- Land on the first sentence of the core statement. Drop the throat-clearing in front of it.
+- If the moment is an answer, move the start back to include the question. Otherwise the clip opens on a reply to nothing and the viewer bounces.
+- When that question rambles past roughly 8 seconds, leave it out and write `context_line` instead: the question rewritten to one line for on-screen text.
+- Never open on a word pointing back before the cut: "that", "it", "they", "yeah", "so", "exactly", "right", "which is why". Either widen the start or supply `context_line`.
+
+**end_second**
+
+- Land on the end of the last sentence of the argument, never on the end of the topic block.
+- Cut before trailing summaries, transitions, and "anyway, so" tails.
+- If the thought is unfinished at the boundary, extend until it closes or drop the moment. Never ship half an argument.
+
+**Never cut** mid-sentence, mid-list, or between a claim and the evidence for it.
+
+**Write the payoff before the title.** One sentence, second person, on what the viewer walks away with. The title is then derived from the payoff, not from transcript wording. A moment with no payoff you can state in one sentence is not a clip. Drop it.
+
+**Check the moment against its own type**, not against one generic bar:
+
+| Type | Carries the clip | Fails when |
+|------|------------------|-----------|
+| Guest story | A turn: what they expected, what happened instead | It summarizes the story instead of telling it |
+| Technical insight | One mechanism explained in plain words | It needs a diagram, or terms the viewer does not have |
+| Market / landscape | A specific read on where things are going, with a reason | It lists players without taking a position |
+| Business / strategy | A number, a trade-off, or a decision with a cost | The advice would fit any company in any year |
+| Hot take | A claim a reasonable person would argue with, plus the reason | It is only a strong tone with no claim under it |
+
+**Run the standalone check.** Name what the viewer must already know. If that is anything other than "nothing", it goes into `context_line` or the start moves back to cover it. If neither works, drop the moment.
+
+### Phase 4 — Strategy Proposal (GATE)
 
 Emit a numbered strategy table. Do NOT render yet.
 
@@ -65,33 +119,37 @@ Inferred tone:   <from voice fingerprint or 02-voice-and-tone.md>
 Target count:    <N> clips (from arg, or inferred from content density)
 
 #1  [00:04:22-00:05:01]  39s  S0 "<hook>"
-    Why: <one line — the angle, the stakes, or the moment>
-    Title: <suggested, ≤60 chars>
-    Style: <hormozi | karaoke | subtle | branded>
+    Payoff: <what the viewer walks away with, one sentence, second person>
+    Needs:  <nothing | what the viewer must know, and how this clip covers it>
+    Why:    <the angle, the stakes, or the moment>
+    Title:  <derived from the payoff, ≤60 chars>
+    Style:  <hormozi | karaoke | subtle | branded>
 
 #2  ...
 
 Unused peaks / skipped moments:
-- [00:18:45] — high energy but no standalone hook
-- [00:34:10] — great quote, but needs 40s of setup
+- [00:18:45] high energy, no payoff you can state in one sentence
+- [00:34:10] great quote, needs 40s of setup that will not fit
+- [00:41:02] answer with no question in reach, and the setup is too long to card
 
 Confirm? (yes / redirect / change specific clips)
 ```
 
 **Stop here. Wait for the user's response.** Do not call `batch_create_clips` on implicit approval — require an explicit "yes", "go", "ship it", or similar.
 
-### Phase 3 — Render (with live progress)
+### Phase 5 — Render (with live progress)
 
 Once the user confirms:
 
-1. Call `batch_create_clips(clip_numbers=[1,2,...], async_mode: true)` → returns `{job_id, clip_count}` immediately.
-2. Emit to the user: _"Rendering {clip_count} clips — I'll report progress per clip."_
-3. Loop: `job_status(job_id, wait_seconds: 30)` → emit ONE terse line per poll, e.g. `"Rendering 3/7 — clip #3 (speaker crop)"`. Exit when `done: true`.
-4. When done, print the output paths and a one-line-per-clip summary (from the result field).
+1. Call `suggest_clips` with the approved list. Every entry carries `payoff`, `standalone`, `context_line`, and `preview_text` (the real opening line, verbatim) alongside the timings. The tool rejects a clip whose context is missing and tells you which one; fix it and resubmit the full list rather than dropping it.
+2. Call `batch_create_clips(clip_numbers=[1,2,...], async_mode: true)` → returns `{job_id, clip_count}` immediately.
+3. Emit to the user: _"Rendering {clip_count} clips — I'll report progress per clip."_
+4. Loop: `job_status(job_id, wait_seconds: 30)` → emit ONE terse line per poll, e.g. `"Rendering 3/7 — clip #3 (speaker crop)"`. Exit when `done: true`.
+5. When done, print the output paths and a one-line-per-clip summary (from the result field).
 
 **Fallback**: if `async_mode` fails (Web UI down), fall back to sync `batch_create_clips(clip_numbers=[...])` — renders silently but still works.
 
-### Phase 4 — Persist
+### Phase 6 — Persist
 
 Write a compact session log to `.podcli/sessions/<episode-slug>.md` (create the dir if missing):
 

--- a/.claude/commands/process-transcript.md
+++ b/.claude/commands/process-transcript.md
@@ -73,20 +73,43 @@ Scan the entire transcript for:
 
 Flag 15-20 potential moments.
 
-### Phase 3: Score Each Moment
+### Phase 3: Anchor Each Moment (Silent)
+
+Before scoring, fix each flagged moment's edges and state its payoff.
+
+**Start**
+
+- Open on the first sentence of the core statement. Drop the throat-clearing in front of it.
+- If the moment is an answer, pull the start back to include the question. A clip that opens on a reply to nothing loses the viewer in two seconds.
+- When that question rambles past roughly 8 seconds, leave it out and write a **setup line** instead: the question rewritten to one line for on-screen text.
+- Never open on a word pointing back before the cut: "that", "it", "they", "yeah", "so", "exactly", "right", "which is why".
+
+**End**
+
+- Close on the last sentence of the argument, not on the last sentence in the topic.
+- Cut before trailing summaries, transitions, and "anyway, so" tails.
+- If the thought is unfinished at the edge, extend until it closes or drop the moment. Never ship half an argument.
+
+**Never cut** mid-sentence, mid-list, or between a claim and the evidence for it.
+
+**Then write the payoff, before any title.** One sentence, second person, on what the viewer walks away with. The title is derived from the payoff, never from transcript wording. A moment with no payoff you can state in one sentence is not a short. Drop it.
+
+**Then run the standalone check.** Name what the viewer must already know. If it is anything other than nothing, it goes into the setup line or the start moves back to cover it. If neither works, drop the moment.
+
+### Phase 4: Score Each Moment
 
 For every flagged moment, score on four dimensions (1-5 each):
 
 | Dimension | What It Measures |
 |-----------|-----------------|
-| **Standalone value** | Makes complete sense without episode context? |
+| **Standalone value** | Makes complete sense with no episode context, including the question it answers? |
 | **Hook strength** | Grabs attention in first 3 seconds of the clip? |
 | **Relevance** | Matters to the show's target audience? |
 | **Quotability** | Contains memorable, shareable phrasing? |
 
 **Total score = sum of 4 dimensions (max 20).**
 
-### Phase 4: Select & Classify
+### Phase 5: Select & Classify
 
 1. Rank all moments by total score
 2. Select the top moments (per target count)
@@ -100,11 +123,23 @@ For every flagged moment, score on four dimensions (1-5 each):
 | **Business / Strategy** | Revenue, fundraising, pricing, go-to-market |
 | **Hot Take / Opinion** | Challenges widely held belief |
 
-### Phase 5: Check for Duplicates
+Then check each moment against its own type, not against one generic bar:
+
+| Type | Carries the clip | Fails when |
+|------|------------------|-----------|
+| **Founder/Guest Story** | A turn: what they expected, what happened instead | It summarizes the story instead of telling it |
+| **Product/Technical Insight** | One mechanism explained in plain words | It needs a diagram, or three terms the viewer does not have |
+| **Market / Landscape** | A specific read on where things are going, with a reason | It lists players without taking a position |
+| **Business / Strategy** | A number, a trade-off, or a decision with a cost attached | The advice would fit any company in any year |
+| **Hot Take / Opinion** | A claim a reasonable person would argue with, plus the reason | It is only a strong tone with no actual claim under it |
+
+A moment that fails its type's bar drops, however well it scored.
+
+### Phase 6: Check for Duplicates
 
 Read `03-episodes-database.md` and verify no selected moments overlap with existing shorts.
 
-### Phase 6: Extract Keywords
+### Phase 7: Extract Keywords
 
 From the full transcript, extract:
 - Main topics discussed
@@ -144,6 +179,10 @@ Format: comma-separated, under 500 characters.
 
 > "[Exact quote from transcript — the hook sentence]"
 
+**Payoff:** [What the viewer walks away with. One sentence, second person.]
+**Needs:** [nothing | what the viewer must already know]
+**Setup line:** [The question this answers, in one line, or omit when the clip carries its own setup]
+
 **Why it works:** [One sentence explaining the appeal]
 
 **Suggested titles:**
@@ -169,6 +208,8 @@ Format: comma-separated, under 500 characters.
 
 For every moment included:
 - [ ] Makes sense without the full episode
+- [ ] Payoff states what the viewer gets, and is not a restatement of the title
+- [ ] Does not open on a word pointing back before the cut, or a setup line covers it
 - [ ] Has a clear start and satisfying end
 - [ ] Hook lands in first 3 seconds
 - [ ] Single focused idea, fully delivered
@@ -182,7 +223,7 @@ For every moment included:
 ## Self-Correction Rules
 
 1. If output feels generic → add specificity from the transcript
-2. If a moment needs context → it's not a good short, skip it
+2. If a moment needs context → pull the start back to include it, or carry it in the setup line. If neither fits, skip the moment
 3. If you can't find enough strong moments → flag it honestly, don't pad with weak ones
 4. Always prioritize variety across content types
 

--- a/.claude/commands/produce-shorts.md
+++ b/.claude/commands/produce-shorts.md
@@ -50,12 +50,12 @@ Each phase calls the corresponding skill's logic. Each phase reports its own Com
 ### Phase 1: Transcript Processing
 *Runs `/process-transcript` logic*
 
-Extract guest info, flag 15-20 moments, score them, select top moments, classify by content type, check for duplicates.
+Extract guest info, flag 15-20 moments, anchor each one (boundaries by meaning, question pulled in or carried as a setup line, payoff written before any title), score them, select top moments, classify by content type, check for duplicates.
 
 ### Phase 2: Title Development
 *Runs `/generate-titles` logic per moment*
 
-For each moment: extract anchor, classify, generate 8 options, verify, flag top 2. Narrow to 2-3 best per moment.
+For each moment: extract anchor, classify, generate 8 options, verify, flag top 2. Narrow to 2-3 best per moment. Every option is derived from the moment's payoff, not from transcript wording.
 
 ### Phase 3: Description Writing
 *Runs `/generate-descriptions` logic*
@@ -100,7 +100,7 @@ Each phase consumes upstream output and passes structured state downstream. Phas
 
 | Phase | Consumes | Produces |
 |-------|----------|----------|
-| 1 | Transcript | Moment list with scores, categories, quotes, timestamps |
+| 1 | Transcript | Moment list with scores, categories, quotes, timestamps, payoff + needs + setup line |
 | 2 | Moment list | 2-3 titles per moment + top picks |
 | 3 | Moments + titles | Per-short + long-form descriptions with hashtags |
 | 4 | Moments | Podcast + shorts thumbnail briefs |

--- a/.claude/commands/review-content.md
+++ b/.claude/commands/review-content.md
@@ -49,7 +49,7 @@ Dispatch subagents in parallel, each owning one dimension. Each returns a findin
 | **Voice Check** | Coffee Test, tone fingerprint match | Yes |
 | **Banned Words** | Exact scan against `02-voice-and-tone.md` | Yes |
 | **Title Review** | Length, keyword-first, shape, anchor presence, no tension-without-payoff | If titles in package |
-| **Standalone Check** | Each short makes sense without the episode | If shorts in package |
+| **Standalone Check** | Each short makes sense without the episode: payoff is stated and is not the title again, nothing is required going in that the clip or its setup line does not cover, and the first line does not point back before the cut | If shorts in package |
 | **Clickbait Detector** | Title promises something the clip can't deliver | If titles + clips both in package |
 | **SEO / Hashtags** | Description hashtags count, show hashtag present, keyword coverage | If descriptions in package |
 | **Duplication Check** | Cross-reference `03-episodes-database.md` | If moments/shorts in package |

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -135,7 +135,8 @@ def _selection_signature(config: dict) -> str:
     ]
     if ai_select:
         try:
-            from services.claude_suggest import kb_signature
+            from services.claude_suggest import PROMPT_VERSION, kb_signature
+            parts.append(PROMPT_VERSION)
             parts.append(kb_signature())
         except Exception:
             # Unique per call, so a run that could not read the knowledge base

--- a/backend/services/claude_suggest.py
+++ b/backend/services/claude_suggest.py
@@ -123,6 +123,12 @@ KB_FILES = [
 ]
 
 
+# Bump when the selection rules in _build_prompt change. Folded into the
+# suggestion cache key for the same reason the knowledge base is: replaying old
+# picks under new rules teaches people the rules do nothing.
+PROMPT_VERSION = 2
+
+
 def kb_signature() -> str:
     """Fingerprint of exactly what the knowledge base contributes to the prompt.
 
@@ -314,6 +320,9 @@ DURATION RULES (CRITICAL):
 CUTTING RULES (CRITICAL):
 - Cut TIGHT. Every second must earn its place.
 - Start at the exact moment the hook hits — no preamble, no "so", no "well"
+- ONE EXCEPTION: if the moment is an ANSWER, start on the QUESTION that prompted it.
+  A question is not preamble, it is the setup the viewer needs. Only leave it out when
+  it rambles past ~8 seconds, and then put it in "context_line" instead.
 - End the MOMENT the point lands with a complete thought — don't trail off
 - NEVER cut mid-sentence or mid-thought. The viewer must feel closure.
 - The last sentence must feel like a natural ending, a punchline, or a mic-drop
@@ -324,6 +333,8 @@ MOMENT SELECTION ({b.lens}):
 - Would YOU stop scrolling for this? If no, skip it.
 - First 3 seconds must HOOK — a bold claim, shocking number, or provocative question
 - Must make complete sense standalone — no "as I mentioned" or "going back to"
+- Must not OPEN on a word pointing back before the cut: "that", "it", "they", "yeah",
+  "so", "exactly", "right", "which is why". Widen the start or write a "context_line".
 - Must end on a COMPLETE THOUGHT — sentence boundary, natural pause, or mic-drop moment
 - Single focused idea — one concept, fully delivered, no loose threads
 - Prioritize: controversial takes, surprising numbers, founder war stories, "wait what?" moments, emotional peaks
@@ -334,6 +345,15 @@ MOMENT SELECTION ({b.lens}):
 
 {f"ALREADY PUBLISHED (do NOT suggest these moments again):{chr(10)}{chr(10).join('- ' + s for s in existing_shorts)}" if existing_shorts else ""}
 {excluded_ranges}{_format_reaction_anchors(reaction_times)}
+
+CONTEXT RULES (CRITICAL):
+- State the PAYOFF first: one sentence, second person, on what the viewer walks away with.
+  If you cannot state it in one sentence, the moment is not a clip. Skip it.
+- The title comes off the payoff, not off the transcript wording.
+- In "needs", name what the viewer must already know. Write "nothing" when the clip
+  carries its own setup.
+- If "needs" is anything other than "nothing", either move start_second back to cover it
+  on camera, or write "context_line": that setup rewritten to one line for on-screen text.
 
 Score each moment on 4 dimensions (1-5 each):
 - standalone: Makes sense without episode context?
@@ -359,7 +379,10 @@ Return this exact JSON structure:
       "scores": {{"standalone": 4, "hook": 5, "relevance": 4, "quotability": 3}},
       "total_score": 16,
       "quote": "The key quote from this moment",
-      "why": "One sentence on why this works as a short"
+      "payoff": "What the viewer walks away with, one sentence, second person",
+      "needs": "nothing",
+      "context_line": "",
+      "why": "One sentence on why this earns 30 seconds of a stranger's attention"
     }}
   ]
 }}
@@ -605,6 +628,9 @@ Transcript:
                     "score": total,
                     "content_type": c.get("content_type", "unknown"),
                     "reasoning": c.get("why", ""),
+                    "payoff": c.get("payoff", ""),
+                    "standalone": c.get("needs", ""),
+                    "context_line": c.get("context_line", ""),
                     "preview_text": c.get("quote", "")[:120],
                     "suggested_caption_style": caption_style,
                     "quote": c.get("quote", ""),
@@ -808,6 +834,9 @@ def suggest_with_claude(
             "score": total,
             "content_type": c.get("content_type", "unknown"),
             "reasoning": c.get("why", ""),
+            "payoff": c.get("payoff", ""),
+            "standalone": c.get("needs", ""),
+            "context_line": c.get("context_line", ""),
             "preview_text": c.get("quote", "")[:120],
             "suggested_caption_style": caption_style,
             "quote": c.get("quote", ""),

--- a/src/handlers/suggest-clips.handler.ts
+++ b/src/handlers/suggest-clips.handler.ts
@@ -6,7 +6,83 @@
  */
 
 import { randomUUID } from "crypto";
-import { validateSuggestionRange } from "../utils/clip-validation.js";
+import { z } from "zod";
+import {
+  validateSuggestionContext,
+  validateSuggestionRange,
+} from "../utils/clip-validation.js";
+
+const suggestionSchema = z.object({
+  title: z.string().describe("Short catchy title for the clip"),
+  start_second: z
+    .number()
+    .describe(
+      "Start timestamp in seconds. If the moment is an answer, move this back " +
+        "to include the question that prompted it.",
+    ),
+  end_second: z.number().describe("End timestamp in seconds"),
+  segments: z
+    .array(z.object({ start: z.number(), end: z.number() }))
+    .optional()
+    .describe(
+      "Multi-cut keep-ranges within the clip. Use to cut out filler/tangents " +
+        "in the middle. Omit for a single continuous clip.",
+    ),
+  payoff: z
+    .string()
+    .describe(
+      "What the viewer walks away with. One sentence, second person, e.g. " +
+        '"You learn why raising a seed round early cost them control of pricing." ' +
+        "Not a description of the clip and not a restatement of the title.",
+    ),
+  standalone: z
+    .string()
+    .describe(
+      "What a viewer who never heard this episode must already know to follow " +
+        'the clip. Write "nothing" when the clip carries its own setup.',
+    ),
+  context_line: z
+    .string()
+    .optional()
+    .describe(
+      "The question or setup that makes the clip land, rewritten to one line " +
+        "for on-screen text. Required whenever standalone is not \"nothing\", " +
+        "or the clip opens on a word pointing back before the cut.",
+    ),
+  reasoning: z
+    .string()
+    .describe("Why this earns 30 seconds of a stranger's attention"),
+  preview_text: z
+    .string()
+    .describe(
+      "The first sentence or two the viewer actually hears, verbatim from " +
+        "start_second. This is what the standalone check reads, so it has to be " +
+        "the real opening line, not a paraphrase.",
+    ),
+  content_type: z
+    .string()
+    .optional()
+    .describe(
+      "Content classification: guest_story, technical_insight, market_landscape, business_strategy, hot_take",
+    ),
+  score: z
+    .number()
+    .optional()
+    .describe(
+      "Virality score (0-20). Sum of standalone + hook + relevance + quotability (each 1-5).",
+    ),
+  suggested_caption_style: z
+    .enum(["hormozi", "karaoke", "subtle", "branded"])
+    .optional()
+    .describe("Recommended caption style for this clip"),
+});
+
+/** Single source of truth for the tool's arguments; server.ts registers this. */
+export const suggestClipsInputShape = {
+  suggestions: z
+    .array(suggestionSchema)
+    .describe("Array of suggested clip moments"),
+};
 
 export const suggestClipsToolDef = {
   name: "suggest_clips",
@@ -14,87 +90,16 @@ export const suggestClipsToolDef = {
     "STEP 2 — Submit your clip suggestions after analyzing the transcript.\n\n" +
     "Before calling this: read the transcript via get_ui_state(include_transcript: true) " +
     "and identify the best viral moments.\n\n" +
+    "Every suggestion must carry its own context. A clip that opens on an answer " +
+    "whose question stayed behind the cut is rejected. Either widen start_second " +
+    "to include the question, or supply context_line.\n\n" +
     "What it does: Stores your suggestions, assigns clip numbers (#1, #2, etc.), " +
     "and pushes them to the Web UI for the user to review.\n\n" +
     "After this: the user reviews in the UI. Then export with " +
     "batch_create_clips(export_selected: true) or create_clip(clip_number: N).",
-  inputSchema: {
-    type: "object" as const,
-    properties: {
-      suggestions: {
-        type: "array",
-        description: "Array of suggested clip moments",
-        items: {
-          type: "object",
-          properties: {
-            title: {
-              type: "string",
-              description: "Short catchy title for the clip",
-            },
-            start_second: {
-              type: "number",
-              description: "Start timestamp in seconds",
-            },
-            end_second: {
-              type: "number",
-              description: "End timestamp in seconds",
-            },
-            segments: {
-              type: "array",
-              description:
-                "Multi-cut keep-ranges within the clip. Use to cut out filler/tangents " +
-                "in the middle. If omitted, the full start→end range is used.",
-              items: {
-                type: "object",
-                properties: {
-                  start: { type: "number" },
-                  end: { type: "number" },
-                },
-                required: ["start", "end"],
-              },
-            },
-            reasoning: {
-              type: "string",
-              description: "Why this moment is viral-worthy",
-            },
-            preview_text: {
-              type: "string",
-              description: "Brief text preview of what's said",
-            },
-            content_type: {
-              type: "string",
-              description:
-                "Content classification: guest_story, technical_insight, market_landscape, business_strategy, hot_take",
-            },
-            score: {
-              type: "number",
-              description: "Virality score (0-20). Sum of standalone + hook + relevance + quotability (each 1-5).",
-            },
-            suggested_caption_style: {
-              type: "string",
-              enum: ["hormozi", "karaoke", "subtle", "branded"],
-              description: "Recommended caption style for this clip",
-            },
-          },
-          required: ["title", "start_second", "end_second", "reasoning"],
-        },
-      },
-    },
-    required: ["suggestions"],
-  },
 };
 
-export interface RawSuggestion {
-  title: string;
-  start_second: number;
-  end_second: number;
-  segments?: Array<{ start: number; end: number }>;
-  reasoning: string;
-  preview_text?: string;
-  content_type?: string;
-  score?: number;
-  suggested_caption_style?: string;
-}
+export type RawSuggestion = z.infer<typeof suggestionSchema>;
 
 export interface SuggestClipsInput {
   suggestions: RawSuggestion[];
@@ -103,12 +108,19 @@ export interface SuggestClipsInput {
 export async function handleSuggestClips(input: SuggestClipsInput): Promise<string> {
   const suggestions = input.suggestions;
 
+  const problems: string[] = [];
   for (let i = 0; i < suggestions.length; i++) {
     const s = suggestions[i];
-    const rangeError = validateSuggestionRange(s.start_second, s.end_second);
-    if (rangeError) {
-      throw new Error(`Suggestion ${i + 1} ("${s.title}"): ${rangeError}`);
-    }
+    const error =
+      validateSuggestionRange(s.start_second, s.end_second) ||
+      validateSuggestionContext(s);
+    if (error) problems.push(`Suggestion ${i + 1} ("${s.title}"): ${error}`);
+  }
+  if (problems.length > 0) {
+    throw new Error(
+      `${problems.length} of ${suggestions.length} suggestions need work. ` +
+        `Fix them and call suggest_clips again with the full list.\n\n${problems.join("\n")}`,
+    );
   }
 
   // Validate and enrich suggestions
@@ -127,6 +139,9 @@ export async function handleSuggestClips(input: SuggestClipsInput): Promise<stri
       end_second: s.end_second,
       segments: segments.length > 0 ? segments : [{ start: s.start_second, end: s.end_second }],
       duration: Math.round(keptDuration * 10) / 10,
+      payoff: s.payoff,
+      standalone: s.standalone,
+      context_line: s.context_line || "",
       reasoning: s.reasoning,
       preview_text: s.preview_text || "",
       content_type: s.content_type || "unknown",

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -99,6 +99,9 @@ export interface SuggestedClip {
   start_second: number;
   end_second: number;
   duration: number;
+  payoff?: string;
+  standalone?: string;
+  context_line?: string;
   reasoning: string;
   preview_text: string;
   segments?: Array<{ start: number; end: number }>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import {
 } from "./handlers/transcribe.handler.js";
 import {
   suggestClipsToolDef,
+  suggestClipsInputShape,
   handleSuggestClips,
 } from "./handlers/suggest-clips.handler.js";
 import {
@@ -186,7 +187,8 @@ async function getWorkflowGuidance(): Promise<string> {
       "1. Set the video: use set_video or transcribe_podcast with a file path\n" +
       "2. Get a transcript: use transcribe_podcast (auto) or import_transcript / parse_transcript\n" +
       "3. Read the transcript: use get_ui_state(include_transcript: true)\n" +
-      "4. Suggest clips: analyze the transcript yourself, then call suggest_clips with your picks\n" +
+      "4. Suggest clips: analyze the transcript yourself, then call suggest_clips with your picks.\n" +
+      "   Each pick needs a payoff and a standalone check, and an answer needs its question.\n" +
       "5. Export: use batch_create_clips(export_selected: true) or create_clip(clip_number: N)\n\n" +
       "Note: The Web UI is not running. Start it with: npm run ui"
     );
@@ -228,7 +230,8 @@ async function getWorkflowGuidance(): Promise<string> {
       `NEXT: Transcript is ready (${wordCount} words). Time to find viral moments!\n` +
         "  → Use get_ui_state(include_transcript: true) to read the full transcript\n" +
         "  → Analyze it for the most engaging, viral-worthy moments\n" +
-        "  → Then call suggest_clips with your suggestions (title, start_second, end_second, reasoning)",
+        "  → For each one: pull the question in if it is an answer, then state the payoff before the title\n" +
+        "  → Then call suggest_clips with your suggestions (title, start_second, end_second, payoff, standalone, reasoning)",
     );
   } else if (phase === "review" && selectedCount > 0) {
     lines.push(
@@ -390,30 +393,7 @@ export function createServer(): McpServer {
   server.tool(
     suggestClipsToolDef.name,
     suggestClipsToolDef.description,
-    {
-      suggestions: z
-        .array(
-          z.object({
-            title: z.string(),
-            start_second: z.number(),
-            end_second: z.number(),
-            segments: z
-              .array(z.object({ start: z.number(), end: z.number() }))
-              .optional()
-              .describe(
-                "Multi-cut keep-ranges. Omit for a single continuous clip.",
-              ),
-            reasoning: z.string(),
-            preview_text: z.string().optional(),
-            content_type: z.string().optional(),
-            score: z.number().optional(),
-            suggested_caption_style: z
-              .enum(["hormozi", "karaoke", "subtle", "branded"])
-              .optional(),
-          }),
-        )
-        .describe("Array of suggested clip moments"),
-    },
+    suggestClipsInputShape,
     async ({ suggestions }) => {
       try {
         const result = await handleSuggestClips({ suggestions });
@@ -1521,6 +1501,9 @@ export function createServer(): McpServer {
           title: z.string().optional(),
           start_second: z.number().optional(),
           end_second: z.number().optional(),
+          payoff: z.string().optional(),
+          standalone: z.string().optional(),
+          context_line: z.string().optional(),
           reasoning: z.string().optional(),
           preview_text: z.string().optional(),
           suggested_caption_style: z
@@ -1539,7 +1522,7 @@ export function createServer(): McpServer {
             content: [
               {
                 type: "text" as const,
-                text: "No updates provided. Specify at least one field: title, start_second, end_second, reasoning, preview_text, or suggested_caption_style.",
+                text: "No updates provided. Specify at least one field: title, start_second, end_second, payoff, standalone, context_line, reasoning, preview_text, or suggested_caption_style.",
               },
             ],
           };
@@ -2529,7 +2512,8 @@ export function createServer(): McpServer {
               "- Questions that hook the viewer",
               "",
               "For each moment, note the start/end timestamps and craft a catchy title.",
-              "Aim for 15-45 second clips (target 20-35s). Then call suggest_clips with your picks.",
+              "Aim for 15-45 second clips (target 20-35s). If a moment is an answer, start on the question. "
+                + "Then call suggest_clips with your picks, each carrying a payoff and a standalone check.",
               "",
               "## Step 5: Export",
               "Call batch_create_clips(export_selected: true) to render all clips.",

--- a/src/ui/client/EpisodeWorkspace.jsx
+++ b/src/ui/client/EpisodeWorkspace.jsx
@@ -812,7 +812,7 @@ const onKeyActivate = (fn) => (e) => {
 
       // Clip editing
       const [editingClip, setEditingClip] = useState(null); // index
-      const [editForm, setEditForm] = useState({ title: '', start: 0, end: 0 });
+      const [editForm, setEditForm] = useState({ title: '', start: 0, end: 0, payoff: '', contextLine: '' });
       const [editDuration, setEditDuration] = useState(0);
       const editDialogRef = useDialog(editingClip !== null, () => setEditingClip(null));
       const previewDialogRef = useDialog(!!previewFile, () => setPreviewFile(null));
@@ -925,7 +925,13 @@ const onKeyActivate = (fn) => (e) => {
         const clip = suggestions[idx];
         if (!clip) return;
         setEditingClip(idx);
-        setEditForm({ title: clip.title, start: clip.start_second, end: clip.end_second });
+        setEditForm({
+          title: clip.title,
+          start: clip.start_second,
+          end: clip.end_second,
+          payoff: clip.payoff || '',
+          contextLine: clip.context_line || '',
+        });
       };
 
       const clampEditTime = (v) => {
@@ -939,7 +945,16 @@ const onKeyActivate = (fn) => (e) => {
         const reTimed = edited && (edited.start_second !== editForm.start || edited.end_second !== editForm.end);
         setSuggestions(prev => {
           const next = [...prev];
-          next[editingClip] = { ...next[editingClip], title: editForm.title, start_second: editForm.start, end_second: editForm.end, duration: Math.round(editForm.end - editForm.start), segments: undefined };
+          next[editingClip] = {
+            ...next[editingClip],
+            title: editForm.title,
+            start_second: editForm.start,
+            end_second: editForm.end,
+            payoff: editForm.payoff,
+            context_line: editForm.contextLine,
+            duration: Math.round(editForm.end - editForm.start),
+            segments: undefined,
+          };
           return next;
         });
         // The score was measured over the old range, so it no longer describes this clip.
@@ -1759,6 +1774,9 @@ const onKeyActivate = (fn) => (e) => {
               start_second: c.start_second,
               end_second: c.end_second,
               reasoning: c.reasoning || c.content_type || '',
+              payoff: c.payoff || '',
+              standalone: c.standalone || '',
+              context_line: c.context_line || '',
               segments: c.segments,
               duration: c.duration ?? Math.round((c.end_second || 0) - (c.start_second || 0)),
             }));
@@ -2616,6 +2634,12 @@ const onKeyActivate = (fn) => (e) => {
 
                         <div className="clip-info">
                           <div className="clip-title">{clip.title}</div>
+                          {clip.payoff && <div className="clip-payoff">{clip.payoff}</div>}
+                          {clip.context_line && (
+                            <div className="clip-context" title={clip.context_line}>
+                              <span>Setup</span> {clip.context_line}
+                            </div>
+                          )}
                           <div className="clip-meta">
                             {fmt(clip.start_second)} {'\u2192'} {fmt(clip.end_second)} {'\u00B7'} {clip.duration}s
                             {energy && (
@@ -2854,6 +2878,19 @@ const onKeyActivate = (fn) => (e) => {
                   <label>Title</label>
                   <input type="text" value={editForm.title} onChange={e => setEditForm(f => ({ ...f, title: e.target.value }))}
                     onKeyDown={e => { if (e.key === 'Enter') saveClipEdit(); }} autoFocus />
+                </div>
+                <div className="edit-field">
+                  <label htmlFor="clip-edit-payoff">Payoff</label>
+                  <textarea id="clip-edit-payoff" rows={2} value={editForm.payoff}
+                    placeholder="What the viewer walks away with, in one sentence"
+                    onChange={e => setEditForm(f => ({ ...f, payoff: e.target.value }))} />
+                </div>
+                <div className="edit-field">
+                  <label htmlFor="clip-edit-context">Setup line</label>
+                  <input id="clip-edit-context" type="text" value={editForm.contextLine}
+                    placeholder="The question this answers, if it is not in the clip"
+                    onChange={e => setEditForm(f => ({ ...f, contextLine: e.target.value }))}
+                    onKeyDown={e => { if (e.key === 'Enter') saveClipEdit(); }} />
                 </div>
                 {videoPath && !sourceIsUrl && (
                   <div className="edit-field">

--- a/src/ui/public/css/styles.css
+++ b/src/ui/public/css/styles.css
@@ -843,6 +843,16 @@ select {
 .clip-meta { font-size: 12px; color: var(--text2); margin-top: 2px; }
 .clip-meta .err { color: var(--red); }
 .clip-meta .warn { color: var(--amber); }
+.clip-payoff {
+  font-size: 12px; color: var(--text2); line-height: 1.45; margin-top: 3px;
+  overflow-wrap: anywhere;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.clip-context {
+  font-size: 11px; color: var(--text3); line-height: 1.45; margin-top: 5px;
+  padding-left: 8px; border-left: 2px solid var(--border); overflow-wrap: anywhere;
+}
+.clip-context span { color: var(--accent-2); font-weight: 600; margin-right: 4px; }
 .clip-actions { display: flex; gap: 4px; flex-shrink: 0; }
 .clip-status { width: 22px; height: 22px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 11px; font-weight: 700; }
 .clip-status.pending { border: 1.5px dashed var(--border); }
@@ -1317,8 +1327,8 @@ input[type="range"]::-webkit-slider-thumb {
   margin-bottom: 12px;
 }
 .clip-edit-panel .edit-field label {
-  font-size: 11px; color: var(--text2); font-weight: 600;
-  display: block; margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px;
+  font-size: 12px; color: var(--text2); font-weight: 600;
+  display: block; margin-bottom: 4px;
 }
 .clip-edit-panel .edit-field input,
 .clip-edit-panel .edit-field textarea {

--- a/src/ui/web-server.ts
+++ b/src/ui/web-server.ts
@@ -3497,6 +3497,9 @@ app.post("/api/claude-suggest", async (req, res) => {
         duration: c.duration ?? c.end_second - c.start_second,
         segments: c.segments,
         reasoning: c.reasoning ?? "",
+        payoff: c.payoff ?? "",
+        standalone: c.standalone ?? "",
+        context_line: c.context_line ?? "",
         preview_text: c.preview_text ?? "",
         content_type: c.content_type,
         score: c.score,
@@ -3571,6 +3574,9 @@ app.post("/api/find-moment", async (req, res) => {
         duration: c.duration ?? c.end_second - c.start_second,
         segments: c.segments,
         reasoning: c.reasoning ?? "",
+        payoff: c.payoff ?? "",
+        standalone: c.standalone ?? "",
+        context_line: c.context_line ?? "",
         preview_text: c.preview_text ?? "",
         content_type: c.content_type,
         score: c.score,
@@ -4006,6 +4012,9 @@ app.post("/api/suggestions/modify", (req, res) => {
     if (typeof upd.title === "string") clip.title = upd.title;
     clip.start_second = nextStart;
     clip.end_second = nextEnd;
+    if (typeof upd.payoff === "string") clip.payoff = upd.payoff;
+    if (typeof upd.standalone === "string") clip.standalone = upd.standalone;
+    if (typeof upd.context_line === "string") clip.context_line = upd.context_line;
     if (typeof upd.reasoning === "string") clip.reasoning = upd.reasoning;
     if (typeof upd.preview_text === "string") clip.preview_text = upd.preview_text;
     if (typeof upd.suggested_caption_style === "string") {

--- a/src/utils/clip-validation.test.ts
+++ b/src/utils/clip-validation.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { validateClipRange, validateSuggestionRange, maxClipSeconds } from "./clip-validation.js";
+import {
+  validateClipRange,
+  validateSuggestionRange,
+  validateSuggestionContext,
+  findOrphanOpener,
+  isSelfContained,
+  maxClipSeconds,
+} from "./clip-validation.js";
 
 describe("validateClipRange", () => {
   it("accepts a normal vertical clip", () => {
@@ -50,5 +57,91 @@ describe("validateSuggestionRange", () => {
 
   it("rejects non-numbers", () => {
     expect(validateSuggestionRange(null, 10)).toMatch(/must be numbers/);
+  });
+});
+
+describe("findOrphanOpener", () => {
+  it("flags replies that point back before the cut", () => {
+    expect(findOrphanOpener("Yeah, and that's exactly why it failed.")).toBe("yeah");
+    expect(findOrphanOpener("That was the moment we knew.")).toBe("that");
+    expect(findOrphanOpener("Because nobody wanted to pay for it.")).toBe("because");
+    expect(findOrphanOpener("I mean, we were broke.")).toBe("i mean");
+  });
+
+  it("lets self-contained openers through", () => {
+    expect(findOrphanOpener("Most founders raise too early.")).toBeNull();
+    expect(findOrphanOpener("So many founders quit at month six.")).toBeNull();
+    expect(findOrphanOpener("It takes ten years to build a brand.")).toBeNull();
+  });
+
+  it("ignores leading punctuation and empty input", () => {
+    expect(findOrphanOpener('"Exactly what I told them."')).toBe("exactly");
+    expect(findOrphanOpener("")).toBeNull();
+    expect(findOrphanOpener(undefined)).toBeNull();
+  });
+});
+
+describe("validateSuggestionContext", () => {
+  const good = {
+    title: "Raising too early cost them pricing power",
+    payoff: "You learn why an early seed round took their pricing control away.",
+    standalone: "nothing",
+    preview_text: "Most founders raise before they have pricing power.",
+  };
+
+  it("accepts a clip that carries its own context", () => {
+    expect(validateSuggestionContext(good)).toBeNull();
+  });
+
+  it("requires a payoff", () => {
+    expect(validateSuggestionContext({ ...good, payoff: "" })).toMatch(/payoff is required/);
+    expect(validateSuggestionContext({ ...good, payoff: "Good story" })).toMatch(/too thin/);
+  });
+
+  it("rejects a payoff that only restates the title", () => {
+    expect(
+      validateSuggestionContext({ ...good, payoff: "Raising too early cost them pricing power!" }),
+    ).toMatch(/restates the title/);
+  });
+
+  it("requires standalone", () => {
+    expect(validateSuggestionContext({ ...good, standalone: "" })).toMatch(
+      /standalone is required/,
+    );
+  });
+
+  it("demands a context_line when the viewer needs prior knowledge", () => {
+    const needsSetup = { ...good, standalone: "that the company had just been acquired" };
+    expect(validateSuggestionContext(needsSetup)).toMatch(/context_line is empty/);
+    expect(
+      validateSuggestionContext({ ...needsSetup, context_line: "Right after the acquisition:" }),
+    ).toBeNull();
+  });
+
+  it("catches an orphaned answer even when standalone claims nothing", () => {
+    const orphan = { ...good, preview_text: "Yeah, and that's exactly why we shut it down." };
+    expect(validateSuggestionContext(orphan)).toMatch(/points at something said before the cut/);
+    expect(
+      validateSuggestionContext({ ...orphan, context_line: "Why did you kill the product?" }),
+    ).toBeNull();
+  });
+
+  it("accepts a payoff in a language that does not use the Latin alphabet", () => {
+    expect(
+      validateSuggestionContext({
+        ...good,
+        title: "რატომ დაიხურა პროდუქტი",
+        payoff: "გაიგებ, რა სიგნალმა აიძულა ისინი პროდუქტი დაეხურათ.",
+      }),
+    ).toBeNull();
+    expect(
+      validateSuggestionContext({ ...good, title: "なぜ畳んだのか", payoff: "撤退を決めた合図が分かります。" }),
+    ).toBeNull();
+  });
+
+  it("isSelfContained treats the empty and 'none' forms as no context needed", () => {
+    expect(isSelfContained("nothing")).toBe(true);
+    expect(isSelfContained("None.")).toBe(true);
+    expect(isSelfContained("who the guest is")).toBe(false);
   });
 });

--- a/src/utils/clip-validation.ts
+++ b/src/utils/clip-validation.ts
@@ -45,3 +45,133 @@ export function validateSuggestionRange(start: unknown, end: unknown): string | 
   }
   return null;
 }
+
+// ---------------------------------------------------------------------------
+// Context checks: does this clip make sense to someone who never heard the
+// episode? A moment can be perfectly cut and still be unwatchable because it
+// opens on an answer whose question stayed behind the cut.
+// ---------------------------------------------------------------------------
+
+const MIN_PAYOFF_WORDS = 5;
+// Japanese and Chinese do not space-delimit, so every payoff in them counts as
+// one "word" however long it runs. A character floor stands in there.
+const MIN_PAYOFF_CHARS = 12;
+
+/** Values that mean "the viewer needs to know nothing going in". */
+const SELF_CONTAINED = new Set([
+  "",
+  "-",
+  "n/a",
+  "na",
+  "none",
+  "no context",
+  "no context needed",
+  "nothing",
+  "nothing needed",
+]);
+
+/**
+ * First words that point backwards at something said before the cut. This is a
+ * backstop, not the primary gate: the model declares `standalone` itself, and
+ * this list only catches the case where it declared "nothing" but cut into the
+ * middle of an exchange anyway.
+ */
+const ORPHAN_OPENERS = new Set([
+  "absolutely", "also", "and", "anyway", "because", "but", "cause", "exactly",
+  "he", "her", "his", "it", "no", "nope", "ok", "okay", "plus", "right", "she",
+  "so", "sure", "that", "their", "them", "they", "those", "totally", "well",
+  "which", "yeah", "yep", "yes",
+]);
+
+/**
+ * Two-word starts that read as self-contained despite a flagged first word,
+ * e.g. "So many founders quit" or "It takes ten years".
+ */
+const SELF_CONTAINED_STARTS = new Set([
+  "it costs", "it takes", "it turns", "no idea", "no matter", "no one",
+  "so few", "so long", "so many", "so much",
+]);
+
+/** Lowercase, punctuation-stripped, single-spaced. Unicode-aware: a Georgian
+ * or Japanese payoff has to survive this, not normalize down to nothing. */
+function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}'\s]/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function wordCount(text: string): number {
+  const n = normalize(text);
+  return n ? n.split(" ").length : 0;
+}
+
+function isTooThin(payoff: string): boolean {
+  const normalized = normalize(payoff);
+  return normalized.includes(" ")
+    ? wordCount(payoff) < MIN_PAYOFF_WORDS
+    : normalized.length < MIN_PAYOFF_CHARS;
+}
+
+export function isSelfContained(standalone: string): boolean {
+  return SELF_CONTAINED.has(normalize(standalone));
+}
+
+/** Returns the backward-pointing opener, or null when the clip starts clean. */
+export function findOrphanOpener(previewText: unknown): string | null {
+  if (typeof previewText !== "string") return null;
+  const words = normalize(previewText).split(" ").filter(Boolean);
+  if (!words.length) return null;
+  if (SELF_CONTAINED_STARTS.has(words.slice(0, 2).join(" "))) return null;
+  // "I mean" is only a stall when the sentence leads with it.
+  if (words[0] === "i" && words[1] === "mean") return "i mean";
+  return ORPHAN_OPENERS.has(words[0]) ? words[0] : null;
+}
+
+export interface SuggestionContext {
+  title?: unknown;
+  payoff?: unknown;
+  standalone?: unknown;
+  context_line?: unknown;
+  preview_text?: unknown;
+}
+
+/** Returns an error message, or null when the clip carries its own context. */
+export function validateSuggestionContext(s: SuggestionContext): string | null {
+  const payoff = typeof s.payoff === "string" ? s.payoff.trim() : "";
+  if (!payoff) {
+    return "payoff is required: one sentence, second person, on what the viewer walks away with.";
+  }
+  if (isTooThin(payoff)) {
+    return `payoff is too thin ("${payoff}"). Write a full sentence on what the viewer walks away with.`;
+  }
+  if (typeof s.title === "string" && normalize(s.title) === normalize(payoff)) {
+    return "payoff just restates the title. Say what the viewer gets, not what the clip is called.";
+  }
+
+  const standalone = typeof s.standalone === "string" ? s.standalone.trim() : "";
+  if (!standalone) {
+    return 'standalone is required: what the viewer must already know to follow this clip, or "nothing".';
+  }
+
+  const contextLine =
+    typeof s.context_line === "string" ? s.context_line.trim() : "";
+
+  if (!isSelfContained(standalone) && !contextLine) {
+    return (
+      `standalone says the viewer needs to know "${standalone}", but context_line is empty. ` +
+      "Either move start_second back to include that setup on camera, or put it in context_line as one line."
+    );
+  }
+
+  const orphan = findOrphanOpener(s.preview_text);
+  if (orphan && !contextLine) {
+    return (
+      `preview_text opens on "${orphan}", which points at something said before the cut. ` +
+      "Either move start_second back to include the question, or set context_line to that setup in one line."
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
Clips were being cut without asking what the viewer gets or whether they could follow it. The worst case is an interview answer whose question stayed behind the cut, so the short opens on a reply to nothing.

Borrowed the shape from [zhouxiaoka/autoclip](https://github.com/zhouxiaoka/autoclip): outline the episode before picking anything, set boundaries at semantic edges, and write the recommend-reason before the title so the title comes off the payoff rather than off transcript wording.

## Tool contract

`suggest_clips` now requires `payoff`, `standalone`, and `preview_text`, and takes an optional `context_line` for the setup when the question is too long to include on camera. `validateSuggestionContext` rejects a missing or title-echoing payoff, prior knowledge with nothing covering it, and an opener that points back before the cut. It reports every bad suggestion at once instead of throwing on the first.

The zod copy in `server.ts` and the dead JSON Schema block in the handler are gone. The shape is defined once.

## Studio generator

`_build_prompt` had the opposite rule (`no preamble, no "so", no "well"`), which stripped the question every time. It now carries the exception, a context rules block, and `payoff`/`needs`/`context_line` in its JSON. Selection rules are versioned into the suggestion cache key so old picks are not replayed under new rules.

## Prompts

`/auto` builds a topic map across the full runtime before picking anything, sets boundaries by meaning rather than by the clock, writes the payoff before the title, and checks each moment against its own content type. Same contract in `/process-transcript`, `/produce-shorts`, and `/review-content`.

## Review UI

Payoff and setup line show per clip and are editable in the clip edit panel. Panel labels are sentence case.

## Notes

Prompts and validator are Unicode-safe: a Georgian or Japanese payoff is no longer rejected as empty.

`context_line` reaches the UI and the session but nothing burns it onto the video yet. The `NameCard` plumbing would carry it.

## Verification

- 305 vitest tests, `tsc --noEmit` clean, full build succeeds
- Python suite identical to the base tree (570 tests, same 16 pre-existing failures from missing `numpy` and `questionary`)
- Every validator rejection branch smoke-tested end to end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved clip selection to ensure each clip works independently, with appropriate questions, setup, context, and payoffs.
  * Added payoff, standalone context, and setup-line details to suggested clips.
  * Displayed and editable clip payoff and context information in the workspace.
  * Added validation before suggestions are saved or rendered, with combined feedback for multiple issues.

* **Bug Fixes**
  * Prevented clips from starting with incomplete or backward-referencing phrases.
  * Improved handling of moments that require additional context.

* **Tests**
  * Added coverage for standalone clips, payoff requirements, setup context, and non-English content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->