### PR TITLE
Strip the comments added with the render fixes

### DIFF
--- a/backend/services/clip_generator.py
+++ b/backend/services/clip_generator.py
@@ -475,15 +475,6 @@ _remotion_available = None  # True/False/None — environment availability, not 
 
 
 def _stop_process_tree(proc: subprocess.Popen) -> None:
-    """Stop a render and everything it spawned.
-
-    proc.kill() reaches only Node. Chromium and the compositor are its
-    children, and a render that has timed out is exactly the one whose
-    children are still busy, holding the CPU the next job needs. On POSIX the
-    child is started in its own session so the whole group can be signalled:
-    TERM first, which render.mjs handles by closing its server and deleting
-    the half-written overlay, then KILL for whatever ignored it.
-    """
     if hasattr(os, "killpg"):
         try:
             pgid = os.getpgid(proc.pid)
@@ -509,18 +500,6 @@ def _run_streaming(
     cwd: str,
     env: dict,
 ) -> subprocess.CompletedProcess:
-    """Run a render and relay its progress as it happens.
-
-    subprocess.run holds both pipes until the child exits, so for the whole of
-    a Remotion render this process printed nothing. The worker upstream reads
-    silence as a wedged engine and stops it, and a render that had finally
-    started completing was being killed at the ten-minute mark for working.
-
-    Both streams are drained on threads so neither pipe can fill and stall the
-    child, and every line is kept: the caller still gets a CompletedProcess to
-    report from exactly as before. Progress lines go straight to stderr with
-    the same flush the rest of this file uses, which is what the worker watches.
-    """
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
@@ -795,14 +774,6 @@ def _render_with_remotion(
         # not happen, and what it threw away was the only description of the
         # failure. Every clip on the Linux worker fell back to burned-in ASS
         # for months and the reason went to /dev/null with the rest of it.
-        #
-        # Above render.mjs's own worst case, not just its per-phase one: it
-        # budgets selectComposition and renderMedia separately, up to 50
-        # minutes each, and a slow first phase does not borrow from the
-        # second. Sized for both back to back plus a buffer, so a render that
-        # is genuinely just slow times out inside Remotion with an actionable
-        # message, rather than being hard-killed here first with nothing but
-        # "TimeoutExpired" to say why.
         result = _run_streaming(
             cmd,
             timeout=2 * 50 * 60 + 300,

--- a/remotion/render.mjs
+++ b/remotion/render.mjs
@@ -65,33 +65,12 @@ function clampLogoScale(raw) {
 // Remotion's 30s default is measured against the font delayRender in Root.tsx,
 // which competes with evaluating the whole bundle. That bundle has three
 // compositions now, and the slowest CI runner does not finish inside 30s.
-//
-// A fixed cap on top of that was wrong in the other direction: a card-heavy
-// clip renders roughly 13x slower than realtime on the container's actual CPU
-// quota, not the few seconds a bundle load costs, and a 120s ceiling killed
-// the render itself mid-flight, not just a slow font load — the "delayRender
-// not cleared" it reported was a symptom of the whole page stalling under
-// load, not a broken font. Scaled to the clip so a 3-second clip still fails
-// fast and a full-length one gets the minutes it actually needs; overridable
-// for a box whose real throughput has already been measured.
 const timeoutFor = (durationSec) => {
   const override = parseInt(process.env.PODCLI_REMOTION_TIMEOUT_MS ?? "", 10);
   if (Number.isFinite(override)) return Math.max(1, override);
-  // durationSec is measured by ffprobe and rarely lands on a whole number;
-  // Remotion rejects a fractional timeoutInMilliseconds outright.
   return Math.round(Math.min(50 * 60_000, Math.max(120_000, 90_000 + durationSec * 15_000)));
 };
 
-/*
- * The compositor caches decoded <OffthreadVideo> frames, and left to itself
- * sizes that cache at half of the memory "available on the system": the host's,
- * not the container's cgroup limit, so a worker capped at 3GB was handed a
- * ~4GB cache target and the kernel killed the compositor at 2.7GB resident,
- * mid-render, on every clip that drew a card with the speaker still in frame.
- * A bound the container can actually honour makes peak memory a constant
- * rather than a function of whichever box the render happens to land on.
- * Overridable in MB for a box whose real headroom has been measured.
- */
 const videoCacheBytes = () => {
   const mb = parseInt(process.env.PODCLI_REMOTION_VIDEO_CACHE_MB ?? "", 10);
   return (Number.isFinite(mb) && mb > 0 ? mb : 512) * 1024 * 1024;
@@ -341,12 +320,6 @@ async function main() {
       chromeMode,
     });
 
-    // os.cpus() reads the host's core count, not the container's cgroup quota,
-    // so on a boxed worker it sizes a tab count the container was never given
-    // the CPU to actually run — the same mismatch PODCLI_WHISPER_THREADS
-    // exists to correct for Whisper. PODCLI_REMOTION_CONCURRENCY lets deploy
-    // config state the real number; unset, it falls back to the old guess for
-    // anywhere still running bare-metal.
     const cpus = os.cpus().length;
     const concurrency = process.env.PODCLI_REMOTION_CONCURRENCY
       ? Math.max(1, parseInt(process.env.PODCLI_REMOTION_CONCURRENCY, 10))

--- a/remotion/src/CaptionedClip.tsx
+++ b/remotion/src/CaptionedClip.tsx
@@ -79,11 +79,6 @@ export const CaptionedClip: React.FC<CaptionedClipProps> = ({
    * surface, and it was the single biggest thing pushing the speaker's band
    * short enough to cut a face in half.
    */
-  /*
-   * A card waits out the name card's opening seconds rather than share the
-   * lower third with it; the two are drawn by the same pass on a render and
-   * neither knows about the other's window on its own.
-   */
   const nameCardSeconds = nameCard?.title ? (nameCard.seconds ?? 3) : 0;
   const pastNameCard = frame / fps >= nameCardSeconds;
   const cardUp = pastNameCard && Boolean(cards?.length) && Boolean(cardAt(cards ?? [], frame / fps));

--- a/tests/test_clip_generator.py
+++ b/tests/test_clip_generator.py
@@ -37,12 +37,6 @@ class ClipGeneratorTests(unittest.TestCase):
         return _exists
 
     def _fake_popen(self, returncode=0, stdout="", stderr="", timeout=None):
-        """A Popen stand-in for _run_streaming: readable pipes, wait(), kill().
-
-        Fresh per call, because the streaming reader drains and closes the pipes.
-        A timeout makes the first wait() raise the way a real child would, and
-        the second, after kill(), return.
-        """
         proc = mock.Mock()
         proc.stdout = io.StringIO(stdout)
         proc.stderr = io.StringIO(stderr)
@@ -293,8 +287,6 @@ class ClipGeneratorTests(unittest.TestCase):
         self.assertEqual(second, (False, None))
         self.assertIsNone(cg._remotion_available)
         self.assertGreaterEqual(mock_run.call_count, 4)
-        # The whole group, not just node: Chromium and the compositor are its
-        # children and are what a timed-out render leaves busy.
         self.assertTrue(mock_killpg.called, "a timed-out render must signal its process group")
         self.assertEqual(mock_killpg.call_args_list[0].args, (4242, cg.signal.SIGTERM))
 


### PR DESCRIPTION
Comment-only. Removes the rationale comments added in #197, #198, #200, #202 and #204; behaviour unchanged. The rationale lives in those PRs.