### PR TITLE
Make render concurrency container-aware

### DIFF
--- a/remotion/render.mjs
+++ b/remotion/render.mjs
@@ -309,8 +309,16 @@ async function main() {
       chromeMode,
     });
 
+    // os.cpus() reads the host's core count, not the container's cgroup quota,
+    // so on a boxed worker it sizes a tab count the container was never given
+    // the CPU to actually run — the same mismatch PODCLI_WHISPER_THREADS
+    // exists to correct for Whisper. PODCLI_REMOTION_CONCURRENCY lets deploy
+    // config state the real number; unset, it falls back to the old guess for
+    // anywhere still running bare-metal.
     const cpus = os.cpus().length;
-    const concurrency = Math.max(2, Math.min(cpus, 8));
+    const concurrency = process.env.PODCLI_REMOTION_CONCURRENCY
+      ? Math.max(1, parseInt(process.env.PODCLI_REMOTION_CONCURRENCY, 10))
+      : Math.max(2, Math.min(cpus, 8));
     if (opts["keep-overlay"]) {
       const outBase = opts.output.replace(/\.[^.]+$/, "");
       captionOverlay = `${outBase}_captions.mov`;


### PR DESCRIPTION
## Summary
Two production recuts failed identically: `Remotion render error: A delayRender() "Waiting for DM Sans" was called but not cleared after 118000ms`, on both worker containers, for real queued jobs.

## Root cause
`render.mjs` sizes Remotion's browser-tab concurrency off `os.cpus().length`, which reads the host's 4 physical cores, not the worker container's `cpus: 3.5` cgroup quota (`docker-compose.yml`). Two worker containers render concurrently on the same 4-core box; docker-compose.yml already documents that under real concurrent load cgroups fair-share it down to about two real cores each. A tab count sized for four Chrome instances competing for ~2 real cores starves an individual tab's font-loading promise long enough to blow the 120s `delayRender` budget.

Confirmed via a live `worker-status` probe against production: `docker stats` showed `worker-2-1 cpu=358.18%` mid-render while the other worker was also busy on a real job; both jobs failed with the identical timeout. A lightweight isolated render probe on the same box succeeded in seconds, ruling out a broken browser/font asset — this is concurrency, not a missing resource.

This is the same class of bug `PODCLI_WHISPER_THREADS` already exists to fix for Whisper (see the comment beside it in `docker-compose.yml`): a thread/tab count read from the host instead of the container's real quota.

## Fix
`PODCLI_REMOTION_CONCURRENCY` env var overrides the `os.cpus()`-derived guess when set; falls back to the old behavior when unset (e.g. bare-metal dev).

Companion fix in podcli-cloud (sets the env var to 2 for both workers): nmbrthirteen/podcli-cloud#44