### PR TITLE
Write the comments I added without em dashes

### DIFF
--- a/backend/services/face_analysis.py
+++ b/backend/services/face_analysis.py
@@ -182,7 +182,7 @@ def analyze_faces(
     if progress_callback:
         progress_callback(75, "Clustering face positions...")
 
-    # Cluster faces into seats — the fixed positions a person occupies.
+    # Cluster faces into seats: the fixed positions a person occupies.
     #
     # Two seats mean two people on screen at once, and the only evidence for
     # that is a frame holding both. Splitting a flat list of positions at the
@@ -212,8 +212,9 @@ def analyze_faces(
             "crop_x": max(mid_x + seam_margin, min(right_seat - crop_w // 2, width - crop_w)),
         })
     else:
-        # One seat. Not "one speaker" — the guest may be off camera entirely,
-        # and the render should stay on the person it can actually see.
+        # One seat, which is not the same as one speaker. The guest may be
+        # off camera entirely, and the render should stay on the person it can
+        # actually see.
         cx = int(np.median(positions))
         clusters_list.append({
             "center_x": cx,

--- a/backend/services/face_track_helpers.py
+++ b/backend/services/face_track_helpers.py
@@ -184,10 +184,10 @@ def crop_center_keeping_faces_visible(
     """Pick the crop center that leaves the most sampled faces in frame.
 
     The median of a run of face positions is only the right answer when
-    those positions are unimodal. When a run mixes two layouts — a
-    fullscreen shot at 960 and a split-screen tile at 1440 — the median
-    lands at 1200, which on a 607-wide crop is the wall between them, and
-    the render holds on nothing for the length of the run.
+    those positions are unimodal. When a run mixes two layouts, a
+    fullscreen shot at 960 and a split-screen tile at 1440, the median lands
+    at 1200, which on a 607-wide crop is the wall between them, and the
+    render holds on nothing for the length of the run.
 
     So score candidate centers by how many faces they actually keep inside
     the crop, and only fall back to closeness as a tiebreak. On a unimodal
@@ -243,8 +243,8 @@ def seats_from_frames(
 
     paired = [sorted(xs) for xs in frame_positions if len(xs) >= 2]
     with_faces = sum(1 for xs in frame_positions if xs)
-    # A share as well as a count, so a handful of false positives — a face in a
-    # photo on the shelf behind someone — cannot seat a second person.
+    # A share as well as a count, so a handful of false positives, a face in a
+    # photo on the shelf behind someone, cannot seat a second person.
     if len(paired) < max(min_paired_frames, with_faces * min_paired_share):
         return None
 

--- a/backend/services/video_processor.py
+++ b/backend/services/video_processor.py
@@ -1496,7 +1496,7 @@ def _track_and_crop_inner(
                 t, cx = face_points[i]
                 run_median = float(median(run_cxs))
                 if abs(cx - run_median) > jump_thresh:
-                    # Layout changed — close current run, start new one.
+                    # Layout changed, so close this run and start a new one.
                     # Close it where the next one opens, not at the previous
                     # sample: the sampler runs at about 12 Hz, so ending a run
                     # one sample early threw away 80ms of video at every cut.
@@ -1645,8 +1645,8 @@ def _track_and_crop_inner(
                 # dissolve and keep the framing: one cut per run, joined end to
                 # end. This used to fall back to a static crop of the longest
                 # run, which is right for that run and wrong for every other
-                # layout in the clip — on a recording that cuts to a fullscreen
-                # shot, a hold on the wall for a third of its length.
+                # layout in the clip. On a recording that cuts to a fullscreen
+                # shot, that is a hold on the wall for a third of its length.
                 for ri, (r_start, r_end, r_cx) in enumerate(runs):
                     seg_start = max(0.0, r_start)
                     seg_end = min(duration, r_end)

--- a/tests/test_choose_segment_tracks.py
+++ b/tests/test_choose_segment_tracks.py
@@ -201,7 +201,7 @@ class AnchorOnlySegmentTests(unittest.TestCase):
 
     def test_unstood_anchor_is_replaced_by_a_real_face(self):
         # One person at 1400 all clip. The turn's speaker has no track of
-        # their own and an anchor at 400 — the invented seat.
+        # their own and an anchor at 400, which is the invented seat.
         targets = self._targets(
             segment_tracks=[(0.0, 1.2, "SPEAKER_01", 7, 400.0)],
             detections=self._one_person(1400, 8.0),


### PR DESCRIPTION
Comments only, no behaviour. Nine lines across the reframing work in 2.7.4 and 2.7.5, rewritten as a colon, a comma, or a second sentence.

The em dashes still in these files predate the change and are left alone; this is limited to lines the reframing commits introduced.

704 tests pass, unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified comments describing seat detection, speaker representation, mixed video layouts, and false-positive prevention.
  * Improved wording and readability in related technical explanations.

* **Tests**
  * Updated test commentary for consistency; test behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->