### PR TITLE
List only the candidate frames that reached the disk

### DIFF
--- a/backend/services/thumbnail_ai.py
+++ b/backend/services/thumbnail_ai.py
@@ -451,7 +451,13 @@ def extract_candidate_frames(
         fh, fw = frame.shape[:2]
         if (fw, fh) != (target_w, target_h):
             frame = cv2.resize(frame, (target_w, target_h), interpolation=cv2.INTER_LANCZOS4)
-        cv2.imwrite(path, frame, [cv2.IMWRITE_JPEG_QUALITY, 92])
+        # imwrite answers a failed write with False rather than raising, and a
+        # full disk is the usual reason. Listing the path regardless hands the
+        # renderer a frame that is not on disk, which it refuses.
+        if not cv2.imwrite(path, frame, [cv2.IMWRITE_JPEG_QUALITY, 92]):
+            log_event("thumbnail-ai", "could not write candidate frame",
+                      level="warn", path=path)
+            continue
         results.append({
             "path": path,
             "timestamp": c["timestamp"],

--- a/backend/services/thumbnail_ai.py
+++ b/backend/services/thumbnail_ai.py
@@ -343,7 +343,9 @@ def extract_candidate_frames(
         for c in candidates:
             if len(selected) >= count:
                 break
-            if c in selected:
+            # Identity, not equality: these dicts hold a numpy frame, and
+            # comparing two of them raises rather than answering.
+            if any(c is s for s in selected):
                 continue
             if any(_too_similar(c, s) for s in selected):
                 continue


### PR DESCRIPTION
Two faults in `extract_candidate_frames`, both of which end with a clip having no picture.

**A frame that was never written was reported anyway.** `cv2.imwrite` answers a failed write by returning `False` rather than raising, and on a render box a full disk is the usual reason. The path went into the returned list regardless, so the cloud worker's upload of that frame failed on the stat and `thumbnail-render` refused it with `no frame at ...` — the guard from #214 reporting a problem made here. Now the frame is skipped and logged.

**The top-up pass crashed on numpy.** When strict diversity leaves fewer candidates than were asked for, a second pass fills the list and skipped what was already chosen with `if c in selected`. A candidate is a dict carrying its own numpy frame, so `in` compared those element-wise and raised `the truth value of an array with more than one element is ambiguous`, taking the command down and leaving the caller with nothing rather than the two or three frames already picked. Identity is what the check meant.

Reported from production: `thumbnail render failed: no frame at /var/lib/podcli-work/.../thumbs-.../frames/frame_2.jpg`.

The matching guard on the cloud side (ignore a listed frame that is not on disk) is on podcli-cloud main as a262be5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video frame selection to avoid errors when comparing candidate frames.
  * Failed frame saves are now detected and skipped instead of producing invalid file references.
  * Added warnings when a frame cannot be saved, improving visibility into storage-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->