### PR TITLE
Ask the card union for a caption, not one kind of card

### DIFF
--- a/remotion/src/components/Cards.tsx
+++ b/remotion/src/components/Cards.tsx
@@ -757,11 +757,14 @@ export const Cards: React.FC<{
    */
   const speakerTakes = Math.max(headNeeds, SPEAKER_MIN * s);
   const bodyRoom = (available: number) => Math.max(0, available - GAP.section * s);
+  // Asked of the union rather than of one kind: only some cards have a caption
+  // at all, and the fit arithmetic runs before anything has narrowed to one.
+  const hasCaption = "caption" in card && Boolean(card.caption);
   const withSpeaker = card.speaker !== null
     && Boolean(videoSrc)
     && room >= headNeeds
     && (!SHOWS_A_FILE.has(card.kind)
-      || mediaBand(card.kind, bodyRoom(room - speakerTakes), s, Boolean(card.caption))
+      || mediaBand(card.kind, bodyRoom(room - speakerTakes), s, hasCaption)
          >= MEDIA_MIN * s);
 
   return (


### PR DESCRIPTION
`card.caption` in the fit arithmetic reads a field only some kinds have, on a value that has not narrowed to one yet. Correct at runtime, where a kind without a caption answers undefined, and it does not typecheck.

Nothing in this repo caught it: `tsconfig.json` covers `src/**/*` and the compositions live in `remotion/src`, so podcli-cloud's studio build is the only thing that typechecks them, and that is where it turned up. Worth closing that gap separately — this PR is the one-line fix.

Types only. The 2.7.23 bundle is unaffected.