### PR TITLE
Round the computed render timeout to an integer

### DIFF
--- a/remotion/render.mjs
+++ b/remotion/render.mjs
@@ -77,7 +77,9 @@ function clampLogoScale(raw) {
 const timeoutFor = (durationSec) => {
   const override = parseInt(process.env.PODCLI_REMOTION_TIMEOUT_MS ?? "", 10);
   if (Number.isFinite(override)) return Math.max(1, override);
-  return Math.min(50 * 60_000, Math.max(120_000, 90_000 + durationSec * 15_000));
+  // durationSec is measured by ffprobe and rarely lands on a whole number;
+  // Remotion rejects a fractional timeoutInMilliseconds outright.
+  return Math.round(Math.min(50 * 60_000, Math.max(120_000, 90_000 + durationSec * 15_000)));
 };
 
 async function main() {


### PR DESCRIPTION
## Summary
Confirmed live in production immediately after 2.7.25 deployed: `Remotion render error: 'timeoutInMilliseconds' should be an integer, but is 878125.005`.

My synthetic verification clip (`ffmpeg testsrc duration=52`) happened to measure as an exact integer via ffprobe, so `timeoutFor()`'s output was already a whole number by luck and the bug never surfaced in testing. A real cut clip's duration is essentially never a round number of seconds, so every real render hit this immediately.

## Fix
`Math.round()` around the computed timeout in `timeoutFor()`.