### PR TITLE
Refuse a frame the renderer cannot draw, and honour two config keys

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -2665,6 +2665,41 @@ def cmd_thumbnail_options(args):
     print(json.dumps({"texts": [list(t) for t in texts], "frames": frames}))
 
 
+_BROWSER_IMAGE_FORMATS = {"PNG", "JPEG", "WEBP", "GIF", "AVIF", "BMP", "ICO"}
+
+
+def _check_frame(path):
+    """Refuse a frame the renderer would fail to draw, while it is still a message.
+
+    A thumbnail is an HTML page photographed by headless Chrome, so the frame is
+    an <img>. A file the browser cannot decode is not an error there: the page
+    renders anyway, the caption box and the logo land on bg_color, and this
+    command exits 0 with a path to a blank card carrying a 15px broken-image
+    glyph. A missing frame is worse, because it also moves the box to the
+    no-photo height. Callers cannot tell either apart from a picture that
+    worked, so neither is allowed past here.
+    """
+    if not os.path.exists(path):
+        print(f"thumbnail render failed: no frame at {path}", file=sys.stderr)
+        sys.exit(1)
+    if path.lower().endswith(".svg"):
+        return
+    try:
+        from PIL import Image
+        with Image.open(path) as im:
+            fmt = im.format
+    except Exception as err:
+        print(f"thumbnail render failed: {path} is not an image ({err})", file=sys.stderr)
+        sys.exit(1)
+    if fmt not in _BROWSER_IMAGE_FORMATS:
+        print(
+            f"thumbnail render failed: {path} is {fmt}, which the renderer cannot draw. "
+            "Convert it to PNG, JPEG or WebP first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def cmd_thumbnail_render(args):
     """Render one final thumbnail from a chosen frame + headline.
 
@@ -2673,6 +2708,7 @@ def cmd_thumbnail_render(args):
     from services.thumbnail_ai import generate_thumbnail_with_template
     from services.asset_store import resolve_logo
 
+    _check_frame(args.frame)
     frame_info = json.loads(args.frame_info) if args.frame_info else None
     out = generate_thumbnail_with_template(
         title=args.title,

--- a/backend/services/thumbnail_html.py
+++ b/backend/services/thumbnail_html.py
@@ -460,7 +460,10 @@ def _build_html(
     photo_css = ""
     photo_uri = ""
     if has_photo:
-        photo_uri = f"file://{os.path.abspath(photo_path)}"
+        # as_uri() rather than an f-string: a '#' or '?' anywhere in the path is
+        # a fragment or a query to the browser, so the image silently drops and
+        # the card renders as bg_color with a broken-image glyph.
+        photo_uri = Path(photo_path).absolute().as_uri()
         brightness = cfg.get("photo_brightness", 0.85)
         photo_css = f"""
         .photo {{
@@ -471,7 +474,7 @@ def _build_html(
         .photo img {{
             width: 100%; height: 100%;
             object-fit: cover;
-            object-position: center center;
+            object-position: {cfg.get("photo_object_position", "center center")};
             filter: brightness({brightness});
         }}
         .photo-vignette {{
@@ -485,7 +488,7 @@ def _build_html(
     layers_html = _layer_html(cfg.get("layers"))
     logo_pos = cfg.get("logo_position", "none")
     if logo_path and os.path.exists(logo_path) and logo_pos != "none":
-        logo_uri = f"file://{os.path.abspath(logo_path)}"
+        logo_uri = Path(logo_path).absolute().as_uri()
         logo_h = cfg.get("logo_height", "50px")
         logo_margin = cfg.get("logo_margin", "50px")
         logo_opacity = cfg.get("logo_opacity", 0.35)
@@ -555,7 +558,9 @@ def _build_html(
     l1_lh = cfg.get("line1_line_height", 1.15)
     l1_mb = cfg.get("line1_margin_bottom", "10px")
     l1_color = cfg.get("line1_color", "#FFFFFF")
-    l1_nowrap = "nowrap"  # Always nowrap — we shrink to fit instead
+    # Shrinking to fit is the default, so line 1 stays on one line. A template
+    # that turns it off is asking to wrap instead.
+    l1_nowrap = "nowrap" if cfg.get("line1_nowrap", True) else "normal"
 
     l2_weight = cfg.get("line2_font_weight", "500")
     l2_style = cfg.get("line2_font_style", "italic")


### PR DESCRIPTION
A thumbnail is an HTML page photographed by headless Chrome, so the frame is an `<img>`. A file the browser cannot decode was never an error: the page rendered anyway, the caption box and the logo landed on `bg_color`, and `thumbnail-render` exited 0 with a path to a blank card carrying a 15px broken-image glyph in the corner. On a dark template that is a black rectangle nobody can tell apart from a picture that worked, and every caller downstream stored it as a finished thumbnail.

A missing frame was worse, because it also moved the text box to the no-photo height, so the failure was visible only as a picture that sat slightly wrong.

Both are refused now, in the words of what happened, while the answer is still a message about one picture rather than a card somebody ships.

Two other things in the same area:

- The `file://` URIs for the photo and the logo were built by string concatenation, so a `#` or a `?` anywhere in the path was a fragment or a query to the browser and the image silently dropped, rendering as `bg_color` the same way. They use `Path.as_uri()` now.
- `photo_object_position` was asked of the model, exposed in the template editor and then never read: the CSS hardcoded `center center`. `line1_nowrap` shipped in the defaults and was documented as tunable while the renderer overwrote it unconditionally. Both now do what they say.

## Verification

`tests/test_thumbnail_html.py` passes (11), and the CLI was run against a probe matrix:

| frame | before | after |
| --- | --- | --- |
| valid PNG | exit 0, photo drawn | exit 0, photo drawn |
| TIFF | exit 0, blank card | exit 1, names the format |
| S3 XML error body named `.png` | exit 0, blank card | exit 1, "is not an image" |
| 0-byte file | exit 0, blank card | exit 1, "is not an image" |
| missing path | exit 0, blank card at wrong height | exit 1, "no frame at ..." |

A render with `photo_object_position` and `line1_nowrap` set was confirmed to pick both up.

## Context

Found while tracing a podcli-cloud report: a workspace picked one of its own background images for a clip thumbnail and got back three pure black cards. The cloud-side half is fixed separately; this is the engine half, and it is what turns that class of failure from a silent blank card into a job that says why.