### PR TITLE
Scale the Remotion render timeout to the clip instead of hardcoding it

### DIFF
--- a/backend/services/clip_generator.py
+++ b/backend/services/clip_generator.py
@@ -704,12 +704,17 @@ def _render_with_remotion(
         # not happen, and what it threw away was the only description of the
         # failure. Every clip on the Linux worker fell back to burned-in ASS
         # for months and the reason went to /dev/null with the rest of it.
+        #
+        # Above render.mjs's own worst-case delayRender budget (50 minutes),
+        # so a render that is genuinely just slow times out inside Remotion
+        # with an actionable message, rather than being hard-killed here first
+        # with nothing but "TimeoutExpired" to say why.
         result = subprocess.run(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            timeout=600,
+            timeout=3300,
             cwd=project_root,
             env=remotion_env,
         )

--- a/backend/services/clip_generator.py
+++ b/backend/services/clip_generator.py
@@ -705,16 +705,19 @@ def _render_with_remotion(
         # failure. Every clip on the Linux worker fell back to burned-in ASS
         # for months and the reason went to /dev/null with the rest of it.
         #
-        # Above render.mjs's own worst-case delayRender budget (50 minutes),
-        # so a render that is genuinely just slow times out inside Remotion
-        # with an actionable message, rather than being hard-killed here first
-        # with nothing but "TimeoutExpired" to say why.
+        # Above render.mjs's own worst case, not just its per-phase one: it
+        # budgets selectComposition and renderMedia separately, up to 50
+        # minutes each, and a slow first phase does not borrow from the
+        # second. Sized for both back to back plus a buffer, so a render that
+        # is genuinely just slow times out inside Remotion with an actionable
+        # message, rather than being hard-killed here first with nothing but
+        # "TimeoutExpired" to say why.
         result = subprocess.run(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-            timeout=3300,
+            timeout=2 * 50 * 60 + 300,
             cwd=project_root,
             env=remotion_env,
         )

--- a/remotion/render.mjs
+++ b/remotion/render.mjs
@@ -75,8 +75,8 @@ function clampLogoScale(raw) {
 // fast and a full-length one gets the minutes it actually needs; overridable
 // for a box whose real throughput has already been measured.
 const timeoutFor = (durationSec) => {
-  const override = process.env.PODCLI_REMOTION_TIMEOUT_MS;
-  if (override) return Math.max(1, parseInt(override, 10));
+  const override = parseInt(process.env.PODCLI_REMOTION_TIMEOUT_MS ?? "", 10);
+  if (Number.isFinite(override)) return Math.max(1, override);
   return Math.min(50 * 60_000, Math.max(120_000, 90_000 + durationSec * 15_000));
 };
 

--- a/remotion/render.mjs
+++ b/remotion/render.mjs
@@ -65,7 +65,20 @@ function clampLogoScale(raw) {
 // Remotion's 30s default is measured against the font delayRender in Root.tsx,
 // which competes with evaluating the whole bundle. That bundle has three
 // compositions now, and the slowest CI runner does not finish inside 30s.
-const DELAY_RENDER_TIMEOUT_MS = 120_000;
+//
+// A fixed cap on top of that was wrong in the other direction: a card-heavy
+// clip renders roughly 13x slower than realtime on the container's actual CPU
+// quota, not the few seconds a bundle load costs, and a 120s ceiling killed
+// the render itself mid-flight, not just a slow font load — the "delayRender
+// not cleared" it reported was a symptom of the whole page stalling under
+// load, not a broken font. Scaled to the clip so a 3-second clip still fails
+// fast and a full-length one gets the minutes it actually needs; overridable
+// for a box whose real throughput has already been measured.
+const timeoutFor = (durationSec) => {
+  const override = process.env.PODCLI_REMOTION_TIMEOUT_MS;
+  if (override) return Math.max(1, parseInt(override, 10));
+  return Math.min(50 * 60_000, Math.max(120_000, 90_000 + durationSec * 15_000));
+};
 
 async function main() {
   const opts = parseArgs();
@@ -304,7 +317,7 @@ async function main() {
       serveUrl: bundleLocation,
       id: "CaptionedClip",
       inputProps,
-      timeoutInMilliseconds: DELAY_RENDER_TIMEOUT_MS,
+      timeoutInMilliseconds: timeoutFor(durationSec),
       browserExecutable,
       chromeMode,
     });
@@ -347,7 +360,7 @@ async function main() {
       outputLocation: captionOverlay,
       inputProps,
       concurrency,
-      timeoutInMilliseconds: DELAY_RENDER_TIMEOUT_MS,
+      timeoutInMilliseconds: timeoutFor(durationSec),
       onProgress: ({ progress }) => {
         const pct = Math.round(progress * 100);
         if (pct > lastPct + 9) {


### PR DESCRIPTION
## Summary
Confirmed root cause of the repeated production recut failures via a controlled probe against the actual worker box (synthetic clip matched to the real job's length, cards + name card, temporarily patched timeout + memory cap):

- With the deployed 120s timeout, a card-heavy 52.5s render is OOM-killed at ~2.7GB resident (`oom_kill` cgroup counter incremented, `dmesg` shows the kernel killing the `remotion` compositor process). This happens regardless of `PODCLI_REMOTION_CONCURRENCY` (tested 1 and 2 — both OOM identically).
- The "delayRender Waiting for DM Sans not cleared" error reported in production was a downstream symptom, not the actual cause: once the compositor dies mid-render, nothing else in that call finishes either, including the unrelated font-load promise.
- With memory raised (confirms the real fix is on the podcli-cloud side, PR incoming) and the timeout raised, the same clip completes cleanly in ~11m40s — a card-heavy clip renders roughly 13x slower than realtime on this box's real CPU quota, which a 120s ceiling was never going to cover.

## Fix
- `remotion/render.mjs`: timeout now scales with clip duration (`90s base + 15s per clip-second`, capped at 50 minutes), overridable via `PODCLI_REMOTION_TIMEOUT_MS`.
- `backend/services/clip_generator.py`: subprocess timeout wrapping the render call raised from 600s to 3300s, keeping headroom above render.mjs's own worst-case budget.

Companion fix (raises the worker memory cap, the other half of this): nmbrthirteen/podcli-cloud#47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of long video renders by allowing timeout limits to scale with clip duration.
  * Added clearer timeout behavior for genuinely slow renders, reducing premature termination.
  * Added an optional configuration override for advanced timeout needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->