### PR TITLE
Build whisper-cli for a portable ISA, not the runner's

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         shell: bash
         run: |
           EXTRA=""
-          if [ "${{ matrix.goos }}" = "darwin" ]; then EXTRA="-DGGML_METAL_EMBED_LIBRARY=ON"; fi
+          if [ "${{ matrix.goos }}" = "darwin" ]; then EXTRA="-DGGML_METAL_EMBED_LIBRARY=ON"; else EXTRA="-DGGML_NATIVE=OFF"; fi
           cmake -B build -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release $EXTRA
           cmake --build build --config Release --target whisper-cli -j
       - name: Stage asset


### PR DESCRIPTION
2.7.27's whisper-cli died with SIGILL on the production worker. The release builds whisper.cpp with ggml's default GGML_NATIVE (-march=native), so each release's binary is tuned to whichever hosted runner built it; three of today's four releases happened to land on compatible runners. With GGML_NATIVE=OFF and no cross-compile, ggml enables its AVX2+FMA+F16C path (x86-64-v3), which any server CPU since 2013 has. Darwin keeps Metal + native (Apple Silicon is uniform).