### PR TITLE
Let studio take a transcript instead of running Whisper

### DIFF
--- a/backend/clip_studio.py
+++ b/backend/clip_studio.py
@@ -98,17 +98,31 @@ def _transcribe(video: str, language: str | None, engine: str | None):
 
 def _load_transcript(path: str) -> list:
     import json
-    with open(path, encoding="utf-8") as fh:
-        data = json.load(fh)
-    words = data.get("words", []) if isinstance(data, dict) else data
+    import math
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"--transcript {path}: {exc}")
+    if isinstance(data, dict):
+        if "words" not in data:
+            raise SystemExit(f"--transcript {path}: expected {{\"words\": [...]}}")
+        words = data["words"]
+    else:
+        words = data
     if not isinstance(words, list):
         raise SystemExit(f"--transcript {path}: expected a list of words or {{\"words\": [...]}}")
     out = []
     for w in words:
         try:
-            out.append({"word": str(w["word"]), "start": float(w["start"]), "end": float(w["end"])})
+            start, end = float(w["start"]), float(w["end"])
         except (KeyError, TypeError, ValueError):
             continue
+        if not (math.isfinite(start) and math.isfinite(end)) or start < 0 or end < start:
+            continue
+        out.append({"word": str(w.get("word", "")), "start": start, "end": end})
+    if not out:
+        raise SystemExit(f"--transcript {path}: no usable words in it")
     print(f"  [transcript] using {len(out)} supplied words", flush=True)
     return out
 

--- a/backend/clip_studio.py
+++ b/backend/clip_studio.py
@@ -96,6 +96,23 @@ def _transcribe(video: str, language: str | None, engine: str | None):
     return res.get("words", [])
 
 
+def _load_transcript(path: str) -> list:
+    import json
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    words = data.get("words", []) if isinstance(data, dict) else data
+    if not isinstance(words, list):
+        raise SystemExit(f"--transcript {path}: expected a list of words or {{\"words\": [...]}}")
+    out = []
+    for w in words:
+        try:
+            out.append({"word": str(w["word"]), "start": float(w["start"]), "end": float(w["end"])})
+        except (KeyError, TypeError, ValueError):
+            continue
+    print(f"  [transcript] using {len(out)} supplied words", flush=True)
+    return out
+
+
 def _find_paragraph(words: list, phrase: str) -> tuple[float, float]:
     """Find the time span of a paragraph by fuzzy-matching its text against
     the transcript word stream. Returns (start, end) seconds."""
@@ -234,6 +251,7 @@ def main():
     ap.add_argument("--paragraph", help="Find fragment by matching this text in the transcript")
     ap.add_argument("--language", default=None, help="Transcription language (e.g. es). Auto-detect if omitted.")
     ap.add_argument("--engine", choices=["whisper-py", "whispercpp", "assemblyai"], default=None, help="Transcription engine")
+    ap.add_argument("--transcript", default=None, help="Word timings JSON for this video (list of {word,start,end} or {words:[...]}); skips transcription")
     ap.add_argument("--caption-style", default="hormozi", choices=["hormozi", "karaoke", "subtle", "branded"])
     ap.add_argument("--caption-position", default="auto", choices=["auto", "upper", "center", "lower"])
     ap.add_argument("--caption-scale", type=float, default=1.0)
@@ -313,8 +331,7 @@ def main():
     out_dir = os.path.join(data_dir, "output")
     os.makedirs(out_dir, exist_ok=True)
 
-    # Need a transcript if cutting by paragraph or if rendering captions.
-    words = _transcribe(video, args.language, args.engine)
+    words = _load_transcript(args.transcript) if args.transcript else _transcribe(video, args.language, args.engine)
 
     if args.paragraph:
         start, end = _find_paragraph(words, args.paragraph)

--- a/backend/services/transcription.py
+++ b/backend/services/transcription.py
@@ -58,6 +58,15 @@ def _whispercpp_ready(model_size: str) -> bool:
     return _whispercpp_cli() is not None and os.path.exists(_whispercpp_model(model_size))
 
 
+def _whisper_threads() -> int:
+    raw = os.environ.get("PODCLI_WHISPER_THREADS", "").strip()
+    try:
+        n = int(raw)
+    except ValueError:
+        n = 0
+    return n if n > 0 else 4
+
+
 def _transcribe_with_whispercpp(file_path, model_size, language, progress_callback, wav_path=None):
     from services import transcription_whispercpp as wcpp
 
@@ -81,6 +90,7 @@ def _transcribe_with_whispercpp(file_path, model_size, language, progress_callba
         vad=vad,
         vad_model=os.environ.get("PODCLI_WHISPERCPP_VAD_MODEL") or None,
         wav_path=wav_path,
+        threads=_whisper_threads(),
     )
     if progress_callback:
         progress_callback(50, "Transcription complete")


### PR DESCRIPTION
Recuts re-transcribed the clip on every run because `studio` had no transcript input. `--transcript path.json` (a list of `{word,start,end}` or `{words:[...]}`, in the input video's own timeline) skips Whisper. The cloud worker passes the episode's words for the window (nmbrthirteen/podcli-cloud#59), so a recut is minutes faster, its captions match the episode transcript instead of a second Whisper pass, and whisper-cli stops being a dependency of recuts.

Also: whisper-cli's `-t` now reads `PODCLI_WHISPER_THREADS` (the worker sets it to 3; nothing read it, so it ran 4 threads on a 3.5-cpu container).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--transcript` option for supplying word-timing JSON directly, allowing video processing without running transcription.
  - Accepts transcript data as either a word list or a wrapped `words` object and ignores invalid entries.

- **Improvements**
  - Added configurable transcription thread counts through an environment setting, with a default fallback for missing or invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->